### PR TITLE
Added Split-KV support for MLA Decode

### DIFF
--- a/benchmark/bench_flash_mla_decode.py
+++ b/benchmark/bench_flash_mla_decode.py
@@ -86,7 +86,7 @@ def benchmark(batch_size, seq_len, provider, block_size, num_kv_splits):
     q_pe = q[:, :, dv:].clone()
 
     workspace_size = flash_mla_get_workspace_size(
-        block_num * block_size, batch_size, num_kv_splits=num_kv_splits
+        block_num * block_size, batch_size, h_q, block_size, num_kv_splits=num_kv_splits
     )
     workspace = torch.empty(workspace_size, device="xpu", dtype=torch.uint8)
     scale = (512 + 64) ** (-0.5)

--- a/benchmark/bench_flash_mla_decode.py
+++ b/benchmark/bench_flash_mla_decode.py
@@ -9,7 +9,7 @@ import triton
 from sgl_kernel import flash_mla_decode, flash_mla_get_workspace_size
 
 bs_range = [1, 4, 16]
-kv_len_range = [1024, 2048, 4096, 8192]
+kv_len_range = [1024, 2048, 4096, 8192, 16384, 32768]
 
 configs = list(itertools.product(bs_range, kv_len_range))
 
@@ -329,9 +329,7 @@ if __name__ == "__main__":
 
     for block_size in args.block_sizes:
         for kv_split in args.num_kv_splits:
-            print(f"\n{'='*60}")
             print(f"Running: block_size={block_size}, num_kv_splits={kv_split}")
-            print(f"{'='*60}")
             benchmark.run(
                 print_data=False,
                 show_plots=False,

--- a/include/sgl_flash_kernel_ops.h
+++ b/include/sgl_flash_kernel_ops.h
@@ -86,4 +86,4 @@ void flash_mla_decode(
     int64_t num_kv_splits = -1);
 
 int64_t flash_mla_get_workspace_size(
-    int64_t max_seq_len, int64_t num_batches, int64_t sm_count = 0, int64_t num_kv_splits = -1);
+    int64_t max_seq_len, int64_t num_batches, int64_t num_heads = 0, int64_t page_size = 0, int64_t num_kv_splits = -1);

--- a/include/sgl_flash_kernel_ops.h
+++ b/include/sgl_flash_kernel_ops.h
@@ -86,4 +86,4 @@ void flash_mla_decode(
     int64_t num_kv_splits = -1);
 
 int64_t flash_mla_get_workspace_size(
-    int64_t max_seq_len, int64_t num_batches, int64_t num_heads = 0, int64_t page_size = 0, int64_t num_kv_splits = -1);
+    int64_t max_seq_len, int64_t num_batches, int64_t num_heads, int64_t page_size, int64_t num_kv_splits = -1);

--- a/python/sgl_kernel/attention.py
+++ b/python/sgl_kernel/attention.py
@@ -133,10 +133,14 @@ def flash_mla_decode(
 
 
 def flash_mla_get_workspace_size(
-    max_seq_len: int, num_batches: int, sm_count: int = 0, num_kv_splits: int = -1
+    max_seq_len: int,
+    num_batches: int,
+    num_heads: int = 0,
+    page_size: int = 0,
+    num_kv_splits: int = -1,
 ) -> int:
     assert max_seq_len > 0, f"max_seq_len must be greater than 0, got {max_seq_len}"
     assert num_batches > 0, f"num_batches must be greater than 0, got {num_batches}"
     return torch.ops.sgl_kernel.flash_mla_get_workspace_size.default(
-        max_seq_len, num_batches, sm_count, num_kv_splits
+        max_seq_len, num_batches, num_heads, page_size, num_kv_splits
     )

--- a/src/sycl/kernels/mla/collective/xe_mla_epilogue.hpp
+++ b/src/sycl/kernels/mla/collective/xe_mla_epilogue.hpp
@@ -64,6 +64,7 @@ class XeMlaEpilogue {
   using FragA = typename CollectiveMainloop::FragA;
   using FragARow = typename CollectiveMainloop::FragARow;
   using ElementA = typename FragA::value_type;
+  using ElementAcc = float;  // Accumulator type for exp_sums/max_logits in split-KV path
 
   using ReduceK = decltype(size<3>(typename TiledMMAPV::ThrLayoutVMNK{}));
 
@@ -150,7 +151,8 @@ class XeMlaEpilogue {
     using ElementA = typename FragA::element_type;
 
     // Reduce k-blocks of A and A_sum across WG, if needed.
-    auto [rA, rA_sum, active] = reduce_A(tArA, tA_max, tA_sum, thr_id);
+    auto [rA, rA_sum, rA_max_unused, active] = reduce_A(tArA, tA_max, tA_sum, thr_id);
+    (void)rA_max_unused;
 
     /* Some subgroups may not have any work to do; if so, quit early. */
     if (!active) return;
@@ -182,6 +184,72 @@ class XeMlaEpilogue {
     copy(copy_o, tOrO, tOgO);
   }
 
+  /// Split-KV epilogue operator.
+  ///
+  /// Stores unnormalized partial O to O_accum and writes exp_sum / max_logit
+  /// for this (head, batch, kv_split) to global memory.
+  ///
+  template <typename QVCoord>
+  CUTLASS_DEVICE void operator()(
+      TensorO2D const& O_accum,  // 2D slice of partial output buffer: (q, v)
+      FragA& tArA,               // O accumulator fragment from mainloop
+      FragARow& tA_max,          // Softmax row-wise max accumulator
+      FragARow& tA_sum,          // Softmax row-wise sum accumulator
+      QVCoord blk_qv,            // WG tile indices: (Q, V)
+      int thr_id,                // Work-item ID
+      ElementAcc& exp_sum,       // Reference to this split's exp_sum element
+      ElementAcc& max_logit,     // Reference to this split's max_logit element
+      int num_kv_splits) {       // Total number of KV splits
+    using namespace cute;
+
+    // Step 1: Cross-subgroup reduction of accumulators
+    auto [rA, rA_sum, rA_max, active] = reduce_A(tArA, tA_max, tA_sum, thr_id);
+
+    // Step 2: Store LSE statistics for this split.
+    // Thread 0 (subgroup 0, lane 0) is always active after reduce_A.
+    if (thr_id == 0) {
+      exp_sum = static_cast<ElementAcc>(rA_sum(0));
+      max_logit = static_cast<ElementAcc>(rA_max(0));
+    }
+
+    // Inactive subgroups (when ReduceK > 1) have no work to do.
+    if (!active) return;
+
+    // Step 3: Write O_accum.
+    // For num_kv_splits > 1, O_accum is stored UNNORMALIZED (raw numerator):
+    //   O_accum_s = sum_i exp2(S_si - max_s) * V_si
+    // The reduction kernel merges via:
+    //   O = [sum_s O_accum_s * exp2(max_s - global_max)]
+    //     / [sum_s exp_sum_s * exp2(max_s - global_max)]
+    //
+    // For num_kv_splits == 1, normalize in-place (no reduction needed).
+    if (num_kv_splits == 1) {
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < rA_sum.size(); i++)
+        rA_sum(i) = ElementA(1) / rA_sum(i);
+
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < rA.size(); i++) {
+        rA(i) *= broadcast<0>(rA_sum, rA, i);
+      }
+    }
+
+    /* Tile output */
+    Tensor cO = make_identity_tensor(O_accum.shape());  // (q,v)
+    Tensor gO = local_tile(cO, TileShapeO{}, blk_qv);   // (q,v)
+
+    /* Prepare slices */
+    TiledCopyO copy_o{O_accum};
+    auto thr_copy_o = copy_o.get_slice(thr_id);
+
+    auto tOrO = thr_copy_o.partition_sg_fragment_S(gO);
+    auto tOgO = thr_copy_o.partition_D(gO);
+
+    /* Reorder tile and write out */
+    reorder(rA, tOrO);
+    copy(copy_o, tOrO, tOgO);
+  }
+
   template <typename FragA, typename FragARow>
   CUTLASS_DEVICE decltype(auto) reduce_A(
       FragA& tArA,       // O accumulator:   (q,v)
@@ -191,7 +259,7 @@ class XeMlaEpilogue {
 
     using namespace sycl::ext::oneapi::this_work_item;
     if constexpr (ReduceK{} == _1{}) {
-      return std::make_tuple(tArA, tA_sum, true);
+      return std::make_tuple(tArA, tA_sum, tA_max, true);
     } else {
       /* Identify A tile ID and k block for this subgroup. */
       auto thr_vak = group<1, 3>(TiledMMAPV{}.get_thr_layout_vmnk()).get_flat_coord(assert_uniform(thr_id));
@@ -283,7 +351,7 @@ class XeMlaEpilogue {
           }
         }
       }
-      return std::make_tuple(rA, rA_sum, active);
+      return std::make_tuple(rA, rA_sum, rA_max, active);
     }
   }
 };

--- a/src/sycl/kernels/mla/collective/xe_mla_mainloop.hpp
+++ b/src/sycl/kernels/mla/collective/xe_mla_mainloop.hpp
@@ -40,7 +40,6 @@
 #include "cute/atom/mma_atom.hpp"
 #include "cutlass/cutlass.h"
 #include "cutlass/gemm/dispatch_policy.hpp"
-
 namespace cutlass::flash_attention {
 
 template <int Stages>
@@ -177,11 +176,7 @@ struct XeMlaMainloop<
   //
   // Shared memory storage for cross-subgroup softmax reduction
   //
-  struct SharedStorage {
-    // Storage for per-subgroup max values (one per subgroup)
-    // Used for cross-SG max reduction before computing exp2
-    cute::array<ElementS, NumSubgroups> sg_max_data;
-  };
+  struct SharedStorage {};
 
   Params params;
   SharedStorage& shared;

--- a/src/sycl/kernels/mla/device/mla_decode_types.hpp
+++ b/src/sycl/kernels/mla/device/mla_decode_types.hpp
@@ -39,6 +39,7 @@
 #include <c10/xpu/XPUStream.h>
 #include <torch/all.h>
 
+#include <cmath>
 #include <cute/tensor.hpp>
 #include <sycl/sycl.hpp>
 
@@ -51,9 +52,9 @@
 
 using namespace cute;
 
-//----------------- set persistent options --------------------//
+//----------------- set splitkv options --------------------//
 template <bool v>
-struct IsPersistent {
+struct EnabledSplitKV {
   static const bool value = v;
 };
 
@@ -98,7 +99,7 @@ struct FMlAProblemShape {
 };
 
 //----------------- define MLA Xe configuration --------------------//
-template <typename T, typename PageSizeOpt = PageSizeOption<64>, typename PersistenceOption = IsPersistent<false>>
+template <typename T, typename PageSizeOpt = PageSizeOption<64>, typename SplitKVOption = EnabledSplitKV<false>>
 struct MlaXe {
   // TODO: add persistence option support in tile scheduler
   using TileScheduler = typename cutlass::flash_attention::kernel::XeMlaIndividualTileScheduler;
@@ -175,8 +176,13 @@ struct MlaXe {
       cutlass::flash_attention::collective::XeMlaEpilogue<CollectiveMainloop, TileShapeOutput, TensorO, GmemTiledCopyO>;
 
   // Kernel instantiation
-  using FmlaKernel = cutlass::flash_attention::kernel::
-      XeMlaFwdKernel<ProblemShape, CollectiveMainloop, CollectiveEpilogue, TileScheduler>;
+  static constexpr bool is_split_kv = SplitKVOption::value;
+  using FmlaKernel = typename cute::conditional_t<
+      SplitKVOption::value,
+      cutlass::flash_attention::kernel::
+          XeMlaSplitKVKernel<ProblemShape, CollectiveMainloop, CollectiveEpilogue, TileScheduler>,
+      cutlass::flash_attention::kernel::
+          XeMlaFwdKernel<ProblemShape, CollectiveMainloop, CollectiveEpilogue, TileScheduler>>;
 
   using Fmla = cutlass::flash_attention::device::MLA<FmlaKernel>;
 };
@@ -189,6 +195,7 @@ inline typename T::Fmla::Arguments args_from_options(
     at::Tensor const& kv_c_and_k_pe_cache,
     at::Tensor const& seq_lens,
     at::Tensor const& page_table,
+    at::Tensor const& workspace,
     double sm_scale,
     int64_t num_kv_splits) {
   cutlass::KernelHardwareInfo hw_info;
@@ -277,6 +284,32 @@ inline typename T::Fmla::Arguments args_from_options(
   kernel_args.dO = stride_O;
   kernel_args.seq_lens = static_cast<const int*>(seq_lens.data_ptr());
 
+  if constexpr (T::is_split_kv) {
+    using cutlass::flash_attention::kernel::SplitKVWorkspaceLayout;
+    SplitKVWorkspaceLayout ws(
+        batch, problem_shape.num_heads_q, num_kv_splits, problem_shape.head_size_o, sizeof(ElementO));
+
+    auto* ws_ptr = static_cast<char*>(workspace.data_ptr());
+    auto* o_accum_ptr = reinterpret_cast<ElementO*>(ws_ptr + ws.o_accum_offset);
+    auto* exp_sums_ptr = reinterpret_cast<float*>(ws_ptr + ws.exp_sums_offset);
+    auto* max_logits_ptr = reinterpret_cast<float*>(ws_ptr + ws.max_logits_offset);
+
+    StrideO stride_O_accum = cute::make_stride(
+        static_cast<int>(batch * problem_shape.num_heads_q * num_kv_splits * problem_shape.head_size_o),
+        cute::_1{},
+        static_cast<int>(problem_shape.head_size_o),
+        static_cast<int>(problem_shape.num_heads_q * num_kv_splits * problem_shape.head_size_o));
+    StrideO stride_lse = cute::make_stride(
+        static_cast<int>(problem_shape.batch * problem_shape.num_heads_q * num_kv_splits),
+        cute::_1{},
+        static_cast<int>(num_kv_splits),
+        static_cast<int>(problem_shape.num_heads_q * num_kv_splits));
+    kernel_args.O_accum = o_accum_ptr;
+    kernel_args.dO_accum = stride_O_accum;
+    kernel_args.exp_sums = exp_sums_ptr;
+    kernel_args.max_logits = max_logits_ptr;
+    kernel_args.dLSE = stride_lse;
+  }
   typename T::CollectiveMainloop::Arguments mainloop_args{
       static_cast<float>(sm_scale),
       static_cast<const int*>(page_table.data_ptr()),
@@ -284,9 +317,30 @@ inline typename T::Fmla::Arguments args_from_options(
       total_page,
       page_count_per_seq};
 
-  typename T::Fmla::Arguments arguments{kernel_args, mainloop_args, {}, hw_info};
+  typename T::Fmla::Arguments arguments{kernel_args, mainloop_args, {}, hw_info, static_cast<int>(num_kv_splits)};
 
   return arguments;
+}
+
+template <typename Element, typename PageSizeOpt, typename SplitKVOpt>
+inline void runMlaImpl(
+    at::Tensor const& out,
+    at::Tensor const& q_nope,
+    at::Tensor const& q_pe,
+    at::Tensor const& kv_c_and_k_pe_cache,
+    at::Tensor const& seq_lens,
+    at::Tensor const& page_table,
+    at::Tensor const& workspace,
+    double sm_scale,
+    int64_t num_kv_splits) {
+  using MlaXeType = MlaXe<Element, PageSizeOpt, SplitKVOpt>;
+  typename MlaXeType::Fmla fmla;
+  auto arguments = args_from_options<MlaXeType>(
+      out, q_nope, q_pe, kv_c_and_k_pe_cache, seq_lens, page_table, workspace, sm_scale, num_kv_splits);
+
+  CUTLASS_CHECK(fmla.can_implement(arguments));
+
+  CUTLASS_CHECK(fmla.run(arguments, workspace.data_ptr()));
 }
 
 template <typename Element, typename PageSizeOpt>
@@ -300,12 +354,31 @@ inline void runMla(
     at::Tensor const& workspace,
     double sm_scale,
     int64_t num_kv_splits) {
-  using MlaXeType = MlaXe<Element, PageSizeOpt, IsPersistent<false>>;
-  typename MlaXeType::Fmla fmla;
-  auto arguments = args_from_options<MlaXeType>(
-      out, q_nope, q_pe, kv_c_and_k_pe_cache, seq_lens, page_table, sm_scale, num_kv_splits);
+  TORCH_CHECK(num_kv_splits >= 1, "num_kv_splits must be resolved before calling runMla, got ", num_kv_splits);
 
-  CUTLASS_CHECK(fmla.can_implement(arguments));
+  if (num_kv_splits > 1) {
+    using cutlass::flash_attention::kernel::SplitKVWorkspaceLayout;
+    int batch = q_nope.size(0);
+    int num_heads = q_nope.size(1);
+    int head_size_o = q_nope.size(2);
+    SplitKVWorkspaceLayout ws(batch, num_heads, num_kv_splits, head_size_o, sizeof(Element));
+    TORCH_CHECK(
+        static_cast<size_t>(workspace.numel()) >= ws.total_bytes,
+        "MLA workspace too small: need ",
+        ws.total_bytes,
+        " bytes for num_kv_splits=",
+        num_kv_splits,
+        ", but got ",
+        workspace.numel(),
+        " bytes. Reallocate workspace with flash_mla_get_workspace_size() using "
+        "matching (batch, num_heads, max_seq_len, page_size) parameters.");
+  }
 
-  CUTLASS_CHECK(fmla.run(arguments, workspace.data_ptr()));
+  if (num_kv_splits == 1) {
+    runMlaImpl<Element, PageSizeOpt, EnabledSplitKV<false>>(
+        out, q_nope, q_pe, kv_c_and_k_pe_cache, seq_lens, page_table, workspace, sm_scale, num_kv_splits);
+  } else {
+    runMlaImpl<Element, PageSizeOpt, EnabledSplitKV<true>>(
+        out, q_nope, q_pe, kv_c_and_k_pe_cache, seq_lens, page_table, workspace, sm_scale, num_kv_splits);
+  }
 }

--- a/src/sycl/kernels/mla/device/mla_runner.hpp
+++ b/src/sycl/kernels/mla/device/mla_runner.hpp
@@ -37,6 +37,7 @@
 
 #include <c10/xpu/XPUStream.h>
 
+#include <cmath>
 #include <sycl/ext/intel/experimental/grf_size_properties.hpp>
 #include <sycl/sycl.hpp>
 
@@ -45,12 +46,10 @@
 #include "cutlass/util/sycl_event_manager.hpp"
 #include "sycl/comm/common.h"
 #include "sycl/kernels/mla/kernel/xe_mla_kernel.hpp"
+#include "sycl/kernels/mla/kernel/xe_mla_reduce_split_kv.hpp"
 
 namespace cutlass::flash_attention::device {
 using namespace cute;
-
-template <typename Kernel>
-class KernelCur {};
 
 ////////////////////////////////////////////////////////////////////////////////
 template <class Kernel_>
@@ -63,13 +62,17 @@ class MLA {
   using KernelArguments = typename Kernel::KernelArguments;
   using Arguments = typename Kernel::Arguments;
   using KernelParams = typename Kernel::Params;
-  //
-  // Params
-  //
+
+  using ProblemShape = typename Kernel::ProblemShape;
+  using ReductionScheduler = cutlass::flash_attention::kernel::XeMlaReduceSplitKScheduler;
+  using ReductionKernel =
+      cutlass::flash_attention::kernel::XeMlaReduceSplitKV<ProblemShape, ReductionScheduler, Kernel>;
+  using ReductionArguments = typename ReductionKernel::Arguments;
+  using ReductionParams = typename ReductionKernel::Params;
+
   struct Params {
     KernelParams fmla_params;
-    Params() = default;
-    explicit Params(KernelParams const& kp) : fmla_params(kp) {}
+    ReductionParams reduction_params;
   };
 
  private:
@@ -102,21 +105,25 @@ class MLA {
     return params_;
   }
 
-  static void set_split_kv(KernelArguments& args) {
-    // TODO: set split_kv in args if needed
-    assert(false && "set_split_kv not implemented yet.");
-    return;
-  }
-
   static cutlass::Status can_implement(Arguments const& args) {
-    return Kernel_::can_implement(args) ? cutlass::Status::kSuccess : cutlass::Status::kErrorInvalidProblem;
-    // return cutlass::Status::kSuccess;
+    if (!Kernel_::can_implement(args)) return cutlass::Status::kErrorInvalidProblem;
+    if constexpr (Kernel::is_split_kv) {
+      ReductionArguments reduce_args{};
+      reduce_args.kernel.shape = args.kernel.shape;
+      reduce_args.num_kv_splits = args.split_kv;
+      if (!ReductionKernel::can_implement(reduce_args)) return cutlass::Status::kErrorInvalidProblem;
+    }
+    return cutlass::Status::kSuccess;
   }
 
   static size_t get_workspace_size(Arguments const& args) {
     size_t workspace_bytes = 0;
     workspace_bytes += Kernel::get_workspace_size(args);
-    // TODO: add Reduction workspace size when splitkv > 1
+    if constexpr (Kernel::is_split_kv) {
+      ReductionArguments reduce_args{};
+      reduce_args.num_kv_splits = args.split_kv;
+      workspace_bytes += ReductionKernel::get_workspace_size(reduce_args);
+    }
     return workspace_bytes;
   }
 
@@ -126,11 +133,32 @@ class MLA {
 
   cutlass::Status initialize(
       Arguments const& args, void* workspace = nullptr, sycl::queue& queue = c10::xpu::getCurrentXPUStream().queue()) {
-    // Initialize the workspace
-    CUTLASS_CHECK(Kernel::initialize_workspace(args, workspace));
+    int split_kv = args.split_kv;
+    if constexpr (!Kernel::is_split_kv) {
+      // Non-split path
+      CUTLASS_CHECK(Kernel::initialize_workspace(args, workspace));
+      params_.fmla_params = Kernel::to_underlying_arguments(args, workspace);
+    } else {
+      // Split-KV path: compute workspace layout and set up both kernel params
+      auto const& s = args.kernel.shape;
+      // Construct split-KV main kernel arguments
+      params_.fmla_params = Kernel::to_underlying_arguments(args, workspace);
 
-    KernelParams kernel_params = Kernel::to_underlying_arguments(args, workspace);
-    params_ = Params{kernel_params};
+      using StrideO = typename Kernel::StrideO;
+
+      typename ReductionKernel::KernelArguments reduce_kernel_args{};
+      reduce_kernel_args.shape = s;
+      reduce_kernel_args.O = args.kernel.O;
+      reduce_kernel_args.dO = args.kernel.dO;
+      reduce_kernel_args.O_accum = args.kernel.O_accum;
+      reduce_kernel_args.dO_accum = args.kernel.dO_accum;
+      reduce_kernel_args.exp_sums = args.kernel.exp_sums;
+      reduce_kernel_args.max_logits = args.kernel.max_logits;
+      reduce_kernel_args.dLSE = args.kernel.dLSE;
+
+      ReductionArguments reduce_args{reduce_kernel_args, args.hw_info, split_kv};
+      params_.reduction_params = ReductionKernel::to_underlying_arguments(reduce_args, workspace);
+    }
 
     if (is_initialized()) return Status::kSuccess;
 
@@ -149,15 +177,18 @@ class MLA {
     if (workspace_bytes > 0 && nullptr == workspace) {
       return Status::kErrorWorkspaceNull;
     }
-
-    auto fmla_params = Kernel::to_underlying_arguments(args, workspace);
-    params_ = Params{fmla_params};
-
-    return cutlass::Status::kSuccess;
+    return initialize(args, workspace);
   }
 
   static cutlass::Status run(Params& params, sycl::queue& queue = c10::xpu::getCurrentXPUStream().queue()) {
-    launch<Kernel, 128>(params.fmla_params);
+    if constexpr (!Kernel::is_split_kv) {
+      // Non-split: launch main kernel only
+      launch<Kernel, 128>(params.fmla_params);
+    } else {
+      // Split-KV: launch split attention kernel + reduction kernel
+      launch<Kernel, 128>(params.fmla_params);
+      launch<ReductionKernel, 128>(params.reduction_params);
+    }
 
     return cutlass::Status::kSuccess;
   }

--- a/src/sycl/kernels/mla/device/mla_runner.hpp
+++ b/src/sycl/kernels/mla/device/mla_runner.hpp
@@ -51,6 +51,21 @@
 namespace cutlass::flash_attention::device {
 using namespace cute;
 
+namespace detail {
+template <class Kernel, bool IsSplitKV = Kernel::is_split_kv>
+struct ReductionTraits {
+  using type = cutlass::flash_attention::kernel::DummyReductionKernel;
+};
+
+template <class Kernel>
+struct ReductionTraits<Kernel, true> {
+  using type = cutlass::flash_attention::kernel::XeMlaReduceSplitKV<
+      typename Kernel::ProblemShape,
+      cutlass::flash_attention::kernel::XeMlaReduceSplitKScheduler,
+      Kernel>;
+};
+}  // namespace detail
+
 ////////////////////////////////////////////////////////////////////////////////
 template <class Kernel_>
 class MLA {
@@ -64,9 +79,7 @@ class MLA {
   using KernelParams = typename Kernel::Params;
 
   using ProblemShape = typename Kernel::ProblemShape;
-  using ReductionScheduler = cutlass::flash_attention::kernel::XeMlaReduceSplitKScheduler;
-  using ReductionKernel =
-      cutlass::flash_attention::kernel::XeMlaReduceSplitKV<ProblemShape, ReductionScheduler, Kernel>;
+  using ReductionKernel = typename detail::ReductionTraits<Kernel>::type;
   using ReductionArguments = typename ReductionKernel::Arguments;
   using ReductionParams = typename ReductionKernel::Params;
 

--- a/src/sycl/kernels/mla/kernel/mla_tile_scheduler.hpp
+++ b/src/sycl/kernels/mla/kernel/mla_tile_scheduler.hpp
@@ -109,7 +109,7 @@ struct XeMlaIndividualTileScheduler {
 
     idx_b = idx_kv_split;
     params.divmod_num_heads(idx_b, head, idx_b);
-    return make_coord(BlockIdxY(), BlockIdxX(), head, idx_b, int(1));
+    return make_coord(BlockIdxY(), BlockIdxX(), head, idx_b, int(-1));
   }
 
   CUTLASS_DEVICE

--- a/src/sycl/kernels/mla/kernel/mla_tile_scheduler.hpp
+++ b/src/sycl/kernels/mla/kernel/mla_tile_scheduler.hpp
@@ -48,6 +48,8 @@ struct XeMlaIndividualTileScheduler {
   struct Params {
     dim3 grid;
     FastDivmod divmod_num_heads;
+    FastDivmod divmod_batch_heads;
+    int num_kv_splits_ = -1;
   };
 
   //
@@ -63,8 +65,8 @@ struct XeMlaIndividualTileScheduler {
   XeMlaIndividualTileScheduler(Params const& params) : params(params) {}
 
   template <class ProblemShape, class TileShape>
-  static Params
-  to_underlying_arguments(ProblemShape const& shape, KernelHardwareInfo hw_info, TileShape const& tile_shape) {
+  static Params to_underlying_arguments(
+      ProblemShape const& shape, KernelHardwareInfo hw_info, TileShape const& tile_shape, int num_kv_splits = -1) {
     using namespace cute;
 
     // Ensure num_heads_q is at least 1 to avoid division by zero
@@ -74,7 +76,12 @@ struct XeMlaIndividualTileScheduler {
         size(ceil_div(shape.head_size_o, get<1>(tile_shape))),  // V tiles
         size(ceil_div(shape.seq_len_qo, get<0>(tile_shape))),   // Q tiles
         size(shape.batch * num_heads));                         // (h,b) combined
-    return Params{grid, FastDivmod{num_heads}};
+
+    if (num_kv_splits > 1) {
+      grid.z *= num_kv_splits;
+    }
+
+    return Params{grid, FastDivmod{num_heads}, FastDivmod{shape.batch * num_heads}, num_kv_splits};
   }
 
   template <int Num_SGs>
@@ -90,14 +97,77 @@ struct XeMlaIndividualTileScheduler {
   CUTLASS_DEVICE
   auto get_block_coord() {
     using namespace cute;
-    int idx_b = BlockIdxZ();
-    int head;
+    int idx_kv_split = BlockIdxZ();
+    int head, idx_b;
+
+    if (params.num_kv_splits_ > 1) {
+      // First extract kv_split_idx, then (head, batch)
+      params.divmod_batch_heads(idx_kv_split, idx_b, idx_kv_split);
+      params.divmod_num_heads(idx_b, head, idx_b);
+      return make_coord(BlockIdxY(), BlockIdxX(), head, idx_b, idx_kv_split);
+    }
+
+    idx_b = idx_kv_split;
     params.divmod_num_heads(idx_b, head, idx_b);
-    return make_coord(BlockIdxY(), BlockIdxX(), head, idx_b);
+    return make_coord(BlockIdxY(), BlockIdxX(), head, idx_b, int(1));
   }
 
   CUTLASS_DEVICE
   XeMlaIndividualTileScheduler& operator++() {
+    valid_ = false;
+    return *this;
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct XeMlaReduceSplitKScheduler {
+  //
+  // Params
+  //
+  struct Params {
+    dim3 grid;
+    FastDivmod divmod_num_heads;
+    int num_kv_splits = -1;
+  };
+
+  //
+  // data members
+  //
+  bool valid_ = true;
+  Params params;
+
+  CUTLASS_DEVICE
+  XeMlaReduceSplitKScheduler(Params const& params) : params(params) {}
+
+  template <class ProblemShape, class TileShape>
+  static Params to_underlying_arguments(
+      ProblemShape const& shape, KernelHardwareInfo hw_info, TileShape const& tile_shape, int num_kv_splits = -1) {
+    using namespace cute;
+    // Grid: (seq_len_qo, num_heads_q, batch)
+    dim3 grid(shape.seq_len_qo, shape.num_heads_q, shape.batch);
+    return Params{grid, {shape.num_heads_q}, num_kv_splits};
+  }
+
+  template <int Num_SGs>
+  static dim3 get_grid_shape(Params const& params) {
+    return params.grid;
+  }
+
+  CUTLASS_DEVICE
+  bool is_valid() {
+    return valid_;
+  }
+
+  CUTLASS_DEVICE
+  auto get_block_coord() {
+    using namespace cute;
+    // (seq_q, head_q, batch)
+    return make_coord(BlockIdxX(), BlockIdxY(), BlockIdxZ());
+  }
+
+  CUTLASS_DEVICE
+  XeMlaReduceSplitKScheduler& operator++() {
     valid_ = false;
     return *this;
   }

--- a/src/sycl/kernels/mla/kernel/xe_mla_kernel.hpp
+++ b/src/sycl/kernels/mla/kernel/xe_mla_kernel.hpp
@@ -41,9 +41,28 @@
 #include "sycl/kernels/mla/collective/xe_mla_epilogue.hpp"
 #include "sycl/kernels/mla/collective/xe_mla_mainloop.hpp"
 #include "sycl/kernels/mla/kernel/mla_tile_scheduler.hpp"
-
 namespace cutlass::flash_attention::kernel {
 using namespace cute;
+
+struct SplitKVWorkspaceLayout {
+  size_t o_accum_offset;
+  size_t exp_sums_offset;
+  size_t max_logits_offset;
+  size_t total_bytes;
+
+  SplitKVWorkspaceLayout(int batch, int num_heads, int num_splits, int head_size_o, size_t elem_o_size) {
+    size_t o_accum_bytes = size_t(batch) * num_heads * num_splits * head_size_o * elem_o_size;
+    size_t lse_bytes = size_t(batch) * num_heads * num_splits * sizeof(float);
+
+    size_t o_accum_aligned = (o_accum_bytes + 255) & ~size_t(255);
+    size_t lse_aligned = (lse_bytes + 255) & ~size_t(255);
+
+    o_accum_offset = 0;
+    exp_sums_offset = o_accum_aligned;
+    max_logits_offset = o_accum_aligned + lse_aligned;
+    total_bytes = o_accum_aligned + lse_aligned + lse_aligned;
+  }
+};
 
 ///////////////////////////////////////////////////////////////////////////////
 template <class ProblemShape_, class CollectiveMainloop_, class CollectiveEpilogue_, class TileScheduler_>
@@ -61,10 +80,6 @@ class XeMlaFwdKernel {
 
   using TileShapeQK = typename CollectiveMainloop::TileShapeQK;
   using TileShapePV = typename CollectiveMainloop::TileShapePV;
-
-  static constexpr int QK_BLK_M = CollectiveMainloop::QK_BLK_M;
-  static constexpr int QK_BLK_N = CollectiveMainloop::QK_BLK_N;
-  static constexpr int QK_BLK_K = CollectiveMainloop::QK_BLK_K;
 
   using ElementQ = typename CollectiveMainloop::TensorQ::element_type;
   using ElementK = typename CollectiveMainloop::TensorK::element_type;
@@ -101,6 +116,8 @@ class XeMlaFwdKernel {
     EpilogueSharedStorage epilogue;
   };
   static constexpr int SharedStorageSize = is_empty_v<SharedStorage> ? size_t(0) : sizeof(SharedStorage);
+
+  static constexpr bool is_split_kv = false;
 
   //
   // KernelArguments
@@ -170,23 +187,18 @@ class XeMlaFwdKernel {
         args.kernel,
         CollectiveMainloop::to_underlying_arguments(args.mainloop, workspace),
         CollectiveEpilogue::to_underlying_arguments(args.epilogue, workspace),
-        TileScheduler::to_underlying_arguments(args.kernel.shape, args.hw_info, TileShapeO{})};
+        TileScheduler::to_underlying_arguments(args.kernel.shape, args.hw_info, TileShapeO{}, args.split_kv)};
   }
 
   static bool can_implement(Arguments const& args) {
     return CollectiveMainloop::can_implement(args.mainloop) && CollectiveEpilogue::can_implement(args.epilogue);
-    // return true; // change as needed
   }
 
   static int get_workspace_size(Arguments const& args) {
-    // If no split-K, no workspace needed
-    if (args.split_kv <= 1) {
-      return 0;
+    if (args.split_kv > 1) {
+      assert(false && "Split-K workspace size is calculated in different path");
     }
-
-    // TODO: For split-K calculate and return workspace size
-    assert(false && "Split-K workspace size calculation not implemented yet.");
-    return -1;
+    return 0;
   }
 
   static cutlass::Status initialize_workspace(Arguments const& args, void* workspace) {
@@ -209,7 +221,6 @@ class XeMlaFwdKernel {
 
     auto& p = params.kernel;
     ProblemShape const& s = p.shape;
-    int head_group_q = s.num_heads_q / s.num_heads_kv;
 
     int thr_id = int(ThreadIdxX());
 
@@ -217,7 +228,7 @@ class XeMlaFwdKernel {
 
     CUTLASS_PRAGMA_NO_UNROLL
     for (; tile_scheduler.is_valid(); ++tile_scheduler) {
-      auto [blk_q, blk_v, head_coord, batch_coord] = tile_scheduler.get_block_coord();
+      auto [blk_q, blk_v, head_coord, batch_coord, unused_split] = tile_scheduler.get_block_coord();
       auto blk_qv = make_coord(blk_q, blk_v);
 
       // Get actual kv sequence length for this batch
@@ -285,4 +296,273 @@ class XeMlaFwdKernel {
 };
 
 ///////////////////////////////////////////////////////////////////////////////
+template <class ProblemShape_, class CollectiveMainloop_, class CollectiveEpilogue_, class TileScheduler_>
+class XeMlaSplitKVKernel {
+ public:
+  //
+  // Type Aliases
+  //
+  using ProblemShape = ProblemShape_;
+
+  // Mainloop derived types
+  using CollectiveMainloop = CollectiveMainloop_;
+  using MainloopArguments = typename CollectiveMainloop::Arguments;
+  using MainloopParams = typename CollectiveMainloop::Params;
+
+  using TileShapeQK = typename CollectiveMainloop::TileShapeQK;
+  using TileShapePV = typename CollectiveMainloop::TileShapePV;
+
+  using ElementQ = typename CollectiveMainloop::TensorQ::element_type;
+  using ElementK = typename CollectiveMainloop::TensorK::element_type;
+  using ElementV = typename CollectiveMainloop::TensorV::element_type;
+
+  using StrideQ = decltype(stride(typename CollectiveMainloop::TensorQ{}));
+  using StrideK = decltype(stride(typename CollectiveMainloop::TensorK{}));
+  using StrideV = decltype(stride(typename CollectiveMainloop::TensorV{}));
+  using SGPerWG = typename CollectiveMainloop::SGPerWG;
+
+  using FragA = typename CollectiveMainloop::FragA;
+  using FragARow = typename CollectiveMainloop::FragARow;
+
+  // Epilogue derived types
+  using CollectiveEpilogue = CollectiveEpilogue_;
+  using EpilogueArguments = typename CollectiveEpilogue::Arguments;
+  using EpilogueParams = typename CollectiveEpilogue::Params;
+
+  using TileShapeO = typename CollectiveEpilogue::TileShapeO;
+  using ElementO = typename CollectiveEpilogue::TensorO::element_type;
+  using StrideO = decltype(stride(typename CollectiveEpilogue::TensorO{}));
+
+  // Tile scheduler derived types
+  using TileScheduler = TileScheduler_;
+  using TileSchedulerParams = typename TileScheduler::Params;
+
+  //
+  // Kernel level shared memory storage
+  //
+  using MainloopSharedStorage = typename CollectiveMainloop::SharedStorage;
+  using EpilogueSharedStorage = typename CollectiveEpilogue::SharedStorage;
+  union SharedStorage {
+    MainloopSharedStorage mainloop;
+    EpilogueSharedStorage epilogue;
+  };
+  static constexpr int SharedStorageSize = is_empty_v<SharedStorage> ? size_t(0) : sizeof(SharedStorage);
+
+  static constexpr bool is_split_kv = true;
+  // TODO: change the max_num_kv_split to `SGPerWG::value * intel::sg_size`
+  static constexpr int kvMaxSplits = 128;
+
+  // Accumulator element type for exp_sums/max_logits
+  using ElementAcc = float;
+
+  //
+  // KernelArguments
+  //
+  struct KernelArguments {
+    ProblemShape shape{};
+    // Q tensors
+    const ElementQ* Q_nope = nullptr;
+    StrideQ dQ_nope{};
+    const ElementQ* Q_pe = nullptr;
+    StrideQ dQ_pe{};
+
+    // K/V tensors (base pointer for paged KV cache)
+    const ElementK* K = nullptr;
+    StrideK dK{};
+    const ElementK* K_pe = nullptr;
+    StrideK dK_pe{};
+    const ElementV* V = nullptr;
+    StrideV dV{};
+
+    // Split-KV partial output
+    ElementO* O_accum = nullptr;  // (batch, num_heads, num_kv_splits, head_size_o)
+    StrideO dO_accum{};
+
+    // Softmax statistics
+    ElementAcc* exp_sums = nullptr;    // (batch, num_heads, num_kv_splits)
+    ElementAcc* max_logits = nullptr;  // (batch, num_heads, num_kv_splits)
+    StrideO dLSE{};
+
+    // Final output
+    ElementO* O = nullptr;
+    StrideO dO{};
+
+    // Sequence lengths per batch (for computing total_blk)
+    const int* seq_lens = nullptr;
+
+    KernelArguments() = default;
+  };
+
+  //
+  // KernelParams
+  //
+  using KernelParams = KernelArguments;
+
+  //
+  // Arguments
+  //
+  struct Arguments {
+    KernelArguments kernel{};
+    MainloopArguments mainloop{};
+    EpilogueArguments epilogue{};
+    KernelHardwareInfo hw_info{};
+    int split_kv = -1;
+  };
+
+  struct Params {
+    KernelParams kernel{};
+    MainloopParams mainloop{};
+    EpilogueParams epilogue{};
+    TileSchedulerParams scheduler{};
+  };
+
+  static Params to_underlying_arguments(Arguments const& args, void* workspace) {
+    return {
+        args.kernel,
+        CollectiveMainloop::to_underlying_arguments(args.mainloop, workspace),
+        CollectiveEpilogue::to_underlying_arguments(args.epilogue, workspace),
+        TileScheduler::to_underlying_arguments(args.kernel.shape, args.hw_info, TileShapeO{}, args.split_kv)};
+  }
+
+  static bool can_implement(Arguments const& args) {
+    return CollectiveMainloop::can_implement(args.mainloop) && CollectiveEpilogue::can_implement(args.epilogue);
+  }
+
+  static int get_workspace_size(Arguments const& args) {
+    int splits = args.split_kv;
+    if (splits <= 1) {
+      assert(false && "non Split-K workspace size is calculated in different path");
+    }
+    auto const& s = args.kernel.shape;
+    SplitKVWorkspaceLayout ws(s.batch, s.num_heads_q, splits, s.head_size_o, sizeof(ElementO));
+    return ws.total_bytes;
+  }
+
+  static cutlass::Status initialize_workspace(Arguments const& args, void* workspace) {
+    return Status::kSuccess;
+  }
+
+  static dim3 get_grid_shape(Params const& params) {
+    return TileScheduler::template get_grid_shape<SGPerWG::value>(params.scheduler);
+  }
+
+  static dim3 get_block_shape() {
+    return dim3(SGPerWG::value * intel::sg_size, 1, 1);
+  }
+
+  CUTLASS_DEVICE
+  void operator()(Params const& params, char* smem_buf) {
+    using namespace sycl::ext::oneapi::this_work_item;
+
+    SharedStorage& shared_storage = *reinterpret_cast<SharedStorage*>(smem_buf);
+
+    auto& p = params.kernel;
+    ProblemShape const& s = p.shape;
+    int num_kv_splits = params.scheduler.num_kv_splits_;
+
+    int thr_id = int(ThreadIdxX());
+
+    TileScheduler tile_scheduler{params.scheduler};
+
+    // LSE statistics: (seq_len_qo, num_kv_splits, num_heads_q, batch)
+    auto shape_lse = make_shape(s.seq_len_qo, num_kv_splits, s.num_heads_q, s.batch);
+    Tensor gExpSums = make_tensor(make_gmem_ptr(p.exp_sums), make_layout(shape_lse, p.dLSE));
+    Tensor gMaxLogits = make_tensor(make_gmem_ptr(p.max_logits), make_layout(shape_lse, p.dLSE));
+
+    CUTLASS_PRAGMA_NO_UNROLL
+    for (; tile_scheduler.is_valid(); ++tile_scheduler) {
+      auto [blk_q, blk_v, head_coord, batch_coord, idx_kv_split] = tile_scheduler.get_block_coord();
+      auto blk_qv = make_coord(blk_q, blk_v);
+
+      // Get actual kv sequence length for this batch
+      int seq_len_kv = p.seq_lens[batch_coord];
+      int total_blk = cute::ceil_div(seq_len_kv, get<1>(TileShapeQK{}));
+
+      // Compute this split's K-block range
+      int num_blocks_per_split = cute::ceil_div(total_blk, num_kv_splits);
+      int start_blk = idx_kv_split * num_blocks_per_split;
+      int end_blk = cute::min(start_blk + num_blocks_per_split, total_blk);
+
+      // Empty split: write zero-contribution sentinels and skip.
+      // exp_sums=0 gates any garbage in O_accum for this split.
+      // max_logits=lowest() ensures empty splits don't pollute global_max.
+      if (start_blk >= total_blk) {
+        if (thr_id == 0) {
+          gExpSums(0, idx_kv_split, head_coord, batch_coord) = ElementAcc(0);
+          gMaxLogits(0, idx_kv_split, head_coord, batch_coord) = std::numeric_limits<ElementAcc>::lowest();
+        }
+        continue;
+      }
+
+      auto shape_Q_nope = make_shape(s.seq_len_qo, s.head_size_q_nope, s.num_heads_q, s.batch);
+      auto shape_Q_pe = make_shape(s.seq_len_qo, s.head_size_q_pe, s.num_heads_q, s.batch);
+
+      auto dcQ_nope = const_cast<ElementQ*>(p.Q_nope);
+      auto dcQ_pe = const_cast<ElementQ*>(p.Q_pe);
+
+      Tensor Q_nope = make_tensor(make_gmem_ptr(dcQ_nope), make_layout(shape_Q_nope, p.dQ_nope));
+      Tensor Q_pe = make_tensor(make_gmem_ptr(dcQ_pe), make_layout(shape_Q_pe, p.dQ_pe));
+
+      // Initialize accumulators for this split (needed for non-first splits
+      // since the mainloop only initializes when blk_k0 == 0)
+      FragA tArA;
+      FragARow tA_max, tA_sum;
+      clear(tArA);
+      fill(tA_max, cutlass::platform::numeric_limits<typename FragARow::element_type>::lowest());
+      clear(tA_sum);
+
+      int page_size = params.mainloop.page_size;
+      auto shape_K = make_shape(page_size, s.head_size_kv, s.total_page, _1{});
+      auto shape_K_pe = make_shape(page_size, s.head_size_k_pe, s.total_page, _1{});
+      auto shape_V = make_shape(s.head_size_kv, page_size, s.total_page, _1{});
+
+      auto dcK = const_cast<ElementK*>(p.K);
+      auto dcK_pe = const_cast<ElementK*>(p.K_pe);
+
+      Tensor K = make_tensor(make_gmem_ptr(dcK), make_layout(shape_K, p.dK));
+      Tensor K_pe = make_tensor(make_gmem_ptr(dcK_pe), make_layout(shape_K_pe, p.dK_pe));
+      Tensor V = make_tensor(make_gmem_ptr(dcK), make_layout(shape_V, p.dV));
+
+      CollectiveMainloop mainloop(params.mainloop, shared_storage.mainloop);
+      mainloop(
+          Q_nope(_, _, head_coord, batch_coord),
+          Q_pe(_, _, head_coord, batch_coord),
+          K(_, _, _, _0{}),
+          K_pe(_, _, _, _0{}),
+          V(_, _, _, _0{}),
+          tArA,
+          tA_max,
+          tA_sum,
+          blk_qv,
+          start_blk,
+          end_blk,
+          total_blk,
+          thr_id,
+          seq_len_kv,
+          batch_coord);
+
+      if constexpr (!is_empty_v<MainloopSharedStorage> && !is_empty_v<EpilogueSharedStorage>) {
+        sycl::group_barrier(get_work_group<3>());
+      }
+
+      // Write partial O and LSE statistics via split-KV epilogue
+      auto shape_Oaccum = make_shape(s.seq_len_qo, s.head_size_o, s.num_heads_q * num_kv_splits, s.batch);
+      Tensor Oaccum = make_tensor(make_gmem_ptr(p.O_accum), make_layout(shape_Oaccum, p.dO_accum));
+      int head_split_coord = head_coord * num_kv_splits + idx_kv_split;
+
+      CollectiveEpilogue epilogue(params.epilogue, shared_storage.epilogue);
+      epilogue(
+          Oaccum(_, _, head_split_coord, batch_coord),
+          tArA,
+          tA_max,
+          tA_sum,
+          blk_qv,
+          thr_id,
+          gExpSums(0, idx_kv_split, head_coord, batch_coord),
+          gMaxLogits(0, idx_kv_split, head_coord, batch_coord),
+          num_kv_splits);
+    }
+  }
+};
+
 }  // namespace cutlass::flash_attention::kernel

--- a/src/sycl/kernels/mla/kernel/xe_mla_reduce_split_kv.hpp
+++ b/src/sycl/kernels/mla/kernel/xe_mla_reduce_split_kv.hpp
@@ -172,13 +172,14 @@ class XeMlaReduceSplitKV {
     TileScheduler tile_scheduler{params.scheduler};
     int num_kv_splits = params.scheduler.num_kv_splits;
 
+    auto seq_len_qo = s.seq_len_qo;
     auto num_heads_q = s.num_heads_q;
     auto head_size_o = s.head_size_o;
     auto batch = s.batch;
-    auto shape_O = make_shape(1, head_size_o, num_heads_q, batch);
-    auto shape_Oaccum = make_shape(1, head_size_o, num_heads_q * num_kv_splits, batch);
-    auto shape_exp_sums = make_shape(1, num_kv_splits, num_heads_q, batch);
-    auto shape_max_logits = make_shape(1, num_kv_splits, num_heads_q, batch);
+    auto shape_O = make_shape(seq_len_qo, head_size_o, num_heads_q, batch);
+    auto shape_Oaccum = make_shape(seq_len_qo, head_size_o, num_heads_q * num_kv_splits, batch);
+    auto shape_exp_sums = make_shape(seq_len_qo, num_kv_splits, num_heads_q, batch);
+    auto shape_max_logits = make_shape(seq_len_qo, num_kv_splits, num_heads_q, batch);
 
     Tensor O = make_tensor(make_gmem_ptr(p.O), make_layout(shape_O, p.dO));
     Tensor Oaccum = make_tensor(make_gmem_ptr(const_cast<ElementO*>(p.O_accum)), make_layout(shape_Oaccum, p.dO_accum));
@@ -197,11 +198,11 @@ class XeMlaReduceSplitKV {
       ElementLSE global_max{cutlass::platform::numeric_limits<ElementLSE>::lowest()};
 
       for (int s_idx = thr_id; s_idx < num_kv_splits; s_idx += WG_SIZE) {
-        ElementLSE cur_max_logit = max_logits(0, s_idx, head_q, idx_b);
+        ElementLSE cur_max_logit = max_logits(seq_idx, s_idx, head_q, idx_b);
         global_max = sycl::max(global_max, cur_max_logit);
         shared_storage.max_logits_slm[s_idx] = cur_max_logit;
 
-        shared_storage.exp_sums_slm[s_idx] = exp_sums(0, s_idx, head_q, idx_b);
+        shared_storage.exp_sums_slm[s_idx] = exp_sums(seq_idx, s_idx, head_q, idx_b);
       }
 
       // Barrier: ensure SLM writes are visible to all threads
@@ -225,7 +226,7 @@ class XeMlaReduceSplitKV {
           ElementLSE local_max = shared_storage.max_logits_slm[k];
           ElementLSE rescale = sycl::native::exp2(local_max - global_max);
 
-          ElementLSE o_val = static_cast<ElementLSE>(Oaccum(0, j, head_q * num_kv_splits + k, idx_b));
+          ElementLSE o_val = static_cast<ElementLSE>(Oaccum(seq_idx, j, head_q * num_kv_splits + k, idx_b));
 
           // O_accum is unnormalized (not divided by exp_sum in epilogue),
           // so multiply by rescale only
@@ -236,7 +237,7 @@ class XeMlaReduceSplitKV {
         ElementLSE inv_global_exp_sums = ElementLSE(1) / global_exp_sums;
         acc *= inv_global_exp_sums;
 
-        O(0, j, head_q, idx_b) = static_cast<ElementO>(acc);
+        O(seq_idx, j, head_q, idx_b) = static_cast<ElementO>(acc);
       }
     }
   }

--- a/src/sycl/kernels/mla/kernel/xe_mla_reduce_split_kv.hpp
+++ b/src/sycl/kernels/mla/kernel/xe_mla_reduce_split_kv.hpp
@@ -1,0 +1,232 @@
+/***************************************************************************************************
+ * Copyright (C) 2026 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+/*! \file
+    \brief MLA Split-KV Reduction Kernel
+*/
+#pragma once
+
+#include <cute/tensor.hpp>
+#include <limits>
+#include <sycl/sycl.hpp>
+
+#include "cutlass/cutlass.h"
+#include "cutlass/kernel_hardware_info.hpp"
+#include "sycl/kernels/mla/kernel/mla_tile_scheduler.hpp"
+
+namespace cutlass::flash_attention::kernel {
+
+using namespace cute;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+template <class ProblemShape_, class TileScheduler_, class MlaKernel_>
+class XeMlaReduceSplitKV {
+ public:
+  //
+  // Type Aliases
+  //
+  using ProblemShape = ProblemShape_;
+  using TileScheduler = TileScheduler_;
+  using TileSchedulerParams = typename TileScheduler::Params;
+
+  // Derive types from the main MLA split-KV kernel
+  using ElementO = typename MlaKernel_::ElementO;
+  using StrideO = typename MlaKernel_::StrideO;
+  using TileShapeO = typename MlaKernel_::TileShapeO;
+  using TileShapeQK = typename MlaKernel_::TileShapeQK;
+  using SGPerWG = typename MlaKernel_::SGPerWG;
+
+  using ElementLSE = float;  // exp_sums/max_logits accumulator type
+
+  // Number of output values processed by each thread
+  static constexpr int num_vals_per_thread = int(get<1>(TileShapeO{}) / (SGPerWG::value * intel::sg_size));
+
+  //
+  // KernelArguments
+  //
+  struct KernelArguments {
+    ProblemShape shape;
+    // Final output
+    ElementO* O = nullptr;
+    StrideO dO{};
+    // Partial outputs from split kernel
+    const ElementO* O_accum = nullptr;
+    StrideO dO_accum{};
+    // Softmax statistics per split
+    const ElementLSE* exp_sums = nullptr;
+    const ElementLSE* max_logits = nullptr;
+    StrideO dLSE{};
+  };
+  //
+  // KernelParams
+  //
+  using KernelParams = KernelArguments;
+
+  //
+  // Arguments
+  //
+  struct Arguments {
+    KernelArguments kernel{};
+    KernelHardwareInfo hw_info{};
+    int num_kv_splits = -1;
+  };
+
+  //
+  // Params
+  //
+  struct Params {
+    KernelParams kernel;
+    TileSchedulerParams scheduler;
+  };
+
+  struct SharedStorage {
+    cutlass::Array<ElementLSE, MlaKernel_::kvMaxSplits> max_logits_slm;
+    cutlass::Array<ElementLSE, MlaKernel_::kvMaxSplits> exp_sums_slm;
+  };
+  static constexpr int SharedStorageSize = sizeof(SharedStorage);
+
+ public:
+  static Params to_underlying_arguments(Arguments const& args, void* workspace) {
+    return {
+        args.kernel,
+        TileScheduler::to_underlying_arguments(args.kernel.shape, args.hw_info, TileShapeO{}, args.num_kv_splits)};
+  }
+
+  static bool can_implement(Arguments const& args) {
+    if (args.kernel.shape.batch <= 0) return false;
+    if (args.num_kv_splits <= 1) return false;
+    if (args.num_kv_splits > MlaKernel_::kvMaxSplits) return false;
+    return true;
+  }
+
+  static int get_workspace_size(Arguments const& /*args*/) {
+    return 0;
+  }
+
+  static cutlass::Status initialize_workspace(Arguments const& /*args*/, void* /*workspace*/ = nullptr) {
+    return Status::kSuccess;
+  }
+
+  static dim3 get_grid_shape(Params const& params) {
+    return TileScheduler::template get_grid_shape<SGPerWG::value>(params.scheduler);
+  }
+
+  static dim3 get_block_shape() {
+    return dim3(SGPerWG::value * intel::sg_size, 1, 1);
+  }
+
+  CUTLASS_DEVICE
+  void operator()(Params const& params, char* smem_buf) {
+    using namespace sycl::ext::oneapi::this_work_item;
+
+    SharedStorage& shared_storage = *reinterpret_cast<SharedStorage*>(smem_buf);
+
+    auto& p = params.kernel;
+    ProblemShape const& s = p.shape;
+
+    int thr_id = int(ThreadIdxX());
+    constexpr int WG_SIZE = SGPerWG::value * intel::sg_size;
+
+    TileScheduler tile_scheduler{params.scheduler};
+    int num_kv_splits = params.scheduler.num_kv_splits;
+
+    auto num_heads_q = s.num_heads_q;
+    auto head_size_o = s.head_size_o;
+    auto batch = s.batch;
+    auto shape_O = make_shape(1, head_size_o, num_heads_q, batch);
+    auto shape_Oaccum = make_shape(1, head_size_o, num_heads_q * num_kv_splits, batch);
+    auto shape_exp_sums = make_shape(1, num_kv_splits, num_heads_q, batch);
+    auto shape_max_logits = make_shape(1, num_kv_splits, num_heads_q, batch);
+
+    Tensor O = make_tensor(make_gmem_ptr(p.O), make_layout(shape_O, p.dO));
+    Tensor Oaccum = make_tensor(make_gmem_ptr(const_cast<ElementO*>(p.O_accum)), make_layout(shape_Oaccum, p.dO_accum));
+    Tensor exp_sums =
+        make_tensor(make_gmem_ptr(const_cast<ElementLSE*>(p.exp_sums)), make_layout(shape_exp_sums, p.dLSE));
+    Tensor max_logits =
+        make_tensor(make_gmem_ptr(const_cast<ElementLSE*>(p.max_logits)), make_layout(shape_max_logits, p.dLSE));
+
+    CUTLASS_PRAGMA_NO_UNROLL
+    for (; tile_scheduler.is_valid(); ++tile_scheduler) {
+      auto [seq_idx, head_q, idx_b] = tile_scheduler.get_block_coord();
+
+      // Step 1: Load per-split statistics into SLM.
+      // Strided loop handles num_kv_splits > WG_SIZE.
+      // Each thread also tracks the max of its assigned splits for group reduction.
+      ElementLSE global_max{cutlass::platform::numeric_limits<ElementLSE>::lowest()};
+
+      for (int s_idx = thr_id; s_idx < num_kv_splits; s_idx += WG_SIZE) {
+        ElementLSE cur_max_logit = max_logits(0, s_idx, head_q, idx_b);
+        global_max = sycl::max(global_max, cur_max_logit);
+        shared_storage.max_logits_slm[s_idx] = cur_max_logit;
+
+        shared_storage.exp_sums_slm[s_idx] = exp_sums(0, s_idx, head_q, idx_b);
+      }
+
+      // Barrier: ensure SLM writes are visible to all threads
+      sycl::group_barrier(get_work_group<3>());
+
+      // Step 2: Find global max across all splits via HW group reduction
+      global_max = reduce_over_group(get_work_group<1>(), global_max, sycl::maximum<>());
+      global_max = sycl::group_broadcast(get_work_group<1>(), global_max, 0);
+
+      // Step 3: Cooperatively reduce output elements
+      // O_accum is unnormalized (numerator only),
+      // so acc += O_accum * rescale, and global_exp_sums += exp_sum * rescale.
+      for (int j = thr_id; j < head_size_o; j += WG_SIZE) {
+        ElementLSE acc = ElementLSE(0);
+        ElementLSE global_exp_sums = ElementLSE(0);
+        for (int k = 0; k < num_kv_splits; k++) {
+          ElementLSE local_exp_sum = shared_storage.exp_sums_slm[k];
+          // Skip empty splits (exp_sums=0, max_logits=-inf sentinel)
+          if (local_exp_sum <= ElementLSE(0)) continue;
+
+          ElementLSE local_max = shared_storage.max_logits_slm[k];
+          ElementLSE rescale = sycl::native::exp2(local_max - global_max);
+
+          ElementLSE o_val = static_cast<ElementLSE>(Oaccum(0, j, head_q * num_kv_splits + k, idx_b));
+
+          // O_accum is unnormalized (not divided by exp_sum in epilogue),
+          // so multiply by rescale only
+          acc += o_val * rescale;
+          global_exp_sums += local_exp_sum * rescale;
+        }
+
+        ElementLSE inv_global_exp_sums = ElementLSE(1) / global_exp_sums;
+        acc *= inv_global_exp_sums;
+
+        O(0, j, head_q, idx_b) = static_cast<ElementO>(acc);
+      }
+    }
+  }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace cutlass::flash_attention::kernel

--- a/src/sycl/kernels/mla/kernel/xe_mla_reduce_split_kv.hpp
+++ b/src/sycl/kernels/mla/kernel/xe_mla_reduce_split_kv.hpp
@@ -46,6 +46,21 @@ namespace cutlass::flash_attention::kernel {
 using namespace cute;
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
+struct DummyReductionKernel {
+  struct Arguments {};
+  struct Params {};
+  static bool can_implement(Arguments const&) {
+    return true;
+  }
+  static int get_workspace_size(Arguments const&) {
+    return 0;
+  }
+  static Params to_underlying_arguments(Arguments const&, void*) {
+    return {};
+  }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
 template <class ProblemShape_, class TileScheduler_, class MlaKernel_>
 class XeMlaReduceSplitKV {
  public:

--- a/src/sycl/mla_decode.cpp
+++ b/src/sycl/mla_decode.cpp
@@ -46,6 +46,44 @@
 
 namespace {
 
+/// Compute optimal split-KV count based on page_size and base parallelism.
+///
+/// Derived from exhaustive tests on BMG :
+///   - batch_size: 1, 4, 16
+///   - seq_len: 1024, 2048, 4096, 8192
+///   - num_heads: 16, 32, 64, 128
+///   - page_size: 16, 32, 64, 128
+///   - num_kv_splits: 1, 2, 4, 8, 10, 16, 20, 24, 30, 36, 48, 64
+/// TODO: find a same optimal kv_split formula (ref:src/sycl/flash_attention.cpp[get_num_splits]), when entire mla is
+/// optimized.
+int64_t set_split_kv(int64_t batch, int64_t num_heads_q, int64_t seq_len_kv, int64_t page_size) {
+  int base_parallel = batch * num_heads_q;
+  int total_pages = (seq_len_kv + page_size - 1) / page_size;
+
+  int kv_per_split;
+  if (page_size <= 16) {
+    kv_per_split = (base_parallel <= 64) ? 256 : 128;
+  } else if (page_size <= 32) {
+    kv_per_split = (base_parallel <= 64) ? 192 : 64;
+  } else if (page_size <= 64) {
+    kv_per_split = (base_parallel <= 64) ? 128 : 64;
+  } else {
+    kv_per_split = page_size;
+  }
+
+  int pages_per_split = std::max(1, kv_per_split / static_cast<int>(page_size));
+  int num_splits = std::max(1, total_pages / pages_per_split);
+  num_splits = std::min(num_splits, total_pages);
+
+  if (batch == 1 && num_heads_q > total_pages) {
+    int ratio = static_cast<int>(num_heads_q) / total_pages;
+    int capped_splits = std::max(2, num_splits / ratio);
+    num_splits = std::min(num_splits, capped_splits);
+  }
+
+  return std::max(1, num_splits);
+}
+
 #define DISPATCH_MLA_PAGE_SIZE(ELEM)                                                                           \
   do {                                                                                                         \
     switch (page_size) {                                                                                       \
@@ -110,7 +148,6 @@ void flash_mla_decode(
 
   auto in_dtype = q_nope.scalar_type();
 
-  TORCH_CHECK(num_kv_splits <= 1, "Manual KV splits are not supported yet.");
   TORCH_CHECK(
       in_dtype == at::ScalarType::Half || in_dtype == at::ScalarType::BFloat16,
       "Unsupported input data type for MLA decode");
@@ -120,22 +157,72 @@ void flash_mla_decode(
       page_size,
       ". Supported: 16, 32, 64, 128");
 
+  if (num_kv_splits < 1) {
+    int page_count_per_seq = page_table.size(1);
+    int max_seq_len = page_size * page_count_per_seq;
+    num_kv_splits = set_split_kv(q_nope.size(0), q_nope.size(1), max_seq_len, page_size);
+  }
+
   DISPATCH_MLA_DTYPE();
 }
 
 #undef DISPATCH_MLA_PAGE_SIZE
 #undef DISPATCH_MLA_DTYPE
 
-int64_t
-flash_mla_get_workspace_size(int64_t max_seq_len, int64_t num_batches, int64_t sm_count, int64_t num_kv_splits) {
-  // Workspace size depends on ElementAcc and ElementLSE (same as ElementAcc)
-  // which are float, so Element type here doesn't matter.
-  using MlaXeType = MlaXe<sycl::half>;
-  typename MlaXeType::Fmla::Arguments arguments;
-  //
-  // TODO: support manual kv splits
-  //
-  return MlaXeType::Fmla::get_workspace_size(arguments);
+namespace {
+template <typename MlaXeType>
+int64_t mla_workspace_size(int64_t num_batches, int64_t num_heads, int64_t num_kv_splits) {
+  typename MlaXeType::Fmla::Arguments args{};
+  args.kernel.shape.batch = num_batches;
+  args.kernel.shape.num_heads_q = num_heads;
+  args.kernel.shape.head_size_o = 512;
+  args.split_kv = num_kv_splits;
+  return MlaXeType::Fmla::get_workspace_size(args);
+}
+}  // namespace
+
+int64_t flash_mla_get_workspace_size(
+    int64_t max_seq_len, int64_t num_batches, int64_t num_heads, int64_t page_size, int64_t num_kv_splits) {
+  if (num_kv_splits < 1) {
+    num_kv_splits = set_split_kv(num_batches, num_heads, max_seq_len, page_size);
+  }
+  if (num_kv_splits == 1) {
+    switch (page_size) {
+      case 16:
+        return mla_workspace_size<MlaXe<cutlass::half_t, PageSizeOption<16>, EnabledSplitKV<false>>>(
+            num_batches, num_heads, num_kv_splits);
+      case 32:
+        return mla_workspace_size<MlaXe<cutlass::half_t, PageSizeOption<32>, EnabledSplitKV<false>>>(
+            num_batches, num_heads, num_kv_splits);
+      case 64:
+        return mla_workspace_size<MlaXe<cutlass::half_t, PageSizeOption<64>, EnabledSplitKV<false>>>(
+            num_batches, num_heads, num_kv_splits);
+      case 128:
+        return mla_workspace_size<MlaXe<cutlass::half_t, PageSizeOption<128>, EnabledSplitKV<false>>>(
+            num_batches, num_heads, num_kv_splits);
+      default:
+        TORCH_CHECK(false, "Unsupported page size: ", page_size);
+        return 0;
+    }
+  } else {
+    switch (page_size) {
+      case 16:
+        return mla_workspace_size<MlaXe<cutlass::half_t, PageSizeOption<16>, EnabledSplitKV<true>>>(
+            num_batches, num_heads, num_kv_splits);
+      case 32:
+        return mla_workspace_size<MlaXe<cutlass::half_t, PageSizeOption<32>, EnabledSplitKV<true>>>(
+            num_batches, num_heads, num_kv_splits);
+      case 64:
+        return mla_workspace_size<MlaXe<cutlass::half_t, PageSizeOption<64>, EnabledSplitKV<true>>>(
+            num_batches, num_heads, num_kv_splits);
+      case 128:
+        return mla_workspace_size<MlaXe<cutlass::half_t, PageSizeOption<128>, EnabledSplitKV<true>>>(
+            num_batches, num_heads, num_kv_splits);
+      default:
+        TORCH_CHECK(false, "Unsupported page size: ", page_size);
+        return 0;
+    }
+  }
 }
 
 #undef SYCL_INTEL_TARGET

--- a/src/sycl/mla_decode.cpp
+++ b/src/sycl/mla_decode.cpp
@@ -184,26 +184,15 @@ int64_t mla_workspace_size(int64_t num_batches, int64_t num_heads, int64_t num_k
 int64_t flash_mla_get_workspace_size(
     int64_t max_seq_len, int64_t num_batches, int64_t num_heads, int64_t page_size, int64_t num_kv_splits) {
   if (num_kv_splits < 1) {
+    TORCH_CHECK(num_heads > 0, "num_heads must be > 0 when num_kv_splits is auto-selected");
+    TORCH_CHECK(
+        page_size == 16 || page_size == 32 || page_size == 64 || page_size == 128,
+        "Unsupported page size: ",
+        page_size);
     num_kv_splits = set_split_kv(num_batches, num_heads, max_seq_len, page_size);
   }
   if (num_kv_splits == 1) {
-    switch (page_size) {
-      case 16:
-        return mla_workspace_size<MlaXe<cutlass::half_t, PageSizeOption<16>, EnabledSplitKV<false>>>(
-            num_batches, num_heads, num_kv_splits);
-      case 32:
-        return mla_workspace_size<MlaXe<cutlass::half_t, PageSizeOption<32>, EnabledSplitKV<false>>>(
-            num_batches, num_heads, num_kv_splits);
-      case 64:
-        return mla_workspace_size<MlaXe<cutlass::half_t, PageSizeOption<64>, EnabledSplitKV<false>>>(
-            num_batches, num_heads, num_kv_splits);
-      case 128:
-        return mla_workspace_size<MlaXe<cutlass::half_t, PageSizeOption<128>, EnabledSplitKV<false>>>(
-            num_batches, num_heads, num_kv_splits);
-      default:
-        TORCH_CHECK(false, "Unsupported page size: ", page_size);
-        return 0;
-    }
+    return 0;
   } else {
     switch (page_size) {
       case 16:

--- a/src/sycl/mla_decode.cpp
+++ b/src/sycl/mla_decode.cpp
@@ -50,15 +50,15 @@ namespace {
 ///
 /// Derived from exhaustive tests on BMG :
 ///   - batch_size: 1, 4, 16
-///   - seq_len: 1024, 2048, 4096, 8192
+///   - seq_len: 1024, 2048, 4096, 8192, 16384, 32768
 ///   - num_heads: 16, 32, 64, 128
 ///   - page_size: 16, 32, 64, 128
-///   - num_kv_splits: 1, 2, 4, 8, 10, 16, 20, 24, 30, 36, 48, 64
+///   - num_kv_splits: 1, 2, 4, 8, 16, 32, 48, 64, 96, 128
 /// TODO: find a same optimal kv_split formula (ref:src/sycl/flash_attention.cpp[get_num_splits]), when entire mla is
 /// optimized.
 int64_t set_split_kv(int64_t batch, int64_t num_heads_q, int64_t seq_len_kv, int64_t page_size) {
-  int base_parallel = batch * num_heads_q;
-  int total_pages = (seq_len_kv + page_size - 1) / page_size;
+  int base_parallel = static_cast<int>(batch * num_heads_q);
+  int total_pages = (static_cast<int>(seq_len_kv) + static_cast<int>(page_size) - 1) / static_cast<int>(page_size);
 
   int kv_per_split;
   if (page_size <= 16) {
@@ -68,20 +68,27 @@ int64_t set_split_kv(int64_t batch, int64_t num_heads_q, int64_t seq_len_kv, int
   } else if (page_size <= 64) {
     kv_per_split = (base_parallel <= 64) ? 128 : 64;
   } else {
-    kv_per_split = page_size;
+    kv_per_split = static_cast<int>(page_size);
   }
 
   int pages_per_split = std::max(1, kv_per_split / static_cast<int>(page_size));
   int num_splits = std::max(1, total_pages / pages_per_split);
   num_splits = std::min(num_splits, total_pages);
 
-  if (batch == 1 && num_heads_q > total_pages) {
-    int ratio = static_cast<int>(num_heads_q) / total_pages;
-    int capped_splits = std::max(2, num_splits / ratio);
-    num_splits = std::min(num_splits, capped_splits);
+  // For long sequences with small page sizes, the base heuristic over-splits
+  // because kv_per_split was tuned for seq_len <= 8K. Each split needs enough
+  // KV work to amortize the split-KV reduction overhead.
+  if (seq_len_kv > 8192) {
+    if (page_size <= 16) {
+      int min_pages = (base_parallel <= 32) ? 64 : 16;
+      num_splits = std::min(num_splits, std::max(1, total_pages / min_pages));
+    }
+    if (page_size <= 32 && base_parallel <= 32) {
+      num_splits = std::min(num_splits, std::max(1, total_pages / 32));
+    }
   }
 
-  return std::max(1, num_splits);
+  return std::clamp(num_splits, 1, 128);
 }
 
 #define DISPATCH_MLA_PAGE_SIZE(ELEM)                                                                           \

--- a/tests/test_flash_mla_decode.py
+++ b/tests/test_flash_mla_decode.py
@@ -121,7 +121,7 @@ def test_flash_mla_decode(
     del q_cpu, kv_cache_cpu, block_table_cpu, seq_lens_cpu
 
     workspace_size = flash_mla_get_workspace_size(
-        block_num * block_size, bs, num_kv_splits=num_kv_splits
+        block_num * block_size, bs, h_q, block_size, num_kv_splits=num_kv_splits
     )
     workspace = torch.empty(workspace_size, device=device, dtype=torch.uint8)
 

--- a/tests/test_flash_mla_decode.py
+++ b/tests/test_flash_mla_decode.py
@@ -64,7 +64,6 @@ def ref_mla(
 # TODO: enable block_size 1
 @pytest.mark.parametrize("block_size", [16, 32, 64, 128])
 @pytest.mark.parametrize("num_heads", [16, 32, 64, 128])
-# TODO: enable num_kv_splits >1
 @pytest.mark.parametrize("num_kv_splits", [-1, 1])
 def test_flash_mla_decode(
     dtype: torch.dtype,

--- a/tests/test_flash_mla_decode.py
+++ b/tests/test_flash_mla_decode.py
@@ -1,4 +1,5 @@
 import gc
+import os
 import sys
 
 import pytest
@@ -7,6 +8,7 @@ import torch.nn.functional as F
 from sgl_kernel import flash_mla_decode, flash_mla_get_workspace_size
 from torch import Tensor
 
+LONG_TESTS = os.getenv("LONG_TESTS") == "1"
 device = torch.device("xpu")
 
 if not torch.xpu.is_available():
@@ -45,20 +47,22 @@ def ref_mla(
     head_dim = query.shape[2]
 
     for i in range(bs):
-        # gather and flatten KV-cache
         kv = kv_cache[block_tables[i]]  # (max_num_blocks, block_size, head_dim)
         kv = kv.view(1, -1, head_dim)[:, : seq_lens[i]]  # (1, seq_len, head_dim)
         v = kv[:, :, :v_head_dim]
 
-        q = query[i].view(num_heads, 1, head_dim)
-        o = F.scaled_dot_product_attention(q, kv, v, scale=scale, enable_gqa=True)
-        out[i] = o.view(num_heads, v_head_dim)
+        for h in range(num_heads):
+            q_h = query[i, h : h + 1, :].unsqueeze(0)  # (1, 1, head_dim)
+            o_h = F.scaled_dot_product_attention(q_h, kv, v, scale=scale)
+            out[i, h] = o_h.view(v_head_dim)
 
     return out
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("mean_seq_len", [128, 1024, 4096])
+@pytest.mark.parametrize(
+    "mean_seq_len", [128, 1024, 4096] + ([8192, 16384, 32768] if LONG_TESTS else [])
+)
 @pytest.mark.parametrize("bs", [1, 2, 4])
 @pytest.mark.parametrize("varlen", [True, False])
 # TODO: enable block_size 1
@@ -110,7 +114,6 @@ def test_flash_mla_decode(
     # --- Reference: run on CPU ---
     out_ref = torch.zeros(bs, h_q, dv, dtype=dtype, device="cpu")
     ref_mla(out_ref, q_cpu, kv_cache_cpu, scale, block_table_cpu, seq_lens_cpu)
-    # out_ref = out_ref.to(device=device)
 
     # --- Kernel under test: run on XPU ---
     q_xpu = q_cpu.to(device=device)


### PR DESCRIPTION
This pull request adds split-KV parallelism to the existing MLA (Multi-head Latent Attention) decode kernel on Intel XPU (BMG). Instead of processing the entire KV sequence in a single workgroup per (batch, head) pair, the KV dimension is partitioned across multiple workgroups that compute partial attention independently, followed by a lightweight reduction kernel that merges the partials using log-sum-exp rescaling.

This is a standard technique that converts the memory-bound decode into a latency-bound problem by increasing GPU occupancy on long sequences.

# Algorithm Overview
The split-KV extension adds two new components on top of the existing mainloop:

**Split Kernel (XeMlaSplitKVKernel):** Each split s processes a contiguous range of KV blocks [start_s, end_s) and produces:
unnormalized partial output, partition function for this split, local maximum
**Reduction Kernel (XeMlaReduceSplitKV)**: Merges S partial outputs into normalized final output:
For num_kv_splits == 1, the existing non-split path executes with zero overhead (no workspace, no reduction kernel).

# Architecture Components
Component | File | Purpose
-- | -- | --
Split-KV Kernel | kernel/xe_mla_kernel.hpp | Partitions KV blocks, stores unnormalized partials + LSE stats
Reduction Kernel | kernel/xe_mla_reduce_split_kv.hpp | New. Merges partials via log-sum-exp rescaling
Tile Scheduler | kernel/mla_tile_scheduler.hpp | Extended with kv_split dim in grid z-axis; new reduction scheduler
Split-KV Epilogue | collective/xe_mla_epilogue.hpp | New overload: stores unnormalized O_accum + exp_sum/max_logit
Workspace Layout | kernel/xe_mla_kernel.hpp | SplitKVWorkspaceLayout — single source of truth for offset math
Device Runner | device/mla_runner.hpp | Conditional reduction kernel instantiation + dual launch
Type Config & Dispatch | device/mla_decode_types.hpp | Compile-time EnabledSplitKV<bool> dispatch, workspace assertion
PyTorch Interface | mla_decode.cpp | set_split_kv heuristic, updated flash_mla_get_workspace_size API

# Key Design Decisions
**Compile-time split dispatch** via `EnabledSplitKV<true/false>` — the non-split path has zero overhead
**Unnormalized partial O** — the split epilogue writes raw numerator without dividing by exp_sum; the reduction kernel performs cross-split normalization
**Split-KV Heuristic** (set_split_kv)
Auto-tunes num_kv_splits based on exhaustive BMG benchmarking across batch_size × seq_len × num_heads × page_size. 

# API Changes
flash_mla_get_workspace_size now requires num_heads and page_size parameters to correctly size the workspace for the auto-tuned split count:
### Before
`workspace_size = flash_mla_get_workspace_size(max_seq_len, batch_size, num_kv_splits=-1)`
### After
`workspace_size = flash_mla_get_workspace_size(max_seq_len, batch_size, num_heads, page_size, num_kv_splits=-1)`

# Performance Benchmarks (BMG)
<img width="4784" height="2981" alt="flash_mla_current_vs_previous" src="https://github.com/user-attachments/assets/c70a0f3f-7965-48f0-a44f-e5ffc1aaf28a" />

**Summary:** 1.1x–2x bandwidth improvement across configurations