### PR TITLE
Fix rmsnorm for non-flattenable 3D tensors (Qwen3 QK Norm)

### DIFF
--- a/src/sycl/Norm.h
+++ b/src/sycl/Norm.h
@@ -32,15 +32,6 @@ inline std::tuple<int64_t, int64_t> _check_layer_norm_inputs(
   TENSOR_CHECK(weight)
   TENSOR_CHECK(bias)
 
-  // For 3D inputs, verify that the leading dimensions can be flattened into a
-  // single batch dimension without a copy (i.e. rows are evenly spaced).
-  if (input.dim() == 3) {
-    TORCH_CHECK(
-        input.size(0) == 1 || input.stride(0) == input.size(1) * input.stride(1),
-        "3D input must have flattenable leading dimensions when treated as a "
-        "batched 2D tensor");
-  }
-
   int64_t hidden_size = input.size(-1);
   int64_t batch_size = input.numel() / hidden_size;
 

--- a/src/sycl/RMSNorm.cpp
+++ b/src/sycl/RMSNorm.cpp
@@ -416,12 +416,17 @@ void GemmaFusedAddRMSNormKernelImplInternal(
 }
 
 void rmsnorm(torch::Tensor& output, torch::Tensor& input, torch::Tensor& weight, double eps) {
+  // Make input contiguous so that non-flattenable 3D tensors (e.g. from
+  // tensor.split().view() in Qwen3 QK Norm) get valid strides for the
+  // kernel.  This is a no-op when the tensor is already contiguous.
+  Tensor input_c = input.contiguous();
+
   std::optional<torch::Tensor> opt_weight = weight;
   std::optional<torch::Tensor> opt_bias;
-  auto [M, N] = _check_layer_norm_inputs(input, c10::IntArrayRef({input.size(-1)}), opt_weight, opt_bias);
+  auto [M, N] = _check_layer_norm_inputs(input_c, c10::IntArrayRef({input_c.size(-1)}), opt_weight, opt_bias);
 
   // Flatten leading dimensions to 2D for the kernel
-  Tensor input_ = flatten_to_2d(input, M, N);
+  Tensor input_ = flatten_to_2d(input_c, M, N);
   Tensor output_ = flatten_to_2d(output, M, N);
   Tensor weight_ = (weight.dim() == 1) ? weight.reshape({N}) : weight;
   Tensor rstd = at::empty({M}, input_.options().dtype(kFloat));
@@ -464,12 +469,14 @@ void fused_add_rmsnorm(torch::Tensor input, torch::Tensor residual, torch::Tenso
 }
 
 void gemma_rmsnorm(torch::Tensor& output, torch::Tensor& input, torch::Tensor& weight, double eps) {
+  Tensor input_c = input.contiguous();
+
   std::optional<torch::Tensor> opt_weight = weight;
   std::optional<torch::Tensor> opt_bias;
-  auto [M, N] = _check_layer_norm_inputs(input, c10::IntArrayRef({input.size(-1)}), opt_weight, opt_bias);
+  auto [M, N] = _check_layer_norm_inputs(input_c, c10::IntArrayRef({input_c.size(-1)}), opt_weight, opt_bias);
 
   // Flatten leading dimensions to 2D for the kernel
-  Tensor input_ = flatten_to_2d(input, M, N);
+  Tensor input_ = flatten_to_2d(input_c, M, N);
   Tensor output_ = flatten_to_2d(output, M, N);
   Tensor weight_ = (weight.dim() == 1) ? weight.reshape({N}) : weight;
   Tensor rstd = at::empty({M}, input_.options().dtype(kFloat));

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -311,5 +311,67 @@ def test_gemma_norm_3d_non_contiguous(batch_size, seq_len, hidden_size, dtype):
     torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
 
 
+###############################################################################
+# Non-flattenable 3D tensor tests (Qwen3 QK Norm split+view pattern)
+# Here the 3D tensor comes from tensor.split(dim=-1).view(B, num_heads, head_dim)
+# where stride(0) != size(1) * stride(1) because of the split.
+###############################################################################
+
+
+def _make_split_view_3d(batch_size, num_heads, head_dim, dtype, num_kv_heads=2):
+    """Reproduce the Qwen3 QK Norm split+view pattern that creates a 3D
+    tensor whose leading dims are NOT flattenable (stride(0) > size(1)*stride(1)).
+    """
+    q_size = num_heads * head_dim
+    kv_size = num_kv_heads * head_dim
+    total = q_size + 2 * kv_size
+    qkv = torch.randn(batch_size, total, device=device, dtype=dtype)
+    q, k, v = qkv.split([q_size, kv_size, kv_size], dim=-1)
+    q_3d = q.view(batch_size, num_heads, head_dim)
+    k_3d = k.view(batch_size, num_kv_heads, head_dim)
+    # Verify the tensor is indeed non-flattenable
+    assert q_3d.stride(0) != q_3d.size(1) * q_3d.stride(1)
+    assert k_3d.stride(0) != k_3d.size(1) * k_3d.stride(1)
+    return q_3d, k_3d
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 16])
+@pytest.mark.parametrize("num_heads", [8, 16])
+@pytest.mark.parametrize("head_dim", [64, 128])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_norm_3d_split_view_qwen3(batch_size, num_heads, head_dim, dtype):
+    """Test rmsnorm with the non-flattenable 3D tensor pattern from Qwen3 QK Norm."""
+    q_3d, k_3d = _make_split_view_3d(batch_size, num_heads, head_dim, dtype)
+    w_q = torch.randn(head_dim, device=device, dtype=dtype)
+    w_k = torch.randn(head_dim, device=device, dtype=dtype)
+
+    y_q_ref = llama_rms_norm(q_3d.contiguous(), w_q)
+    y_q = sgl_kernel.rmsnorm(q_3d, w_q)
+    torch.testing.assert_close(y_q_ref, y_q, rtol=1e-3, atol=1e-3)
+
+    y_k_ref = llama_rms_norm(k_3d.contiguous(), w_k)
+    y_k = sgl_kernel.rmsnorm(k_3d, w_k)
+    torch.testing.assert_close(y_k_ref, y_k, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 16])
+@pytest.mark.parametrize("num_heads", [8, 16])
+@pytest.mark.parametrize("head_dim", [64, 128])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_gemma_norm_3d_split_view_qwen3(batch_size, num_heads, head_dim, dtype):
+    """Test gemma_rmsnorm with the non-flattenable 3D tensor pattern from Qwen3 QK Norm."""
+    q_3d, k_3d = _make_split_view_3d(batch_size, num_heads, head_dim, dtype)
+    w_q = torch.randn(head_dim, device=device, dtype=dtype)
+    w_k = torch.randn(head_dim, device=device, dtype=dtype)
+
+    y_q_ref = gemma_rms_norm(q_3d.contiguous(), w_q)
+    y_q = sgl_kernel.gemma_rmsnorm(q_3d, w_q)
+    torch.testing.assert_close(y_q_ref, y_q, rtol=1e-3, atol=1e-3)
+
+    y_k_ref = gemma_rms_norm(k_3d.contiguous(), w_k)
+    y_k = sgl_kernel.gemma_rmsnorm(k_3d, w_k)
+    torch.testing.assert_close(y_k_ref, y_k, rtol=1e-3, atol=1e-3)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary

Fix rmsnorm crash on Qwen3 models caused by non-flattenable 3D tensors from QK Norm `split+view` pattern.

Fixes https://github.com/sgl-project/sgl-kernel-xpu/issues/169

## Problem

Qwen3 uses QK Norm which calls rmsnorm on 3D tensors created by:
```python
qkv.split([q_size, kv_size, kv_size], dim=-1)  # non-contiguous view
q.view(batch_size, num_heads, head_dim)          # 3D with stride(0) != size(1)*stride(1)
```

The `TORCH_CHECK` in `_check_layer_norm_inputs` (Norm.h) rejected these tensors with:
```
RuntimeError: 3D input must have flattenable leading dimensions when treated as a batched 2D tensor
```

## Fix

1. **`src/sycl/RMSNorm.cpp`**: Call `.contiguous()` on input in `rmsnorm()` and `gemma_rmsnorm()` entry points before validation. This is a no-op for already-contiguous tensors.
2. **`src/sycl/Norm.h`**: Remove the overly strict flattenability check (callers now guarantee contiguity).
3. **`tests/test_norm.py`**: Add `test_norm_3d_split_view_qwen3` and `test_gemma_norm_3d_split_view_qwen3` reproducing the exact Qwen3 pattern.

## Testing

- Verified Qwen3-0.6B inference works end-to-end on Intel Data Center GPU Max 1550 after applying this fix
- Added parametrized tests covering the exact split+view tensor pattern with multiple batch sizes, head counts, head dims, and dtypes
