### PR TITLE
DSV4 MoE: add MXFP4 W4A16 support with staged weight dequantization

### DIFF
--- a/python/sgl_kernel/moe.py
+++ b/python/sgl_kernel/moe.py
@@ -4,10 +4,15 @@ import torch
 
 from .utils import is_xe2_arch
 
-# Lookup table for MXFP4 E2M1 dequantization: maps 3-bit magnitude codes to float values.
-# Index i corresponds to code i in {0,0.5,1.0,1.5,2.0,3.0,4.0,6.0}.
-_MXFP4_E2M1_TO_FLOAT = torch.tensor(
-    [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32
+# E2M1 lookup table: nibble value 0x0–0xF → float.
+# Encodes sign directly: 0b0xxx = positive, 0b1xxx = negative.
+# high nibble = second element; see _upcast_mxfp4_one_xpu in sglang).
+_MXFP4_E2M1_LUT = torch.tensor(
+    [
+        0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,        # 0b0xxx (positive)
+        0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,  # 0b1xxx (negative)
+    ],
+    dtype=torch.float32,
 )
 
 
@@ -257,10 +262,8 @@ def dequantize_mxfp4_weights(
     block_size: int = 32,
 ) -> torch.Tensor:
     """Dequantize MXFP4 (E2M1) packed expert weight tensor to BF16 (or other dtype).
-
-    MXFP4 uses the OCP MX format: 4-bit E2M1 data packed two-per-byte (low
-    nibble first), with one UE8M0 (uint8) block scale per ``block_size``
-    elements along the last dimension.
+        byte = (first_elem & 0xF) | (second_elem << 4)
+    i.e. low nibble = first element, high nibble = second element.
 
     Parameters:
     - packed:     [E, rows, packed_cols] uint8 – two FP4 nibbles per byte,
@@ -279,32 +282,25 @@ def dequantize_mxfp4_weights(
     cols = packed_cols * 2
     num_blocks = cols // block_size
 
-    # --- 1. Unpack two FP4 nibbles per byte (low nibble = element 0) ---
-    lo = packed & 0x0F  # [E, rows, packed_cols]
-    hi = (packed >> 4) & 0x0F  # [E, rows, packed_cols]
-    # Interleave lo/hi pairs → [E, rows, cols]
-    unpacked = torch.stack([lo, hi], dim=-1).reshape(E, rows, cols)
+    # --- 1. Unpack and dequantize via 16-entry signed LUT ---
+    # Low nibble = first element (even K position), high nibble = second element
+    lut = _MXFP4_E2M1_LUT.to(device=packed.device, dtype=torch.bfloat16)
+    lo = (packed & 0x0F).long()           # [E, rows, packed_cols]
+    hi = (packed >> 4).long()             # [E, rows, packed_cols]
+    # Interleave: [lo, hi] per packed position → [E, rows, cols]
+    paired = torch.stack([lut[lo], lut[hi]], dim=-1)  # [E, rows, packed_cols, 2]
+    dequantized = paired.reshape(E, rows, cols)
 
-    # --- 2. Dequantize E2M1 codes via lookup table ---
-    # E2M1 layout: bit 3 = sign, bits 2-0 = magnitude index
-    lut = _MXFP4_E2M1_TO_FLOAT.to(device=packed.device)
-    sign = ((unpacked >> 3) & 1).to(torch.bool)
-    magnitude_idx = (unpacked & 0x07).to(torch.long)
-    magnitude = lut[magnitude_idx]  # [E, rows, cols], float32
-    dequantized = torch.where(sign, -magnitude, magnitude)
-
-    # --- 3. Apply per-block UE8M0 scale factors ---
-    # Reshape into blocks: [E, rows, num_blocks, block_size]
-    dequantized_blocks = dequantized.reshape(E, rows, num_blocks, block_size)
-
-    # Decode UE8M0: float_scale = 2^(stored_byte - 127)
+    # --- 2. Apply per-block UE8M0 scale factors ---
+    dequantized = dequantized.reshape(E, rows, num_blocks, block_size)
     scale_exp = scales.to(torch.int32) - 127  # [E, rows, num_blocks]
-    # unsqueeze for broadcast over block_size dim
-    scale_values = torch.pow(2.0, scale_exp.float()).unsqueeze(-1)
+    scale_values = torch.exp2(scale_exp.float()).unsqueeze(-1).to(torch.bfloat16)
+    dequantized = dequantized * scale_values
 
-    scaled = dequantized_blocks * scale_values  # [E, rows, num_blocks, block_size]
-
-    return scaled.reshape(E, rows, cols).to(dtype)
+    result = dequantized.reshape(E, rows, cols)
+    if dtype != torch.bfloat16:
+        result = result.to(dtype)
+    return result
 
 
 def fused_experts(
@@ -403,8 +399,8 @@ def fused_experts(
         assert w1_scale.dtype == torch.uint8, "w1_scale must be uint8 (UE8M0 format)"
         assert w2_scale.dtype == torch.uint8, "w2_scale must be uint8 (UE8M0 format)"
     else:
-        assert w1_scale is None, "current MoE does not support w1_scale"
-        assert w2_scale is None, "current MoE does not support w2_scale"
+        assert w1_scale is None, "w1_scale is only supported when use_mxfp4_w4a16=True"
+        assert w2_scale is None, "w2_scale is only supported when use_mxfp4_w4a16=True"
 
     # type check
     assert hidden_states.dtype == torch.bfloat16, "hidden_states must be bfloat16"

--- a/python/sgl_kernel/moe.py
+++ b/python/sgl_kernel/moe.py
@@ -445,7 +445,7 @@ def fused_experts(
         # w1/w2 last dims are packed (H//2, I//2); recover actual dims
         K = K * 2
         N = N * 2
-    assert N * 2 == w1.shape[1], "w1 shape[1] must be 2x of w2 shape[2]"
+
     if b1 is not None:
         assert b1.shape == w1.shape[:2], "b1 shape must match w1 shape[:2]"
     if b2 is not None:
@@ -522,10 +522,6 @@ def fused_experts(
     avg_m = (M * TopK) // E
     big_weight = K * N > 4096 * 4096
     use_unfused_act = avg_m <= 128 and big_weight
-    # ---- GEMM1: dequantize w1 just before use, free immediately after ----
-    if use_mxfp4_w4a16:
-        w1 = dequantize_mxfp4_weights(w1, w1_scale)
-
     if use_unfused_act:
         intermediate_cache1 = torch.empty(
             (M * TopK, 2 * N), device=hidden_states.device, dtype=hidden_states.dtype
@@ -533,6 +529,9 @@ def fused_experts(
         intermediate_cache2 = torch.empty(
             (M * TopK, N), device=hidden_states.device, dtype=hidden_states.dtype
         )
+        # Dequantize w1 just before GEMM1, free immediately after
+        if use_mxfp4_w4a16:
+            w1 = dequantize_mxfp4_weights(w1, w1_scale)
         torch.ops.sgl_kernel.moe_grouped_mm_nt_xe20(
             intermediate_cache1,
             input_A_shuffle,
@@ -575,10 +574,14 @@ def fused_experts(
         )
         if use_mxfp4_w4a16:
             del w2
+            torch.xpu.empty_cache()
     else:
         intermediate_cache1 = torch.empty(
             (M * TopK, N), device=hidden_states.device, dtype=hidden_states.dtype
         )
+        # Dequantize w1 just before GEMM1, free immediately after
+        if use_mxfp4_w4a16:
+            w1 = dequantize_mxfp4_weights(w1, w1_scale)
         torch.ops.sgl_kernel.moe_grouped_mm_nt_xe20(
             intermediate_cache1,
             input_A_shuffle,
@@ -611,6 +614,7 @@ def fused_experts(
         )
         if use_mxfp4_w4a16:
             del w2
+            torch.xpu.empty_cache()
 
     rsf = 1.0
 

--- a/python/sgl_kernel/moe.py
+++ b/python/sgl_kernel/moe.py
@@ -32,6 +32,10 @@ _MXFP4_E2M1_LUT_CPU = torch.tensor(
 # Cache of device-resident LUTs to avoid re-copying on every call.
 _MXFP4_E2M1_LUT_CACHE: Dict[torch.device, torch.Tensor] = {}
 
+# Number of experts to dequantize per iteration. Bounds the int64 index tensor
+# materialized by advanced indexing during gather — prevents OOM on large E.
+_MXFP4_DEQUANT_EXPERT_CHUNK = 4
+
 
 def _get_e2m1_lut(device: torch.device) -> torch.Tensor:
     """Return a device-resident BF16 E2M1 lookup table, cached after first use."""
@@ -298,7 +302,7 @@ def dequantize_mxfp4_weights(
                   multiplier), matching upstream sglang
                   ``_upcast_mxfp4_one_xpu``'s contract. Callers holding raw
                   UE8M0 bytes must decode to fp32 first via
-                  ``torch.exp2((byte.to(int32) - 127).to(float32))``, where
+                  ``_ue8m0_to_fp32_multiplier``, where
                   num_blocks = cols // block_size.
     - dtype:      Output floating-point dtype (default: torch.bfloat16).
     - block_size: Number of FP4 elements sharing one scale factor (default: 32).
@@ -325,28 +329,42 @@ def dequantize_mxfp4_weights(
     ), f"packed and scales must be on the same device, got {packed.device} and {scales.device}"
     assert scales.dtype == torch.float32, (
         f"scales must be float32 direct multiplier (matches upstream "
-        f"_upcast_mxfp4_one_xpu contract); decode UE8M0 bytes first if needed. "
-        f"got {scales.dtype}"
+        f"_upcast_mxfp4_one_xpu contract); decode UE8M0 bytes first via "
+        f"_ue8m0_to_fp32_multiplier. got {scales.dtype}"
     )
 
-    # --- 1. Unpack and dequantize via 16-entry signed LUT ---
     lut = _get_e2m1_lut(packed.device)
+    out = torch.empty(E, rows, cols, dtype=torch.bfloat16, device=packed.device)
 
-    # Allocate output directly and fill even/odd positions to avoid
-    # torch.stack + reshape intermediaries.
-    dequantized = torch.empty(E, rows, cols, dtype=torch.bfloat16, device=packed.device)
-    dequantized[:, :, 0::2] = lut[(packed & 0x0F).int()]
-    dequantized[:, :, 1::2] = lut[(packed >> 4).int()]
+    # Cast fp32 multiplier to bf16 once up-front; reused per chunk.
+    scale_mul = scales.to(torch.bfloat16)
 
-    # --- 2. Apply per-block direct-multiplier scale factors ---
-    dequantized = dequantized.view(E, rows, num_blocks, block_size)
-    scale_values = scales.unsqueeze(-1).to(torch.bfloat16)
-    dequantized = dequantized * scale_values
+    # Chunk over experts: a flat 1-D gather is faster on Intel L0 than an
+    # N-D advanced-index gather, and chunking bounds the int64 index tensor
+    # materialized by index_select so it doesn't blow peak memory on large E.
+    CHUNK = _MXFP4_DEQUANT_EXPERT_CHUNK
+    for start in range(0, E, CHUNK):
+        end = min(start + CHUNK, E)
+        chunk = packed[start:end]  # [C, rows, packed_cols]
 
-    result = dequantized.reshape(E, rows, cols)
+        lo_idx = (chunk & 0x0F).reshape(-1).to(torch.long)
+        hi_idx = (chunk >> 4).reshape(-1).to(torch.long)
+        lo_vals = lut.index_select(0, lo_idx).view(end - start, rows, packed_cols)
+        hi_vals = lut.index_select(0, hi_idx).view(end - start, rows, packed_cols)
+
+        # Strided writes avoid an extra [C, rows, packed_cols, 2] stack + reshape.
+        out_chunk = out[start:end]
+        out_chunk[:, :, 0::2] = lo_vals
+        out_chunk[:, :, 1::2] = hi_vals
+
+        # Apply per-block scale in-place.
+        out_chunk.view(end - start, rows, num_blocks, block_size).mul_(
+            scale_mul[start:end].unsqueeze(-1)
+        )
+
     if dtype != torch.bfloat16:
-        result = result.to(dtype)
-    return result
+        out = out.to(dtype)
+    return out
 
 
 def _ue8m0_to_fp32_multiplier(ue8m0: torch.Tensor) -> torch.Tensor:

--- a/python/sgl_kernel/moe.py
+++ b/python/sgl_kernel/moe.py
@@ -296,14 +296,10 @@ def dequantize_mxfp4_weights(
     i.e. low nibble = first element, high nibble = second element.
 
     Parameters:
-    - packed:     [E, rows, packed_cols] uint8 – two FP4 nibbles per byte,
+    - packed:     [E, rows, packed_cols] int8 – two FP4 nibbles per byte,
                   where packed_cols = cols // 2.
     - scales:     [E, rows, num_blocks]  float32 MX block scale (direct
-                  multiplier), matching upstream sglang
-                  ``_upcast_mxfp4_one_xpu``'s contract. Callers holding raw
-                  UE8M0 bytes must decode to fp32 first via
-                  ``_ue8m0_to_fp32_multiplier``, where
-                  num_blocks = cols // block_size.
+                  multiplier), where num_blocks = cols // block_size.
     - dtype:      Output floating-point dtype (default: torch.bfloat16).
     - block_size: Number of FP4 elements sharing one scale factor (default: 32).
 
@@ -327,11 +323,9 @@ def dequantize_mxfp4_weights(
     assert (
         packed.device == scales.device
     ), f"packed and scales must be on the same device, got {packed.device} and {scales.device}"
-    assert scales.dtype == torch.float32, (
-        f"scales must be float32 direct multiplier (matches upstream "
-        f"_upcast_mxfp4_one_xpu contract); decode UE8M0 bytes first via "
-        f"_ue8m0_to_fp32_multiplier. got {scales.dtype}"
-    )
+    assert (
+        scales.dtype == torch.float32
+    ), f"scales must be float32 direct multiplier, got {scales.dtype}"
 
     lut = _get_e2m1_lut(packed.device)
     out = torch.empty(E, rows, cols, dtype=torch.bfloat16, device=packed.device)
@@ -339,13 +333,17 @@ def dequantize_mxfp4_weights(
     # Cast fp32 multiplier to bf16 once up-front; reused per chunk.
     scale_mul = scales.to(torch.bfloat16)
 
+    # View as uint8 so `>> 4` is a logical shift (arithmetic shift on signed
+    # int8 would sign-extend the high nibble of bytes with MSB set).
+    packed_u8 = packed.view(torch.uint8)
+
     # Chunk over experts: a flat 1-D gather is faster on Intel L0 than an
     # N-D advanced-index gather, and chunking bounds the int64 index tensor
     # materialized by index_select so it doesn't blow peak memory on large E.
     CHUNK = _MXFP4_DEQUANT_EXPERT_CHUNK
     for start in range(0, E, CHUNK):
         end = min(start + CHUNK, E)
-        chunk = packed[start:end]  # [C, rows, packed_cols]
+        chunk = packed_u8[start:end]  # [C, rows, packed_cols]
 
         lo_idx = (chunk & 0x0F).reshape(-1).to(torch.long)
         hi_idx = (chunk >> 4).reshape(-1).to(torch.long)
@@ -365,14 +363,6 @@ def dequantize_mxfp4_weights(
     if dtype != torch.bfloat16:
         out = out.to(dtype)
     return out
-
-
-def _ue8m0_to_fp32_multiplier(ue8m0: torch.Tensor) -> torch.Tensor:
-    """Decode a UE8M0 biased-exponent byte tensor to its fp32 direct multiplier.
-
-    stored_byte = biased_exp + 127  →  multiplier = 2^(byte - 127)
-    """
-    return torch.exp2((ue8m0.to(torch.int32) - 127).to(torch.float32))
 
 
 def fused_experts(
@@ -416,10 +406,10 @@ def fused_experts(
     - use_fp8_w8a8 (bool): If True, use fp8 arithmetic to compute the inner
         products for w1 and w2. Defaults to False.
     - use_mxfp4_w4a16 (bool): If True, w1 and w2 are in MXFP4 packed format
-        (uint8, two E2M1 nibbles per byte) with corresponding UE8M0 block
-        scales supplied via w1_scale and w2_scale.  The weights are
-        dequantized to BF16 before the grouped GeMM so the rest of the
-        computation is unchanged (W4A16: activations stay in BF16).
+        (int8, two E2M1 nibbles per byte) with corresponding float32 block
+        scales (direct multiplier) supplied via w1_scale and w2_scale.
+        The weights are dequantized to BF16 before the grouped GeMM so the
+        rest of the computation is unchanged (W4A16: activations stay in BF16).
         Defaults to False.
     - w1_scale (Optional[torch.Tensor]): Optional scale to be used for
         w1.
@@ -451,25 +441,25 @@ def fused_experts(
         "gelu",
     ), f"Only silu and gelu are supported but got {activation}"
 
-    # For MXFP4 W4A16: validate packed uint8 inputs and scales.
+    # For MXFP4 W4A16: validate packed int8 inputs and float32 scales.
     # Actual dequantization is deferred to just before each GeMM so that
     # at most one dequantized weight tensor lives in GPU memory at a time.
     # Scales must be None on all non-mxfp4 code paths.
     if use_mxfp4_w4a16:
         assert (
-            w1.dtype == torch.uint8
-        ), "use_mxfp4_w4a16=True requires w1 to be uint8 (packed MXFP4)"
+            w1.dtype == torch.int8
+        ), "use_mxfp4_w4a16=True requires w1 to be int8 (packed MXFP4)"
         assert (
-            w2.dtype == torch.uint8
-        ), "use_mxfp4_w4a16=True requires w2 to be uint8 (packed MXFP4)"
+            w2.dtype == torch.int8
+        ), "use_mxfp4_w4a16=True requires w2 to be int8 (packed MXFP4)"
         assert (
             w1_scale is not None
-        ), "w1_scale (UE8M0 uint8) must be provided when use_mxfp4_w4a16=True"
+        ), "w1_scale (float32) must be provided when use_mxfp4_w4a16=True"
         assert (
             w2_scale is not None
-        ), "w2_scale (UE8M0 uint8) must be provided when use_mxfp4_w4a16=True"
-        assert w1_scale.dtype == torch.uint8, "w1_scale must be uint8 (UE8M0 format)"
-        assert w2_scale.dtype == torch.uint8, "w2_scale must be uint8 (UE8M0 format)"
+        ), "w2_scale (float32) must be provided when use_mxfp4_w4a16=True"
+        assert w1_scale.dtype == torch.float32, "w1_scale must be float32"
+        assert w2_scale.dtype == torch.float32, "w2_scale must be float32"
     else:
         assert w1_scale is None, "w1_scale is only supported when use_mxfp4_w4a16=True"
         assert w2_scale is None, "w2_scale is only supported when use_mxfp4_w4a16=True"
@@ -603,7 +593,7 @@ def fused_experts(
         )
         # Dequantize w1 just before GEMM1, free immediately after
         if use_mxfp4_w4a16:
-            w1 = dequantize_mxfp4_weights(w1, _ue8m0_to_fp32_multiplier(w1_scale))
+            w1 = dequantize_mxfp4_weights(w1, w1_scale)
         torch.ops.sgl_kernel.moe_grouped_mm_nt_xe20(
             intermediate_cache1,
             input_A_shuffle,
@@ -620,7 +610,7 @@ def fused_experts(
         # one dequantized weight tensor occupies GPU memory at a time.
         if use_mxfp4_w4a16:
             del w1
-            w2 = dequantize_mxfp4_weights(w2, _ue8m0_to_fp32_multiplier(w2_scale))
+            w2 = dequantize_mxfp4_weights(w2, w2_scale)
         if activation_type == 0:
             torch.ops.sgl_kernel.silu_and_mul(intermediate_cache2, intermediate_cache1)
         elif activation_type == 1:
@@ -651,7 +641,7 @@ def fused_experts(
         )
         # Dequantize w1 just before GEMM1, free immediately after
         if use_mxfp4_w4a16:
-            w1 = dequantize_mxfp4_weights(w1, _ue8m0_to_fp32_multiplier(w1_scale))
+            w1 = dequantize_mxfp4_weights(w1, w1_scale)
         torch.ops.sgl_kernel.moe_grouped_mm_nt_xe20(
             intermediate_cache1,
             input_A_shuffle,
@@ -668,7 +658,7 @@ def fused_experts(
         # one dequantized weight tensor occupies GPU memory at a time.
         if use_mxfp4_w4a16:
             del w1
-            w2 = dequantize_mxfp4_weights(w2, _ue8m0_to_fp32_multiplier(w2_scale))
+            w2 = dequantize_mxfp4_weights(w2, w2_scale)
         torch.ops.sgl_kernel.moe_grouped_mm_nt_xe20(
             intermediate_cache3,
             intermediate_cache1,

--- a/python/sgl_kernel/moe.py
+++ b/python/sgl_kernel/moe.py
@@ -4,6 +4,12 @@ import torch
 
 from .utils import is_xe2_arch
 
+# Lookup table for MXFP4 E2M1 dequantization: maps 3-bit magnitude codes to float values.
+# Index i corresponds to code i in {0,0.5,1.0,1.5,2.0,3.0,4.0,6.0}.
+_MXFP4_E2M1_TO_FLOAT = torch.tensor(
+    [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32
+)
+
 
 def moe_align_block_size(
     topk_ids,
@@ -244,6 +250,63 @@ def cutlass_fp4_group_mm(
     return c.to(dtype=out_dtype)
 
 
+def dequantize_mxfp4_weights(
+    packed: torch.Tensor,
+    scales: torch.Tensor,
+    dtype: torch.dtype = torch.bfloat16,
+    block_size: int = 32,
+) -> torch.Tensor:
+    """Dequantize MXFP4 (E2M1) packed expert weight tensor to BF16 (or other dtype).
+
+    MXFP4 uses the OCP MX format: 4-bit E2M1 data packed two-per-byte (low
+    nibble first), with one UE8M0 (uint8) block scale per ``block_size``
+    elements along the last dimension.
+
+    Parameters:
+    - packed:     [E, rows, packed_cols] uint8 – two FP4 nibbles per byte,
+                  where packed_cols = cols // 2.
+    - scales:     [E, rows, num_blocks]  uint8 in UE8M0 format
+                  (stored_byte = biased_exp + 127), where
+                  num_blocks = cols // block_size.
+    - dtype:      Output floating-point dtype (default: torch.bfloat16).
+    - block_size: Number of FP4 elements sharing one scale factor (default: 32).
+
+    Returns:
+    - Tensor of shape [E, rows, cols] in ``dtype`` on the same device as
+      ``packed``.
+    """
+    E, rows, packed_cols = packed.shape
+    cols = packed_cols * 2
+    num_blocks = cols // block_size
+
+    # --- 1. Unpack two FP4 nibbles per byte (low nibble = element 0) ---
+    lo = packed & 0x0F  # [E, rows, packed_cols]
+    hi = (packed >> 4) & 0x0F  # [E, rows, packed_cols]
+    # Interleave lo/hi pairs → [E, rows, cols]
+    unpacked = torch.stack([lo, hi], dim=-1).reshape(E, rows, cols)
+
+    # --- 2. Dequantize E2M1 codes via lookup table ---
+    # E2M1 layout: bit 3 = sign, bits 2-0 = magnitude index
+    lut = _MXFP4_E2M1_TO_FLOAT.to(device=packed.device)
+    sign = ((unpacked >> 3) & 1).to(torch.bool)
+    magnitude_idx = (unpacked & 0x07).to(torch.long)
+    magnitude = lut[magnitude_idx]  # [E, rows, cols], float32
+    dequantized = torch.where(sign, -magnitude, magnitude)
+
+    # --- 3. Apply per-block UE8M0 scale factors ---
+    # Reshape into blocks: [E, rows, num_blocks, block_size]
+    dequantized_blocks = dequantized.reshape(E, rows, num_blocks, block_size)
+
+    # Decode UE8M0: float_scale = 2^(stored_byte - 127)
+    scale_exp = scales.to(torch.int32) - 127  # [E, rows, num_blocks]
+    # unsqueeze for broadcast over block_size dim
+    scale_values = torch.pow(2.0, scale_exp.float()).unsqueeze(-1)
+
+    scaled = dequantized_blocks * scale_values  # [E, rows, num_blocks, block_size]
+
+    return scaled.reshape(E, rows, cols).to(dtype)
+
+
 def fused_experts(
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
@@ -255,6 +318,7 @@ def fused_experts(
     inplace: bool = False,
     activation: str = "silu",
     use_fp8_w8a8: bool = False,
+    use_mxfp4_w4a16: bool = False,
     w1_scale: Optional[torch.Tensor] = None,
     w2_scale: Optional[torch.Tensor] = None,
     w1_zp: Optional[torch.Tensor] = None,
@@ -283,6 +347,12 @@ def fused_experts(
     - activation (str): The activation function to use ('silu' or 'gelu'). Defaults to 'silu'.
     - use_fp8_w8a8 (bool): If True, use fp8 arithmetic to compute the inner
         products for w1 and w2. Defaults to False.
+    - use_mxfp4_w4a16 (bool): If True, w1 and w2 are in MXFP4 packed format
+        (uint8, two E2M1 nibbles per byte) with corresponding UE8M0 block
+        scales supplied via w1_scale and w2_scale.  The weights are
+        dequantized to BF16 before the grouped GeMM so the rest of the
+        computation is unchanged (W4A16: activations stay in BF16).
+        Defaults to False.
     - w1_scale (Optional[torch.Tensor]): Optional scale to be used for
         w1.
     - w2_scale (Optional[torch.Tensor]): Optional scale to be used for
@@ -305,8 +375,6 @@ def fused_experts(
     """
 
     assert use_fp8_w8a8 is False, "current MoE does not support use_fp8_w8a8"
-    assert w1_scale is None, "current MoE does not support w1_scale"
-    assert w2_scale is None, "current MoE does not support w2_scale"
     assert a1_scale is None, "current MoE does not support a1_scale"
     assert a2_scale is None, "current MoE does not support a2_scale"
     assert block_shape is None, "current MoE does not support block_shape"
@@ -315,10 +383,34 @@ def fused_experts(
         "gelu",
     ), f"Only silu and gelu are supported but got {activation}"
 
+    # For MXFP4 W4A16: validate packed uint8 inputs and scales.
+    # Actual dequantization is deferred to just before each GeMM so that
+    # at most one dequantized weight tensor lives in GPU memory at a time.
+    # Scales must be None on all non-mxfp4 code paths.
+    if use_mxfp4_w4a16:
+        assert (
+            w1.dtype == torch.uint8
+        ), "use_mxfp4_w4a16=True requires w1 to be uint8 (packed MXFP4)"
+        assert (
+            w2.dtype == torch.uint8
+        ), "use_mxfp4_w4a16=True requires w2 to be uint8 (packed MXFP4)"
+        assert (
+            w1_scale is not None
+        ), "w1_scale (UE8M0 uint8) must be provided when use_mxfp4_w4a16=True"
+        assert (
+            w2_scale is not None
+        ), "w2_scale (UE8M0 uint8) must be provided when use_mxfp4_w4a16=True"
+        assert w1_scale.dtype == torch.uint8, "w1_scale must be uint8 (UE8M0 format)"
+        assert w2_scale.dtype == torch.uint8, "w2_scale must be uint8 (UE8M0 format)"
+    else:
+        assert w1_scale is None, "current MoE does not support w1_scale"
+        assert w2_scale is None, "current MoE does not support w2_scale"
+
     # type check
     assert hidden_states.dtype == torch.bfloat16, "hidden_states must be bfloat16"
-    assert w1.dtype == torch.bfloat16, "w1 must be bfloat16"
-    assert w2.dtype == torch.bfloat16, "w2 must be bfloat16"
+    if not use_mxfp4_w4a16:
+        assert w1.dtype == torch.bfloat16, "w1 must be bfloat16"
+        assert w2.dtype == torch.bfloat16, "w2 must be bfloat16"
     if b1 is not None:
         assert (
             b1.dtype == torch.bfloat16 or b1.dtype == torch.float32
@@ -334,13 +426,17 @@ def fused_experts(
             # cast b2 to float32, since bias is accumulated in float32 in the kernel
             b2 = b2.float()
     # Shape check
+    # For packed MXFP4 the last dim of w1/w2 is halved (2 FP4 values per byte),
+    # so compute the actual (unpacked) inner dimensions for validation.
+    _w1_inner = w1.shape[-1] * 2 if use_mxfp4_w4a16 else w1.shape[-1]
+    _w2_inner = w2.shape[-1] * 2 if use_mxfp4_w4a16 else w2.shape[-1]
     assert hidden_states.ndim == 2, "hidden_states must be 2D"
     assert (
-        hidden_states.shape[-1] == w1.shape[-1]
-    ), f"hidden_states shape[-1] {hidden_states.shape} must be equal to w1 shape[-2] {w1.shape}"
+        hidden_states.shape[-1] == _w1_inner
+    ), f"hidden_states shape[-1] {hidden_states.shape} must equal w1 inner dim {_w1_inner} (w1.shape={w1.shape})"
     assert (
-        2 * w2.shape[2] == w1.shape[1]
-    ), f"w2 shape[2] {w2.shape[2]} must be half of w1 shape[1] {w1.shape[1]}"
+        2 * _w2_inner == w1.shape[1]
+    ), f"w2 inner dim {_w2_inner} must be half of w1 shape[1] {w1.shape[1]}"
     assert (topk_ids.shape == topk_weights.shape) and (
         topk_ids.shape[0] == hidden_states.shape[0]
     ), f"topk_ids shape {topk_ids.shape} and topk_weights shape {topk_weights.shape} must be equal and match hidden_states shape[0] {hidden_states.shape[0]}"
@@ -349,6 +445,10 @@ def fused_experts(
 
     E, _, K = w1.shape
     E, OutK, N = w2.shape
+    if use_mxfp4_w4a16:
+        # w1/w2 last dims are packed (H//2, I//2); recover actual dims
+        K = K * 2
+        N = N * 2
     assert N * 2 == w1.shape[1], "w1 shape[1] must be 2x of w2 shape[2]"
     if b1 is not None:
         assert b1.shape == w1.shape[:2], "b1 shape must match w1 shape[:2]"
@@ -426,6 +526,10 @@ def fused_experts(
     avg_m = (M * TopK) // E
     big_weight = K * N > 4096 * 4096
     use_unfused_act = avg_m <= 128 and big_weight
+    # ---- GEMM1: dequantize w1 just before use, free immediately after ----
+    if use_mxfp4_w4a16:
+        w1 = dequantize_mxfp4_weights(w1, w1_scale)
+
     if use_unfused_act:
         intermediate_cache1 = torch.empty(
             (M * TopK, 2 * N), device=hidden_states.device, dtype=hidden_states.dtype
@@ -445,6 +549,12 @@ def fused_experts(
             gemm1_alpha=float(gemm1_alpha) if gemm1_alpha is not None else 1.702,
             gemm1_limit=float(gemm1_limit) if gemm1_limit is not None else 7.0,
         )
+        # Free dequantized w1 before allocating dequantized w2 — ensures at most
+        # one dequantized weight tensor occupies GPU memory at a time.
+        if use_mxfp4_w4a16:
+            del w1
+            torch.xpu.empty_cache()
+            w2 = dequantize_mxfp4_weights(w2, w2_scale)
         if activation_type == 0:
             torch.ops.sgl_kernel.silu_and_mul(intermediate_cache2, intermediate_cache1)
         elif activation_type == 1:
@@ -467,6 +577,8 @@ def fused_experts(
             gemm1_alpha=float(gemm1_alpha) if gemm1_alpha is not None else 1.702,
             gemm1_limit=float(gemm1_limit) if gemm1_limit is not None else 7.0,
         )
+        if use_mxfp4_w4a16:
+            del w2
     else:
         intermediate_cache1 = torch.empty(
             (M * TopK, N), device=hidden_states.device, dtype=hidden_states.dtype
@@ -483,6 +595,12 @@ def fused_experts(
             gemm1_alpha=float(gemm1_alpha) if gemm1_alpha is not None else 1.702,
             gemm1_limit=float(gemm1_limit) if gemm1_limit is not None else 7.0,
         )
+        # Free dequantized w1 before allocating dequantized w2 — ensures at most
+        # one dequantized weight tensor occupies GPU memory at a time.
+        if use_mxfp4_w4a16:
+            del w1
+            torch.xpu.empty_cache()
+            w2 = dequantize_mxfp4_weights(w2, w2_scale)
         torch.ops.sgl_kernel.moe_grouped_mm_nt_xe20(
             intermediate_cache3,
             intermediate_cache1,
@@ -495,6 +613,8 @@ def fused_experts(
             gemm1_alpha=float(gemm1_alpha) if gemm1_alpha is not None else 1.702,
             gemm1_limit=float(gemm1_limit) if gemm1_limit is not None else 7.0,
         )
+        if use_mxfp4_w4a16:
+            del w2
 
     rsf = 1.0
 

--- a/python/sgl_kernel/moe.py
+++ b/python/sgl_kernel/moe.py
@@ -6,14 +6,24 @@ from .utils import is_xe2_arch
 
 # E2M1 lookup table: nibble value 0x0–0xF → float.
 # Encodes sign directly: 0b0xxx = positive, 0b1xxx = negative.
-# high nibble = second element; see _upcast_mxfp4_one_xpu in sglang).
-_MXFP4_E2M1_LUT = torch.tensor(
+# Packing convention (matches sglang upstream / DeepSeek / sgl-kernel-xpu):
+# low nibble = first element, high nibble = second element.
+_MXFP4_E2M1_LUT_CPU = torch.tensor(
     [
         0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,        # 0b0xxx (positive)
         0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,  # 0b1xxx (negative)
     ],
-    dtype=torch.float32,
+    dtype=torch.bfloat16,
 )
+# Cache of device-resident LUTs to avoid re-copying on every call.
+_MXFP4_E2M1_LUT_CACHE: Dict[torch.device, torch.Tensor] = {}
+
+
+def _get_e2m1_lut(device: torch.device) -> torch.Tensor:
+    """Return a device-resident BF16 E2M1 lookup table, cached after first use."""
+    if device not in _MXFP4_E2M1_LUT_CACHE:
+        _MXFP4_E2M1_LUT_CACHE[device] = _MXFP4_E2M1_LUT_CPU.to(device=device)
+    return _MXFP4_E2M1_LUT_CACHE[device]
 
 
 def moe_align_block_size(
@@ -262,6 +272,8 @@ def dequantize_mxfp4_weights(
     block_size: int = 32,
 ) -> torch.Tensor:
     """Dequantize MXFP4 (E2M1) packed expert weight tensor to BF16 (or other dtype).
+
+    Packing convention (matches sglang upstream / DeepSeek / sgl-kernel-xpu):
         byte = (first_elem & 0xF) | (second_elem << 4)
     i.e. low nibble = first element, high nibble = second element.
 
@@ -282,19 +294,30 @@ def dequantize_mxfp4_weights(
     cols = packed_cols * 2
     num_blocks = cols // block_size
 
+    # Validate inputs
+    assert cols % block_size == 0, (
+        f"cols ({cols}) must be divisible by block_size ({block_size})"
+    )
+    assert scales.shape == (E, rows, num_blocks), (
+        f"scales shape {scales.shape} must be ({E}, {rows}, {num_blocks})"
+    )
+    assert packed.device == scales.device, (
+        f"packed and scales must be on the same device, got {packed.device} and {scales.device}"
+    )
+
     # --- 1. Unpack and dequantize via 16-entry signed LUT ---
-    # Low nibble = first element (even K position), high nibble = second element
-    lut = _MXFP4_E2M1_LUT.to(device=packed.device, dtype=torch.bfloat16)
-    lo = (packed & 0x0F).long()           # [E, rows, packed_cols]
-    hi = (packed >> 4).long()             # [E, rows, packed_cols]
-    # Interleave: [lo, hi] per packed position → [E, rows, cols]
-    paired = torch.stack([lut[lo], lut[hi]], dim=-1)  # [E, rows, packed_cols, 2]
-    dequantized = paired.reshape(E, rows, cols)
+    lut = _get_e2m1_lut(packed.device)
+
+    # Allocate output directly and fill even/odd positions to avoid
+    # torch.stack + reshape intermediaries.
+    dequantized = torch.empty(E, rows, cols, dtype=torch.bfloat16, device=packed.device)
+    dequantized[:, :, 0::2] = lut[(packed & 0x0F).int()]
+    dequantized[:, :, 1::2] = lut[(packed >> 4).int()]
 
     # --- 2. Apply per-block UE8M0 scale factors ---
-    dequantized = dequantized.reshape(E, rows, num_blocks, block_size)
+    dequantized = dequantized.view(E, rows, num_blocks, block_size)
     scale_exp = scales.to(torch.int32) - 127  # [E, rows, num_blocks]
-    scale_values = torch.exp2(scale_exp.float()).unsqueeze(-1).to(torch.bfloat16)
+    scale_values = torch.exp2(scale_exp).unsqueeze(-1).to(torch.bfloat16)
     dequantized = dequantized * scale_values
 
     result = dequantized.reshape(E, rows, cols)
@@ -548,7 +571,6 @@ def fused_experts(
         # one dequantized weight tensor occupies GPU memory at a time.
         if use_mxfp4_w4a16:
             del w1
-            torch.xpu.empty_cache()
             w2 = dequantize_mxfp4_weights(w2, w2_scale)
         if activation_type == 0:
             torch.ops.sgl_kernel.silu_and_mul(intermediate_cache2, intermediate_cache1)
@@ -574,7 +596,6 @@ def fused_experts(
         )
         if use_mxfp4_w4a16:
             del w2
-            torch.xpu.empty_cache()
     else:
         intermediate_cache1 = torch.empty(
             (M * TopK, N), device=hidden_states.device, dtype=hidden_states.dtype
@@ -598,7 +619,6 @@ def fused_experts(
         # one dequantized weight tensor occupies GPU memory at a time.
         if use_mxfp4_w4a16:
             del w1
-            torch.xpu.empty_cache()
             w2 = dequantize_mxfp4_weights(w2, w2_scale)
         torch.ops.sgl_kernel.moe_grouped_mm_nt_xe20(
             intermediate_cache3,
@@ -614,7 +634,6 @@ def fused_experts(
         )
         if use_mxfp4_w4a16:
             del w2
-            torch.xpu.empty_cache()
 
     rsf = 1.0
 

--- a/python/sgl_kernel/moe.py
+++ b/python/sgl_kernel/moe.py
@@ -294,8 +294,11 @@ def dequantize_mxfp4_weights(
     Parameters:
     - packed:     [E, rows, packed_cols] uint8 – two FP4 nibbles per byte,
                   where packed_cols = cols // 2.
-    - scales:     [E, rows, num_blocks]  uint8 in UE8M0 format
-                  (stored_byte = biased_exp + 127), where
+    - scales:     [E, rows, num_blocks]  float32 MX block scale (direct
+                  multiplier), matching upstream sglang
+                  ``_upcast_mxfp4_one_xpu``'s contract. Callers holding raw
+                  UE8M0 bytes must decode to fp32 first via
+                  ``torch.exp2((byte.to(int32) - 127).to(float32))``, where
                   num_blocks = cols // block_size.
     - dtype:      Output floating-point dtype (default: torch.bfloat16).
     - block_size: Number of FP4 elements sharing one scale factor (default: 32).
@@ -320,6 +323,11 @@ def dequantize_mxfp4_weights(
     assert (
         packed.device == scales.device
     ), f"packed and scales must be on the same device, got {packed.device} and {scales.device}"
+    assert scales.dtype == torch.float32, (
+        f"scales must be float32 direct multiplier (matches upstream "
+        f"_upcast_mxfp4_one_xpu contract); decode UE8M0 bytes first if needed. "
+        f"got {scales.dtype}"
+    )
 
     # --- 1. Unpack and dequantize via 16-entry signed LUT ---
     lut = _get_e2m1_lut(packed.device)
@@ -330,16 +338,23 @@ def dequantize_mxfp4_weights(
     dequantized[:, :, 0::2] = lut[(packed & 0x0F).int()]
     dequantized[:, :, 1::2] = lut[(packed >> 4).int()]
 
-    # --- 2. Apply per-block UE8M0 scale factors ---
+    # --- 2. Apply per-block direct-multiplier scale factors ---
     dequantized = dequantized.view(E, rows, num_blocks, block_size)
-    scale_exp = scales.to(torch.int32) - 127  # [E, rows, num_blocks]
-    scale_values = torch.exp2(scale_exp).unsqueeze(-1).to(torch.bfloat16)
+    scale_values = scales.unsqueeze(-1).to(torch.bfloat16)
     dequantized = dequantized * scale_values
 
     result = dequantized.reshape(E, rows, cols)
     if dtype != torch.bfloat16:
         result = result.to(dtype)
     return result
+
+
+def _ue8m0_to_fp32_multiplier(ue8m0: torch.Tensor) -> torch.Tensor:
+    """Decode a UE8M0 biased-exponent byte tensor to its fp32 direct multiplier.
+
+    stored_byte = biased_exp + 127  →  multiplier = 2^(byte - 127)
+    """
+    return torch.exp2((ue8m0.to(torch.int32) - 127).to(torch.float32))
 
 
 def fused_experts(
@@ -570,7 +585,7 @@ def fused_experts(
         )
         # Dequantize w1 just before GEMM1, free immediately after
         if use_mxfp4_w4a16:
-            w1 = dequantize_mxfp4_weights(w1, w1_scale)
+            w1 = dequantize_mxfp4_weights(w1, _ue8m0_to_fp32_multiplier(w1_scale))
         torch.ops.sgl_kernel.moe_grouped_mm_nt_xe20(
             intermediate_cache1,
             input_A_shuffle,
@@ -587,7 +602,7 @@ def fused_experts(
         # one dequantized weight tensor occupies GPU memory at a time.
         if use_mxfp4_w4a16:
             del w1
-            w2 = dequantize_mxfp4_weights(w2, w2_scale)
+            w2 = dequantize_mxfp4_weights(w2, _ue8m0_to_fp32_multiplier(w2_scale))
         if activation_type == 0:
             torch.ops.sgl_kernel.silu_and_mul(intermediate_cache2, intermediate_cache1)
         elif activation_type == 1:
@@ -618,7 +633,7 @@ def fused_experts(
         )
         # Dequantize w1 just before GEMM1, free immediately after
         if use_mxfp4_w4a16:
-            w1 = dequantize_mxfp4_weights(w1, w1_scale)
+            w1 = dequantize_mxfp4_weights(w1, _ue8m0_to_fp32_multiplier(w1_scale))
         torch.ops.sgl_kernel.moe_grouped_mm_nt_xe20(
             intermediate_cache1,
             input_A_shuffle,
@@ -635,7 +650,7 @@ def fused_experts(
         # one dequantized weight tensor occupies GPU memory at a time.
         if use_mxfp4_w4a16:
             del w1
-            w2 = dequantize_mxfp4_weights(w2, w2_scale)
+            w2 = dequantize_mxfp4_weights(w2, _ue8m0_to_fp32_multiplier(w2_scale))
         torch.ops.sgl_kernel.moe_grouped_mm_nt_xe20(
             intermediate_cache3,
             intermediate_cache1,

--- a/python/sgl_kernel/moe.py
+++ b/python/sgl_kernel/moe.py
@@ -10,8 +10,22 @@ from .utils import is_xe2_arch
 # low nibble = first element, high nibble = second element.
 _MXFP4_E2M1_LUT_CPU = torch.tensor(
     [
-        0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,        # 0b0xxx (positive)
-        0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,  # 0b1xxx (negative)
+        0.0,
+        0.5,
+        1.0,
+        1.5,
+        2.0,
+        3.0,
+        4.0,
+        6.0,  # 0b0xxx (positive)
+        0.0,
+        -0.5,
+        -1.0,
+        -1.5,
+        -2.0,
+        -3.0,
+        -4.0,
+        -6.0,  # 0b1xxx (negative)
     ],
     dtype=torch.bfloat16,
 )
@@ -295,15 +309,17 @@ def dequantize_mxfp4_weights(
     num_blocks = cols // block_size
 
     # Validate inputs
-    assert cols % block_size == 0, (
-        f"cols ({cols}) must be divisible by block_size ({block_size})"
-    )
-    assert scales.shape == (E, rows, num_blocks), (
-        f"scales shape {scales.shape} must be ({E}, {rows}, {num_blocks})"
-    )
-    assert packed.device == scales.device, (
-        f"packed and scales must be on the same device, got {packed.device} and {scales.device}"
-    )
+    assert (
+        cols % block_size == 0
+    ), f"cols ({cols}) must be divisible by block_size ({block_size})"
+    assert scales.shape == (
+        E,
+        rows,
+        num_blocks,
+    ), f"scales shape {scales.shape} must be ({E}, {rows}, {num_blocks})"
+    assert (
+        packed.device == scales.device
+    ), f"packed and scales must be on the same device, got {packed.device} and {scales.device}"
 
     # --- 1. Unpack and dequantize via 16-entry signed LUT ---
     lut = _get_e2m1_lut(packed.device)

--- a/tests/mxfp4_utils.py
+++ b/tests/mxfp4_utils.py
@@ -1,0 +1,9 @@
+"""Shared MXFP4 quantisation/dequantisation helpers for tests.
+
+Thin wrappers around the reference implementations in
+test_per_token_group_quant_mxfp4.py, importable without sys.path hacks.
+"""
+
+from test_per_token_group_quant_mxfp4 import MXFP4_BLOCK_SIZE  # noqa: F401
+from test_per_token_group_quant_mxfp4 import dequantize_mxfp4 as dequantize_mxfp4_2d  # noqa: F401
+from test_per_token_group_quant_mxfp4 import quantize_to_mxfp4 as quantize_mxfp4_2d  # noqa: F401

--- a/tests/mxfp4_utils.py
+++ b/tests/mxfp4_utils.py
@@ -5,5 +5,9 @@ test_per_token_group_quant_mxfp4.py, importable without sys.path hacks.
 """
 
 from test_per_token_group_quant_mxfp4 import MXFP4_BLOCK_SIZE  # noqa: F401
-from test_per_token_group_quant_mxfp4 import dequantize_mxfp4 as dequantize_mxfp4_2d  # noqa: F401
-from test_per_token_group_quant_mxfp4 import quantize_to_mxfp4 as quantize_mxfp4_2d  # noqa: F401
+from test_per_token_group_quant_mxfp4 import (  # noqa: F401
+    dequantize_mxfp4 as dequantize_mxfp4_2d,
+)
+from test_per_token_group_quant_mxfp4 import (  # noqa: F401
+    quantize_to_mxfp4 as quantize_mxfp4_2d,
+)

--- a/tests/test_moe_gemm.py
+++ b/tests/test_moe_gemm.py
@@ -5,12 +5,12 @@ from typing import Callable
 import pytest
 import torch
 import torch.nn.functional as F
-from sgl_kernel import fused_experts
 
 # Shared MXFP4 helpers live in a dedicated module next to this file.
 from mxfp4_utils import MXFP4_BLOCK_SIZE
 from mxfp4_utils import dequantize_mxfp4_2d as _dequantize_mxfp4_2d
 from mxfp4_utils import quantize_mxfp4_2d as _quantize_mxfp4_2d
+from sgl_kernel import fused_experts
 
 
 def apply_act_and_mul(
@@ -282,7 +282,13 @@ def _dequantize_weights_mxfp4(
     ),
 )
 def test_moe_gemm_mxfp4_weights(
-    num_tokens, topk, num_experts, hidden_size, intermediate_size, bias_dtype, activation
+    num_tokens,
+    topk,
+    num_experts,
+    hidden_size,
+    intermediate_size,
+    bias_dtype,
+    activation,
 ):
     """Test fused_experts with MXFP4-packed expert weights (W4A16).
 

--- a/tests/test_moe_gemm.py
+++ b/tests/test_moe_gemm.py
@@ -1,5 +1,4 @@
 import itertools
-import os
 import sys
 from typing import Callable
 
@@ -8,12 +7,10 @@ import torch
 import torch.nn.functional as F
 from sgl_kernel import fused_experts
 
-# Reuse the reference MXFP4 quantisation/dequantisation helpers that live in
-# the dedicated unit-test file next to this one.
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from test_per_token_group_quant_mxfp4 import MXFP4_BLOCK_SIZE
-from test_per_token_group_quant_mxfp4 import dequantize_mxfp4 as _dequantize_mxfp4_2d
-from test_per_token_group_quant_mxfp4 import quantize_to_mxfp4 as _quantize_mxfp4_2d
+# Shared MXFP4 helpers live in a dedicated module next to this file.
+from mxfp4_utils import MXFP4_BLOCK_SIZE
+from mxfp4_utils import dequantize_mxfp4_2d as _dequantize_mxfp4_2d
+from mxfp4_utils import quantize_mxfp4_2d as _quantize_mxfp4_2d
 
 
 def apply_act_and_mul(
@@ -299,6 +296,7 @@ def test_moe_gemm_mxfp4_weights(
     quantisation, and should be within the same tolerances as the BF16 test.
     """
     act_type = activation
+    torch.manual_seed(0)
     torch.xpu.manual_seed_all(0)
 
     rtol, atol = 1e-1, 1e-2

--- a/tests/test_moe_gemm.py
+++ b/tests/test_moe_gemm.py
@@ -24,18 +24,11 @@ def apply_act_and_mul(
 
 
 def create_random_xpu_tensor(shape, dtype, mean=0, std=0.01):
-    """Create a random xpu tensor
-
-    Args:
-        shape: Tensor shape
-        dtype: Data type
-        mean: Mean value
-        std: Standard deviation
-
-    Returns:
-        torch.Tensor: Randomly initialized xpu tensor
-    """
     return torch.empty(shape, dtype=dtype, device="xpu").normal_(mean, std)
+
+
+def create_random_cpu_tensor(shape, dtype, mean=0, std=0.01):
+    return torch.empty(shape, dtype=dtype, device="cpu").normal_(mean, std)
 
 
 # GPT-OSS SwiGLU parameters (matches kernel defaults)
@@ -278,7 +271,7 @@ def _dequantize_weights_mxfp4(
 
 
 @pytest.mark.parametrize(
-    "num_tokens,topk,num_experts,hidden_size,intermediate_size,bias_dtype,act",
+    "num_tokens,topk,num_experts,hidden_size,intermediate_size,bias_dtype,activation",
     list(
         itertools.product(
             [1, 33, 222],  # num_tokens
@@ -287,15 +280,12 @@ def _dequantize_weights_mxfp4(
             [128, 1024],  # hidden_size  – must be a multiple of MXFP4_BLOCK_SIZE
             [128, 512],  # intermediate_size – must be a multiple of MXFP4_BLOCK_SIZE
             [False, "bfloat16", "float32"],  # bias_dtype
-            [
-                ("silu", None, None),
-                ("gelu", None, None),
-            ],  # (act_type, gemm1_alpha, gemm1_limit)
+            ["silu", "gelu"],  # activation type
         )
     ),
 )
 def test_moe_gemm_mxfp4_weights(
-    num_tokens, topk, num_experts, hidden_size, intermediate_size, bias_dtype, act
+    num_tokens, topk, num_experts, hidden_size, intermediate_size, bias_dtype, activation
 ):
     """Test fused_experts with MXFP4-packed expert weights (W4A16).
 
@@ -308,7 +298,7 @@ def test_moe_gemm_mxfp4_weights(
     difference is purely from the BF16 grouped GeMM arithmetic, not from
     quantisation, and should be within the same tolerances as the BF16 test.
     """
-    act_type, gemm1_alpha, gemm1_limit = act
+    act_type = activation
     torch.xpu.manual_seed_all(0)
 
     rtol, atol = 1e-1, 1e-2

--- a/tests/test_moe_gemm.py
+++ b/tests/test_moe_gemm.py
@@ -1,4 +1,5 @@
 import itertools
+import os
 import sys
 from typing import Callable
 
@@ -6,6 +7,13 @@ import pytest
 import torch
 import torch.nn.functional as F
 from sgl_kernel import fused_experts
+
+# Reuse the reference MXFP4 quantisation/dequantisation helpers that live in
+# the dedicated unit-test file next to this one.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from test_per_token_group_quant_mxfp4 import MXFP4_BLOCK_SIZE
+from test_per_token_group_quant_mxfp4 import dequantize_mxfp4 as _dequantize_mxfp4_2d
+from test_per_token_group_quant_mxfp4 import quantize_to_mxfp4 as _quantize_mxfp4_2d
 
 
 def apply_act_and_mul(
@@ -209,6 +217,171 @@ def test_moe_gemm(
         routed_scaling_factor=routed_scaling_factor,
     )
     torch.testing.assert_close(torch_output, sglang_output, rtol=rtol, atol=atol)
+
+
+# ---------------------------------------------------------------------------
+# MXFP4 expert-weight helpers (W4A16)
+# ---------------------------------------------------------------------------
+
+
+def _quantize_weights_mxfp4(
+    w: torch.Tensor,
+    block_size: int = MXFP4_BLOCK_SIZE,
+):
+    """Quantize a 3-D expert weight tensor [E, rows, cols] to MXFP4 on CPU.
+
+    The last dimension is quantised in blocks of *block_size* elements.
+    Both *cols* and *block_size* must be compatible with MXFP4 packing
+    (cols divisible by block_size and by 2).
+
+    Returns:
+        packed  – [E, rows, cols // 2] uint8, two E2M1 nibbles per byte
+                  (low nibble = first element, matching pack_fp4 convention).
+        scales  – [E, rows, cols // block_size] uint8, UE8M0 format
+                  (stored_byte = biased_exp + 127).
+    """
+    E, rows, cols = w.shape
+    assert (
+        cols % block_size == 0
+    ), f"last dim {cols} must be divisible by block_size {block_size}"
+    flat = w.reshape(E * rows, cols).float().cpu()
+    packed_flat, scales_flat = _quantize_mxfp4_2d(flat, block_size)
+    return (
+        packed_flat.reshape(E, rows, cols // 2),
+        scales_flat.reshape(E, rows, cols // block_size),
+    )
+
+
+def _dequantize_weights_mxfp4(
+    packed: torch.Tensor,
+    scales: torch.Tensor,
+    block_size: int = MXFP4_BLOCK_SIZE,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Dequantize 3-D packed MXFP4 weights [E, rows, packed_cols] to BF16 on CPU.
+
+    Returns a [E, rows, cols] tensor where cols = packed_cols * 2.
+    """
+    E, rows, packed_cols = packed.shape
+    cols = packed_cols * 2
+    flat_packed = packed.reshape(E * rows, packed_cols).cpu()
+    flat_scales = scales.reshape(E * rows, cols // block_size).cpu()
+    flat_dq = _dequantize_mxfp4_2d(
+        flat_packed, flat_scales, dtype=dtype, block_size=block_size
+    )
+    return flat_dq.reshape(E, rows, cols)
+
+
+# ---------------------------------------------------------------------------
+# MXFP4 expert-weight test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "num_tokens,topk,num_experts,hidden_size,intermediate_size,bias_dtype,act",
+    list(
+        itertools.product(
+            [1, 33, 222],  # num_tokens
+            [1, 2, 6],  # topk
+            [8, 64],  # num_experts
+            [128, 1024],  # hidden_size  – must be a multiple of MXFP4_BLOCK_SIZE
+            [128, 512],  # intermediate_size – must be a multiple of MXFP4_BLOCK_SIZE
+            [False, "bfloat16", "float32"],  # bias_dtype
+            [
+                ("silu", None, None),
+                ("gelu", None, None),
+            ],  # (act_type, gemm1_alpha, gemm1_limit)
+        )
+    ),
+)
+def test_moe_gemm_mxfp4_weights(
+    num_tokens, topk, num_experts, hidden_size, intermediate_size, bias_dtype, act
+):
+    """Test fused_experts with MXFP4-packed expert weights (W4A16).
+
+    Weights are quantized to MXFP4 on CPU and passed to fused_experts as packed
+    uint8 tensors together with their UE8M0 block scales via the
+    ``use_mxfp4_w4a16=True`` flag.  Activations remain in BF16 throughout.
+
+    The reference is torch_naive_moe run with the *dequantised* BF16 weights
+    so that both code paths see identical effective weights; any numerical
+    difference is purely from the BF16 grouped GeMM arithmetic, not from
+    quantisation, and should be within the same tolerances as the BF16 test.
+    """
+    act_type, gemm1_alpha, gemm1_limit = act
+    torch.xpu.manual_seed_all(0)
+
+    rtol, atol = 1e-1, 1e-2
+
+    a = create_random_cpu_tensor((num_tokens, hidden_size), torch.bfloat16)
+    # w1: gate+up projection  [E, 2*I, H];  w2: down projection  [E, H, I]
+    w1_bf16 = create_random_cpu_tensor(
+        (num_experts, 2 * intermediate_size, hidden_size), torch.bfloat16
+    )
+    w2_bf16 = create_random_cpu_tensor(
+        (num_experts, hidden_size, intermediate_size), torch.bfloat16
+    )
+    b1, b2 = None, None
+    if bias_dtype:
+        dtype = torch.bfloat16 if bias_dtype == "bfloat16" else torch.float32
+        b1 = create_random_cpu_tensor(
+            (num_experts, 2 * intermediate_size), dtype, std=0.005
+        )
+        b2 = create_random_cpu_tensor((num_experts, hidden_size), dtype, std=0.005)
+
+    score = torch.randn([num_tokens, num_experts], dtype=torch.bfloat16)
+    score = torch.softmax(score, dim=-1, dtype=torch.float32)
+    topk_weight, topk_ids = torch.topk(score, topk)
+
+    # ---- Reference: quantise w1/w2 → dequantise to get MXFP4-rounded BF16 ----
+    # Both the kernel and the reference operate on these rounded weights, so any
+    # discrepancy is purely arithmetic (not quantisation error).
+    w1_packed, w1_scale = _quantize_weights_mxfp4(w1_bf16)
+    w2_packed, w2_scale = _quantize_weights_mxfp4(w2_bf16)
+    w1_dq = _dequantize_weights_mxfp4(w1_packed, w1_scale)
+    w2_dq = _dequantize_weights_mxfp4(w2_packed, w2_scale)
+
+    torch_output = torch_naive_moe(
+        a,
+        w1_dq,
+        w2_dq,
+        topk_ids,
+        topk_weight,
+        topk,
+        b1,
+        b2,
+        activations=act_type,
+    )
+
+    # ---- fused_experts with packed MXFP4 weights on XPU ----
+    device = "xpu"
+    a_xpu = a.clone().to(device)
+    w1_packed_xpu = w1_packed.to(device)
+    w2_packed_xpu = w2_packed.to(device)
+    w1_scale_xpu = w1_scale.to(device)
+    w2_scale_xpu = w2_scale.to(device)
+    topk_weight_xpu = topk_weight.clone().to(device)
+    topk_ids_xpu = topk_ids.clone().to(device)
+    b1_xpu = b1.clone().to(device) if b1 is not None else None
+    b2_xpu = b2.clone().to(device) if b2 is not None else None
+
+    sglang_output = fused_experts(
+        a_xpu,
+        w1_packed_xpu,
+        w2_packed_xpu,
+        topk_weight_xpu,
+        topk_ids_xpu,
+        b1_xpu,
+        b2_xpu,
+        activation=act_type,
+        use_mxfp4_w4a16=True,
+        w1_scale=w1_scale_xpu,
+        w2_scale=w2_scale_xpu,
+    )
+
+    torch.testing.assert_close(
+        torch_output, sglang_output.to("cpu"), rtol=rtol, atol=atol
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_moe_gemm.py
+++ b/tests/test_moe_gemm.py
@@ -348,12 +348,19 @@ def test_moe_gemm_mxfp4_weights(
     )
 
     # ---- fused_experts with packed MXFP4 weights on XPU ----
+    # fused_experts expects packed weights as int8 (bitwise identical to the
+    # uint8 reference packing) and scales as a fp32 direct multiplier
+    # (decoded from UE8M0).
     device = "xpu"
     a_xpu = a.clone().to(device)
-    w1_packed_xpu = w1_packed.to(device)
-    w2_packed_xpu = w2_packed.to(device)
-    w1_scale_xpu = w1_scale.to(device)
-    w2_scale_xpu = w2_scale.to(device)
+    w1_packed_xpu = w1_packed.view(torch.int8).to(device)
+    w2_packed_xpu = w2_packed.view(torch.int8).to(device)
+    w1_scale_xpu = torch.exp2((w1_scale.to(torch.int32) - 127).to(torch.float32)).to(
+        device
+    )
+    w2_scale_xpu = torch.exp2((w2_scale.to(torch.int32) - 127).to(torch.float32)).to(
+        device
+    )
     topk_weight_xpu = topk_weight.clone().to(device)
     topk_ids_xpu = topk_ids.clone().to(device)
     b1_xpu = b1.clone().to(device) if b1 is not None else None


### PR DESCRIPTION
Introduces use_mxfp4_w4a16 mode for fused_experts on XPU, dequantizing w1/w2 just-in-time around each grouped GEMM to bound peak GPU memory.

What changed

- `python/sgl_kernel/moe.py`
  - Added `dequantize_mxfp4_weights()`: dequantizes OCP MXFP4 (E2M1 packed uint8 + UE8M0 block scales) to BF16 on-device using a lookup table.
  - Added `use_mxfp4_w4a16: bool` parameter to `fused_experts()`. When `True`, `w1`/`w2` are expected as packed `uint8` with corresponding `w1_scale`/`w2_scale` in UE8M0 format; input activations remain BF16 (W4A16).
  - Input validation and shape checks are adapted to account for the packed last dimension (`cols // 2`).