### PR TITLE
add topk_softmax kernel

### DIFF
--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -48,7 +48,7 @@ jobs:
         timeout-minutes: 20
         run: |
           docker exec -w /root/sglang ci_sglang_xpu \
-            /bin/bash -c "cd /root/sglang/sgl-kernel-xpu/tests &&  python3 -m pytest -v -s test_awq_dequant.py"
+            /bin/bash -c "cd /root/sglang/sgl-kernel-xpu/tests &&  python3 -m pytest -v -s test_awq_dequant.py test_topk_softmax.py"
 
       - name: Run E2E Bfloat16 tests
         timeout-minutes: 20

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -126,6 +126,11 @@ void gemma_fused_add_rmsnorm(torch::Tensor& input, torch::Tensor& residual, torc
 void silu_and_mul(torch::Tensor& out, torch::Tensor& input);
 void gelu_tanh_and_mul(torch::Tensor& out, torch::Tensor& input);
 void gelu_and_mul(torch::Tensor& out, torch::Tensor& input);
+void topk_softmax(
+    at::Tensor& topk_weights,
+    at::Tensor& topk_indices,
+    at::Tensor& gating_output,
+    bool renormalize);
 void apply_rope_pos_ids_cos_sin_cache(
     at::Tensor q,
     at::Tensor k,

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -126,11 +126,7 @@ void gemma_fused_add_rmsnorm(torch::Tensor& input, torch::Tensor& residual, torc
 void silu_and_mul(torch::Tensor& out, torch::Tensor& input);
 void gelu_tanh_and_mul(torch::Tensor& out, torch::Tensor& input);
 void gelu_and_mul(torch::Tensor& out, torch::Tensor& input);
-void topk_softmax(
-    at::Tensor& topk_weights,
-    at::Tensor& topk_indices,
-    at::Tensor& gating_output,
-    bool renormalize);
+void topk_softmax(at::Tensor& topk_weights, at::Tensor& topk_indices, at::Tensor& gating_output, bool renormalize);
 void apply_rope_pos_ids_cos_sin_cache(
     at::Tensor q,
     at::Tensor k,

--- a/python/sgl_kernel/moe.py
+++ b/python/sgl_kernel/moe.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 
@@ -28,11 +28,11 @@ def moe_align_block_size(
 def topk_softmax(
     topk_weights: torch.Tensor,
     topk_ids: torch.Tensor,
-    token_expert_indices: torch.Tensor,
     gating_output: float,
+    renormalize: bool = False,
 ) -> None:
     torch.ops.sgl_kernel.topk_softmax.default(
-        topk_weights, topk_ids, token_expert_indices, gating_output
+        topk_weights, topk_ids, gating_output, renormalize
     )
 
 

--- a/src/sycl/MoEOps.cpp
+++ b/src/sycl/MoEOps.cpp
@@ -1,0 +1,333 @@
+#include <ATen/ATen.h>
+#include <ATen/OpMathType.h>
+#include <ATen/Parallel.h>
+#include <c10/xpu/XPUStream.h>
+#include <torch/all.h>
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <sycl/sycl.hpp>
+#include <vector>
+
+#include "SYCLHelpers.h"
+#include "Utils.h"
+
+namespace TopKSoftmaxImpl {
+
+template <typename T>
+struct FusedTopkSoftmax {
+  static constexpr int sub_group_size = 32;
+  static constexpr int max_group_size = 1024;
+  static constexpr int malloc_per_item = 8;
+  static constexpr float kNegInfinity = INFINITY * -1;
+
+  FusedTopkSoftmax(
+      float* topk_weights,
+      int* topk_ids,
+      int* rows_for_experts,
+      int* offsets,
+      const T* gating_output,
+      const bool renormalize,
+      const int tokens,
+      const int experts,
+      const int top_k)
+      : topk_weights(topk_weights),
+        topk_ids(topk_ids),
+        rows_for_experts(rows_for_experts),
+        offsets(offsets),
+        gating_output(gating_output),
+        renormalize(renormalize),
+        tokens(tokens),
+        experts(experts),
+        top_k(top_k) {}
+
+  static inline sycl::nd_range<3> get_nd_range(
+      const int tokens,
+      const int experts) {
+    int calc_per_item = (experts + sub_group_size - 1) / sub_group_size;
+    int group_size = (experts + calc_per_item - 1) / calc_per_item;
+    group_size = group_size < sub_group_size ? sub_group_size : group_size;
+    group_size = group_size < max_group_size ? group_size : max_group_size;
+    int sub_groups_per_group =
+        (group_size + sub_group_size - 1) / sub_group_size;
+    group_size = sub_groups_per_group * sub_group_size;
+    int global_size =
+        (tokens + sub_groups_per_group - 1) / sub_groups_per_group;
+
+    sycl::range<3> local(1, 1, group_size);
+    sycl::range<3> global(1, 1, global_size);
+    return sycl::nd_range<3>(global * local, local);
+  }
+
+  static inline T Sigmoid(T x) {
+    float sycl_x = static_cast<float>(x);
+    float result = 1.0f / (1.0f + sycl::exp(-sycl_x));
+    return static_cast<T>(result);
+  }
+
+  [[sycl::reqd_sub_group_size(sub_group_size)]] void operator()(
+      sycl::nd_item<3> item) const {
+    int group_id = item.get_group_linear_id();
+    int local_range = item.get_local_range(2);
+    int sub_groups_per_group = local_range / sub_group_size;
+    int calc_per_item = (experts + sub_group_size - 1) / sub_group_size;
+
+    sycl::sub_group sg = item.get_sub_group();
+    int sg_id = sg.get_group_id();
+    int sg_local_id = sg.get_local_id();
+
+    int tid = group_id * sub_groups_per_group + sg_id;
+
+    if (tid >= tokens) {
+      return; // Out of bounds
+    }
+
+    T local_elems[malloc_per_item];
+    int local_idx[malloc_per_item];
+
+    int start_offset = sg_local_id * calc_per_item;
+    int local_num = calc_per_item;
+
+    if (start_offset + local_num >= experts) {
+      local_num = experts - start_offset;
+      if (local_num < 0) {
+        local_num = 0; // No elements to process
+      }
+    }
+
+    for (int e = 0; e < calc_per_item; ++e) {
+      local_elems[e] = kNegInfinity;
+      local_idx[e] = -1;
+    }
+
+    for (int e = 0; e < local_num; ++e) {
+      local_elems[e] = gating_output[tid * experts + start_offset + e];
+      local_idx[e] = start_offset + e;
+    }
+
+    // Perform top-k selection
+    T topk_weights_local[malloc_per_item];
+    int topk_ids_local[malloc_per_item];
+
+    for (int k = 0; k < top_k; ++k) {
+      T k_max = kNegInfinity;
+      int k_max_idx = -1;
+      int remove_ix = -1;
+      for (int e = 0; e < calc_per_item; ++e) {
+        T my_val = local_elems[e];
+        int my_idx = local_idx[e];
+        for (int offset = sub_group_size / 2; offset > 0; offset /= 2) {
+          T other_val = sycl::permute_group_by_xor(sg, my_val, offset);
+          int other_idx = sycl::permute_group_by_xor(sg, my_idx, offset);
+          if (other_val > my_val ||
+              (other_val == my_val && other_idx < my_idx)) {
+            my_val = other_val;
+            my_idx = other_idx;
+          }
+        }
+        if (my_val > k_max || (my_val == k_max && my_idx < k_max_idx)) {
+          k_max = my_val;
+          k_max_idx = my_idx;
+
+          if (k_max_idx == local_idx[e]) {
+            remove_ix = e; // Mark this index for removal
+          } else
+            remove_ix = -1;
+        }
+      }
+      topk_weights_local[k] = k_max;
+      topk_ids_local[k] = k_max_idx;
+      if (remove_ix != -1) {
+        // Reset the score to avoid re-selection
+        local_elems[remove_ix] = kNegInfinity;
+        local_idx[remove_ix] = -1;
+        remove_ix = -1;
+      }
+    }
+
+    float max_score = topk_weights_local[0];
+    float sum_exp = 0;
+
+    for (int i = 0; i < top_k; ++i) {
+      float score = topk_weights_local[i];
+      sum_exp += sycl::exp(score - max_score);
+    }
+
+    for (int e = 0; e < calc_per_item; ++e) {
+      float score = local_elems[e];
+      float my_val = sycl::exp(score - max_score);
+      for (int offset = sub_group_size / 2; offset > 0; offset /= 2) {
+        float other_val = sycl::permute_group_by_xor(sg, my_val, offset);
+        my_val += other_val;
+      }
+      sum_exp += my_val;
+    }
+
+    for (int i = 0; i < top_k; ++i) {
+      float score = topk_weights_local[i];
+      topk_weights_local[i] = sycl::exp(score - max_score) / sum_exp;
+    }
+
+    if (renormalize) {
+      // Renormalize the top-k weights
+      float sum = 0;
+      for (int i = 0; i < top_k; ++i) {
+        sum += topk_weights_local[i];
+      }
+      if (sum > 0) {
+        for (int i = 0; i < top_k; ++i) {
+          topk_weights_local[i] /= sum;
+        }
+      }
+    }
+
+    if (sg_local_id == 0) {
+      int offset = tid * top_k;
+      for (int i = 0; i < top_k; ++i) {
+        topk_weights[offset + i] = topk_weights_local[i];
+        if (topk_ids_local[i] < 0 || topk_ids_local[i] >= experts) {
+          // Ensure valid index
+          topk_ids[offset + i] = 0;
+          offsets[offset + i] = 0;
+          continue;
+        }
+        topk_ids[offset + i] = topk_ids_local[i];
+        auto ref_num_tokens = sycl::atomic_ref<
+            int,
+            sycl::memory_order_relaxed,
+            sycl::memory_scope_device,
+            sycl::access::address_space::global_space>(
+            *(rows_for_experts + topk_ids_local[i]));
+        int old = ref_num_tokens.fetch_add(1);
+        offsets[offset + i] = old;
+      }
+    }
+  }
+  float* topk_weights;
+  int* topk_ids;
+  int* rows_for_experts;
+  int* offsets;
+  const T* gating_output;
+  const bool renormalize;
+  const int tokens;
+  const int experts;
+  const int top_k;
+};
+
+template <typename T>
+void launch_fused_topk_softmax(
+    sycl::queue& queue,
+    const T* gating_output,
+    float* topk_weights,
+    int* topk_indices,
+    int* rows_for_experts,
+    int* offsets,
+    const bool renormalize,
+    const int top_k,
+    const int num_tokens,
+    const int num_experts) {
+
+  using Kernel = FusedTopkSoftmax<T>;
+  auto range = Kernel::get_nd_range(num_tokens, num_experts);
+
+  auto global_range = range.get_global_range();
+  auto local_range = range.get_local_range();
+
+    Kernel task(
+        topk_weights,
+        topk_indices,
+        rows_for_experts,
+        offsets,
+        gating_output,
+        renormalize,
+        num_tokens,
+        num_experts,
+        top_k);
+
+  sycl_kernel_submit(global_range, local_range, queue, task);
+  return;
+}
+
+template <typename T>
+void fused_topk_softmax(
+    const T* gating_output,
+    float* topk_weights,
+    int* topk_indices,
+    int* rows_for_experts,
+    int* offsets,
+    const bool renormalize,
+    const int num_tokens,
+    const int num_experts,
+    const int topk) {
+
+  auto stream = at::xpu::getCurrentXPUStream();
+  auto queue = stream.queue();  
+
+  launch_fused_topk_softmax(
+      queue,
+      gating_output,
+      topk_weights,
+      topk_indices,
+      rows_for_experts,
+      offsets,
+      renormalize,
+      topk,
+      num_tokens,
+      num_experts);
+};
+}; // namespace TopKSoftmaxImpl
+
+/**
+ * @brief Perform topk after softmax on gating_output.
+ * @param topk_weights The topk_weights tensor of shape [n_tokens, n_topk].
+ * @param topk_indices The topk_indices tensor of shape [n_tokens, n_topk].
+ * @param gating_output The gating output tensor of shape [n_tokens, n_experts].
+ * @param renormalize The renormalize bool whether the topk_weights needs to be renormalized.
+ * @return void.
+ */
+void topk_softmax(
+    at::Tensor& topk_weights,
+    at::Tensor& topk_indices,
+    at::Tensor& gating_output,
+    bool renormalize) {
+  auto shape = gating_output.sizes().vec();
+  TORCH_CHECK(
+      shape.size() == 2,
+      "gating_output must be 2D tensor, but got ",
+      shape.size(),
+      "D");
+  int n_tokens = shape[0];
+  int n_experts = shape[1];
+
+  TORCH_CHECK(
+      n_experts <= 128,
+      "n_experts only support up to 128, but got ",
+      n_experts);
+
+  int n_experts_aligned = (n_experts + 7) / 8 * 8; // align to 8
+
+  int64_t n_topk = topk_weights.size(1);
+
+  auto rows_for_experts =
+      at::zeros({n_experts_aligned}, at::dtype(at::kInt).device(at::kXPU));
+  auto offsets =
+      at::empty({n_tokens, n_topk}, at::dtype(at::kInt).device(at::kXPU));
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::kBFloat16,
+      at::kHalf,
+      gating_output.scalar_type(),
+      "fused_topk_softmax_kernel",
+      [&]() {
+        TopKSoftmaxImpl::fused_topk_softmax<scalar_t>(
+            reinterpret_cast<scalar_t*>(gating_output.data_ptr()),
+            reinterpret_cast<float*>(topk_weights.data_ptr()),
+            reinterpret_cast<int*>(topk_indices.data_ptr()),
+            reinterpret_cast<int*>(rows_for_experts.data_ptr()),
+            reinterpret_cast<int*>(offsets.data_ptr()),
+            renormalize,
+            n_tokens,
+            n_experts,
+            n_topk);
+      });
+}

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -46,6 +46,11 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def("gemma_fused_add_rmsnorm(Tensor! input, Tensor! residual, Tensor weight, float eps) -> ()");
   m.impl("gemma_fused_add_rmsnorm", torch::kXPU, &at::native::xpu::gemma_fused_add_rmsnorm);
 
+  m.def("topk_softmax(Tensor! topk_weights, Tensor! topk_indices, Tensor gating_output, bool renormalize) -> ()");
+  m.impl("topk_softmax", torch::kXPU, static_cast<
+      void (*)(at::Tensor&, at::Tensor&, at::Tensor&, bool)
+  >(&topk_softmax));
+
   //   m.def(
   //       "fp8_blockwise_scaled_mm(Tensor mat_a, Tensor mat_b, Tensor scales_a, Tensor scales_b, ScalarType out_dtype,
   //       -> Tensor");

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -47,9 +47,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("gemma_fused_add_rmsnorm", torch::kXPU, &at::native::xpu::gemma_fused_add_rmsnorm);
 
   m.def("topk_softmax(Tensor! topk_weights, Tensor! topk_indices, Tensor gating_output, bool renormalize) -> ()");
-  m.impl("topk_softmax", torch::kXPU, static_cast<
-      void (*)(at::Tensor&, at::Tensor&, at::Tensor&, bool)
-  >(&topk_softmax));
+  m.impl(
+      "topk_softmax", torch::kXPU, static_cast<void (*)(at::Tensor&, at::Tensor&, at::Tensor&, bool)>(&topk_softmax));
 
   //   m.def(
   //       "fp8_blockwise_scaled_mm(Tensor mat_a, Tensor mat_b, Tensor scales_a, Tensor scales_b, ScalarType out_dtype,

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -8,7 +8,6 @@ import utils
 device = utils.get_device()
 
 
-
 @pytest.mark.parametrize("dim", [128, 256, 512, 2048, 4096, 11008, 16384])
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -8,6 +8,7 @@ import utils
 device = utils.get_device()
 
 
+
 @pytest.mark.parametrize("dim", [128, 256, 512, 2048, 4096, 11008, 16384])
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])

--- a/tests/test_topk_softmax.py
+++ b/tests/test_topk_softmax.py
@@ -10,6 +10,7 @@ elif torch.xpu.is_available():
 else:
     device = torch.device("cpu")
 
+
 def fused_topk_torch_native(
     hidden_states: torch.Tensor,
     gating_output: torch.Tensor,
@@ -30,7 +31,7 @@ def fused_topk_torch_native(
         topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
     return topk_weights, topk_ids
 
-    
+
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("n_token", [2, 32, 4096])
 @pytest.mark.parametrize("n_expert", [8, 32])
@@ -38,18 +39,20 @@ def fused_topk_torch_native(
 @pytest.mark.parametrize("renormalize", [False, True])
 def test_topk_softmax(dtype, n_token, n_topk, n_expert, renormalize):
     torch.manual_seed(1024)
-    
+
     # expand gating_output by M, otherwise bfloat16 fall into same value aftering truncating
     hidden_states = torch.randn(n_token, 100, device=device, dtype=dtype)
-    gating_output = torch.randn(n_token, n_expert, device=device, dtype=dtype) * 2 * n_token
-    
+    gating_output = (
+        torch.randn(n_token, n_expert, device=device, dtype=dtype) * 2 * n_token
+    )
+
     ref_token_weights, ref_topk_indices = fused_topk_torch_native(
         hidden_states.float(),
         gating_output.float(),
         n_topk,
         renormalize,
-    )    
-    
+    )
+
     assert hidden_states.shape[0] == gating_output.shape[0], "Number of tokens mismatch"
 
     M, _ = hidden_states.shape
@@ -57,15 +60,17 @@ def test_topk_softmax(dtype, n_token, n_topk, n_expert, renormalize):
     topk_weights = torch.empty(
         M, n_topk, dtype=torch.float32, device=hidden_states.device
     )
-    topk_indices = torch.empty(M, n_topk, dtype=torch.int32, device=hidden_states.device)
-    
+    topk_indices = torch.empty(
+        M, n_topk, dtype=torch.int32, device=hidden_states.device
+    )
+
     sgl_kernel.topk_softmax(
         topk_weights,
         topk_indices,
         gating_output,
         renormalize,
-    )    
-    
+    )
+
     # Compare the results
     res = torch.zeros(n_token, n_expert, dtype=torch.float, device=hidden_states.device)
     ref = torch.zeros(n_token, n_expert, dtype=torch.float, device=hidden_states.device)
@@ -75,4 +80,4 @@ def test_topk_softmax(dtype, n_token, n_topk, n_expert, renormalize):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])    
+    pytest.main([__file__])

--- a/tests/test_topk_softmax.py
+++ b/tests/test_topk_softmax.py
@@ -1,0 +1,78 @@
+import pytest
+import sgl_kernel
+import torch
+import torch.nn.functional as F
+
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+elif torch.xpu.is_available():
+    device = torch.device("xpu")
+else:
+    device = torch.device("cpu")
+
+def fused_topk_torch_native(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+):
+    assert (
+        hidden_states.shape[0] == gating_output.shape[0]
+    ), f"Number of tokens mismatch, {hidden_states.shape=} vs {gating_output.shape=}"
+    M, _ = hidden_states.shape
+    topk_weights = torch.empty(
+        M, topk, dtype=torch.float32, device=hidden_states.device
+    )
+    topk_ids = torch.empty(M, topk, dtype=torch.int32, device=hidden_states.device)
+    topk_weights = F.softmax(gating_output.float(), dim=-1)
+    topk_weights, topk_ids = torch.topk(topk_weights, topk, dim=-1)
+    if renormalize:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+    return topk_weights, topk_ids
+
+    
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("n_token", [2, 32, 4096])
+@pytest.mark.parametrize("n_expert", [8, 32])
+@pytest.mark.parametrize("n_topk", [1, 2, 4])
+@pytest.mark.parametrize("renormalize", [False, True])
+def test_topk_softmax(dtype, n_token, n_topk, n_expert, renormalize):
+    torch.manual_seed(1024)
+    
+    # expand gating_output by M, otherwise bfloat16 fall into same value aftering truncating
+    hidden_states = torch.randn(n_token, 100, device=device, dtype=dtype)
+    gating_output = torch.randn(n_token, n_expert, device=device, dtype=dtype) * 2 * n_token
+    
+    ref_token_weights, ref_topk_indices = fused_topk_torch_native(
+        hidden_states.float(),
+        gating_output.float(),
+        n_topk,
+        renormalize,
+    )    
+    
+    assert hidden_states.shape[0] == gating_output.shape[0], "Number of tokens mismatch"
+
+    M, _ = hidden_states.shape
+
+    topk_weights = torch.empty(
+        M, n_topk, dtype=torch.float32, device=hidden_states.device
+    )
+    topk_indices = torch.empty(M, n_topk, dtype=torch.int32, device=hidden_states.device)
+    
+    sgl_kernel.topk_softmax(
+        topk_weights,
+        topk_indices,
+        gating_output,
+        renormalize,
+    )    
+    
+    # Compare the results
+    res = torch.zeros(n_token, n_expert, dtype=torch.float, device=hidden_states.device)
+    ref = torch.zeros(n_token, n_expert, dtype=torch.float, device=hidden_states.device)
+    res.scatter_(1, topk_indices.long(), topk_weights)
+    ref.scatter_(1, ref_topk_indices.long(), ref_token_weights)
+    torch.testing.assert_close(res, ref, atol=3e-3, rtol=1e-3)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])    


### PR DESCRIPTION
This PR adds the `topk_softmax` kernel.

The kernel code is from [ipex-gpu](https://github.com/intel-innersource/frameworks.ai.pytorch.ipex-gpu/blob/76d1e5d66bb466c0158b55dcfbc1520d2b7e006c/csrc/gpu/aten/operators/MoeOps.cpp#L247). The API of the kernel is aligned with the [upstream](https://github.com/sgl-project/sglang/blob/9a0cac1be0e5f3a2f7ab33731b00de4f0ad5bb80/sgl-kernel/python/sgl_kernel/moe.py#L28-L33).

Test plan:
```sh
python tests/test_topk_softmax.py 
```