### PR TITLE
Fix CMake Incremental Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ build
 
 # vscode
 .vscode/
+
+# FetchContent persistent cache (cutlass, etc.)
+.deps/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,21 @@ project(sgl_kernel)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_STANDARD 20)
 
+# Auto-detect ccache/sccache for faster rebuilds.
+find_program(CCACHE_PROGRAM ccache)
+find_program(SCCACHE_PROGRAM sccache)
+if(CCACHE_PROGRAM)
+  set(CMAKE_C_COMPILER_LAUNCHER   "${CCACHE_PROGRAM}")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+  set(SYCL_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE STRING "")
+elseif(SCCACHE_PROGRAM)
+  set(CMAKE_C_COMPILER_LAUNCHER   "${SCCACHE_PROGRAM}")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${SCCACHE_PROGRAM}")
+  set(SYCL_COMPILER_LAUNCHER "${SCCACHE_PROGRAM}" CACHE STRING "")
+else()
+  set(SYCL_COMPILER_LAUNCHER "" CACHE STRING "")
+endif()
+
 set(ATen_XPU_SYCL_XE20)
 set(ATen_XPU_SYCL_COMMON)
 
@@ -31,6 +46,13 @@ include(${SGL_OPS_XPU_ROOT}/cmake/SYCL.cmake)
 include(${SGL_OPS_XPU_ROOT}/cmake/BuildFlags.cmake)
 
 include(FetchContent)
+
+# Persist FetchContent downloads outside the build tree so that
+# rm -rf build does not re-clone large repositories.
+if(NOT FETCHCONTENT_BASE_DIR)
+  set(FETCHCONTENT_BASE_DIR "${PROJECT_SOURCE_DIR}/.deps"
+      CACHE PATH "FetchContent download directory")
+endif()
 
 # SYCL support in cutlass
 add_compile_definitions(CUTLASS_ENABLE_SYCL)

--- a/README.md
+++ b/README.md
@@ -10,11 +10,20 @@ Currently we only support building from source. To use on Intel GPUs, you need t
 
 ## Build from source
 
-Development build:
+Development build (incremental — only changed kernels recompile):
 
 ```bash
 source /PATH/TO/ONEAPI/setvars.sh
-pip install -v .
+pip install scikit-build-core ninja wheel  # one-time setup
+pip install -v -e . --no-build-isolation
+```
+
+To enable parallel builds on low memory systems, you may use the following.
+Experiment with lower $num_processes values if you face icpx compiler errors:
+
+```bash
+export num_processes=8
+CMAKE_BUILD_PARALLEL_LEVEL=$(num_processes) pip install -v -e . --no-build-isolation
 ```
 
 

--- a/cmake/Modules/FindSYCL.cmake
+++ b/cmake/Modules/FindSYCL.cmake
@@ -290,6 +290,11 @@ macro(SYCL_WRAP_SRCS sycl_target generated_files)
 
       set(SYCL_build_type "Device")
 
+      # Pass compiler launcher (ccache/sccache) to the build script if set.
+      if(NOT DEFINED SYCL_COMPILER_LAUNCHER)
+        set(SYCL_COMPILER_LAUNCHER "")
+      endif()
+
       # Configure the build script
       configure_file("${SYCL_run_sycl}" "${custom_target_script_pregen}" @ONLY)
       file(GENERATE

--- a/cmake/Modules/FindSYCL/run_sycl.cmake
+++ b/cmake/Modules/FindSYCL/run_sycl.cmake
@@ -30,6 +30,7 @@ set(SYCL_executable "@SYCL_EXECUTABLE@") # path
 set(SYCL_compile_flags @SYCL_COMPILE_FLAGS@) # list
 set(SYCL_include_dirs [==[@SYCL_include_dirs@]==]) # list
 set(SYCL_compile_definitions [==[@SYCL_compile_definitions@]==]) # list
+set(SYCL_compiler_launcher "@SYCL_COMPILER_LAUNCHER@") # path (ccache or empty)
 
 list(REMOVE_DUPLICATES SYCL_INCLUDE_DIRS)
 
@@ -112,21 +113,22 @@ macro(SYCL_execute_process status command)
   execute_process(COMMAND ${ARGN} RESULT_VARIABLE SYCL_result )
 endmacro()
 
-# Delete the target file
-SYCL_execute_process(
-  "Removing ${generated_file}"
-  COMMAND "${CMAKE_COMMAND}" -E remove "${generated_file}"
-  )
-
 # Generate the code
 if(WIN32)
   set(SYCL_dependency_file_args /clang:-MD /clang:-MF /clang:${SYCL_generated_dependency_file})
 else()
   set(SYCL_dependency_file_args -MD -MF "${SYCL_generated_dependency_file}")
 endif()
+# Build the compiler command: optionally prepend ccache/sccache launcher.
+if(SYCL_compiler_launcher)
+  set(_sycl_compiler_cmd "${SYCL_compiler_launcher}" "${SYCL_executable}")
+else()
+  set(_sycl_compiler_cmd "${SYCL_executable}")
+endif()
+
 SYCL_execute_process(
   "Generating ${generated_file}"
-  COMMAND "${SYCL_executable}"
+  COMMAND ${_sycl_compiler_cmd}
   ${SYCL_dependency_file_args}
   -c
   "${source_file}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ exclude = [
 
 [tool.scikit-build]
 cmake.build-type = "Release"
-build-dir = "build"
+build-dir = "build/{wheel_tag}"
 minimum-version = "build-system.requires"
 
 wheel.py-api = "cp39"


### PR DESCRIPTION
- Remove unconditional object file deletion in run_sycl.cmake to enable incremental builds
- Auto-detect and use ccache/sccache for both C++ and SYCL compilations
- Persist FetchContent downloads outside build/ to avoid re-cloning cutlass
- Use stable build directory and --no-build-isolation for pip install