### PR TITLE
Uncomment gelu config and fix typo in swiglu name

### DIFF
--- a/benchmark/bench_fused_moe.py
+++ b/benchmark/bench_fused_moe.py
@@ -143,14 +143,14 @@ shape_configs = [
 
 shape_configs_gelu = [
     # grok, tp=1
-    # {
-    #     "num_experts": 8,
-    #     "topk": 2,
-    #     "hidden_size": 8192,
-    #     "shard_intermediate_size": 16384,
-    #     "dtype": torch.bfloat16,
-    #     "block_shape": None,
-    # }
+    {
+        "num_experts": 8,
+        "topk": 2,
+        "hidden_size": 8192,
+        "shard_intermediate_size": 16384,
+        "dtype": torch.bfloat16,
+        "block_shape": None,
+    }
 ]
 
 

--- a/benchmark/bench_fused_moe.py
+++ b/benchmark/bench_fused_moe.py
@@ -128,17 +128,6 @@ shape_configs = [
         "dtype": torch.bfloat16,
         "block_shape": None,
     },
-    # lmsys/gpt-oss-20b-bf16, tp = 4
-    {
-        "num_experts": 32,
-        "topk": 4,
-        "hidden_size": 2880,
-        "shard_intermediate_size": 2880,
-        "dtype": torch.bfloat16,
-        "block_shape": None,
-        "gemm1_alpha": SWIGLU_GPT_OSS_ALPHA,
-        "gemm1_limit": SWIGLU_GPT_OSS_LIMIT,
-    },
 ]
 
 shape_configs_gelu = [
@@ -150,7 +139,21 @@ shape_configs_gelu = [
         "shard_intermediate_size": 16384,
         "dtype": torch.bfloat16,
         "block_shape": None,
-    }
+    },
+]
+
+shape_configs_swiglu_gpt_oss = [
+    # lmsys/gpt-oss-20b-bf16, tp = 4
+    {
+        "num_experts": 32,
+        "topk": 4,
+        "hidden_size": 2880,
+        "shard_intermediate_size": 2880,
+        "dtype": torch.bfloat16,
+        "block_shape": None,
+        "gemm1_alpha": SWIGLU_GPT_OSS_ALPHA,
+        "gemm1_limit": SWIGLU_GPT_OSS_LIMIT,
+    },
 ]
 
 
@@ -173,6 +176,11 @@ with_bias = [False, True]
 configs = [(k, *v, b, "silu") for k, v, b in product(bs, shape_values, with_bias)]
 shape_values_gelu = [_cfg_vals(d) for d in shape_configs_gelu]
 configs += [(k, *v, b, "gelu") for k, v, b in product(bs, shape_values_gelu, with_bias)]
+shape_values_swiglu_gpt_oss = [_cfg_vals(d) for d in shape_configs_swiglu_gpt_oss]
+configs += [
+    (k, *v, b, "silu")
+    for k, v, b in product(bs, shape_values_swiglu_gpt_oss, with_bias)
+]
 all_results = []
 
 

--- a/src/sycl/kernels/moe/xe20/moe_kernel.hpp
+++ b/src/sycl/kernels/moe/xe20/moe_kernel.hpp
@@ -101,7 +101,7 @@ class MoEGEMM {
 
   auto make_B_tensors(ElementB* ptr_B, int N, int K) {
     if constexpr (FuseAct) {
-      if constexpr (ActType == SWILGU_GPT_OSS) {
+      if constexpr (ActType == SWIGLU_GPT_OSS) {
         // Weights are interleaved for GPT-OSS: [gate_row0, up_row0, gate_row1, up_row1, ...]
         // Gate rows are at offsets 0, 2*K, 4*K, ... → row stride = 2*K
         auto B0 =
@@ -126,7 +126,7 @@ class MoEGEMM {
   auto make_Bias_tensors(float* ptr_Bias, int N) {
     if constexpr (WithBias) {
       if constexpr (FuseAct) {
-        if constexpr (ActType == SWILGU_GPT_OSS) {
+        if constexpr (ActType == SWIGLU_GPT_OSS) {
           // Bias is interleaved for GPT-OSS: [bias_gate0, bias_up0, bias_gate1, bias_up1, ...]
           // Gate bias at even indices → stride 2; up bias at odd indices → start +1, stride 2
           auto Bias0 = make_tensor(make_gmem_ptr<float>(ptr_Bias), make_layout(make_shape(N / 2), make_stride(_2{})));
@@ -146,7 +146,7 @@ class MoEGEMM {
       }
     } else {
       // return a tuple of empty tensors with stride matching the active path
-      if constexpr (FuseAct && ActType == SWILGU_GPT_OSS) {
+      if constexpr (FuseAct && ActType == SWIGLU_GPT_OSS) {
         return cute::make_tuple(
             make_tensor(make_gmem_ptr<float>(nullptr), make_layout(make_shape(0), make_stride(_2{}))),
             make_tensor(make_gmem_ptr<float>(nullptr), make_layout(make_shape(0), make_stride(_2{}))));

--- a/src/sycl/kernels/moe/xe20/moe_mainloop.hpp
+++ b/src/sycl/kernels/moe/xe20/moe_mainloop.hpp
@@ -49,7 +49,7 @@
 
 #define SILU 0
 #define GELU 1
-#define SWILGU_GPT_OSS 2
+#define SWIGLU_GPT_OSS 2
 
 template <typename T>
 struct dump;
@@ -362,7 +362,7 @@ struct MoEMainloop<
       if constexpr (ActType == SILU) {
         s = 1.0f / (1.0f + sycl::native::exp(-x));
         tCrC0(i) = x * s * y;
-      } else if constexpr (ActType == SWILGU_GPT_OSS) {
+      } else if constexpr (ActType == SWIGLU_GPT_OSS) {
         float gate = sycl::fmin(x, gemm1_limit);
         float up = sycl::fmax(-gemm1_limit, sycl::fmin(y, gemm1_limit));
         float t = gate * gemm1_alpha;


### PR DESCRIPTION
Re-enable gelu config in bench_fused_moe.py which mistakenly got commented through PR #134 and fix a typo in the SWIGLU macro name. 