### PR TITLE
Top K Renorm Probs Kernel

### DIFF
--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -72,6 +72,7 @@ jobs:
               python3 bench_per_token_group_quant_mxfp4.py 2>&1 | tee per_token_group_quant_mxfp4.py.log \
               python3 bench_per_token_group_quant_8bit_v2.py 2>&1 | tee bench_per_token_group_quant_8bit_v2.py.log \
               python3 bench_scatter_tokens_to_experts.py 2>&1 | tee bench_scatter_tokens_to_experts.py.log \
+              python3 bench_top_k_renorm_probs.py 2>&1 | tee bench_top_k_renorm_probs.py.log \
             "
 
       - name: Copy logs from container

--- a/benchmark/bench_top_k_renorm_probs.py
+++ b/benchmark/bench_top_k_renorm_probs.py
@@ -1,0 +1,90 @@
+from itertools import product
+
+import pandas as pd
+import torch
+import triton
+from sgl_kernel import top_k_renorm_prob
+
+batch_size_range = [1, 99, 989]
+vocab_size_range = [1024, 32000, 128256]
+top_k_range = [10, 100, 500]
+
+configs = [
+    (bs, vocab_size, top_k)
+    for bs, vocab_size in product(batch_size_range, vocab_size_range)
+    for top_k in top_k_range
+    if top_k < vocab_size
+]
+
+all_results = []
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["batch_size", "vocab_size", "top_k"],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=["sgl_kernel"],
+        line_names=["SGL Kernel"],
+        styles=[("blue", "-")],
+        ylabel="Time (ms)",
+        plot_name="top-k-renorm-probs-performance",
+        args={},
+    )
+)
+def benchmark(batch_size, vocab_size, top_k, provider):
+    print(
+        f"benchmark {provider} with batch_size={batch_size} vocab_size={vocab_size} top_k={top_k}"
+    )
+    dtype = torch.float32
+    torch.set_default_device("xpu")
+    torch.xpu.manual_seed_all(0)
+
+    # Create input probabilities
+    probs = torch.rand(
+        batch_size, vocab_size, dtype=dtype, device="xpu", requires_grad=False
+    )
+    # Normalize to get valid probabilities
+    probs = probs / probs.sum(dim=-1, keepdim=True)
+
+    # Warmup
+    for _ in range(10):
+        _ = top_k_renorm_prob(probs, top_k)
+    torch.xpu.synchronize()
+
+    bench_lambda = lambda: top_k_renorm_prob(probs, top_k)
+
+    quantiles = [0.5, 0.25, 0.75]
+    ms, _, _ = triton.testing.do_bench(
+        bench_lambda, quantiles=quantiles, return_mode="median"
+    )
+
+    torch.xpu.empty_cache()
+
+    # Calculate memory bandwidth
+    num_elements = batch_size * vocab_size
+
+    total_bytes = 2 * (probs.numel() * probs.element_size())  # read and write
+    bandwidth_gb_s = total_bytes / (ms / 1e3) / 1e9
+
+    del probs
+
+    all_results.append(
+        {
+            "batch_size": batch_size,
+            "vocab_size": vocab_size,
+            "top_k": top_k,
+            "provider": provider,
+            "bandwidth_gb_s": bandwidth_gb_s,
+            "ms": ms,
+        }
+    )
+    return ms
+
+
+if __name__ == "__main__":
+    benchmark.run(print_data=False)
+    print("Benchmark finished!")
+
+    df = pd.DataFrame(all_results)
+    print(df.to_markdown())

--- a/benchmark/bench_top_k_renorm_probs.py
+++ b/benchmark/bench_top_k_renorm_probs.py
@@ -38,7 +38,7 @@ def benchmark(batch_size, vocab_size, top_k, provider):
     )
     dtype = torch.float32
     torch.set_default_device("xpu")
-    torch.xpu.manual_seed_all(0)
+    torch.xpu.manual_seed_all(42)
 
     # Create input probabilities
     probs = torch.rand(

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -417,7 +417,7 @@ void min_p_sampling_from_probs(
     std::optional<at::Generator> gen);
 
 void top_k_renorm_probs(
-    at::Tensor probs, at::Tensor renorm_probs, std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val);
+    const at::Tensor& probs, at::Tensor& renorm_probs, const std::optional<at::Tensor>& maybe_top_k_arr, int64_t top_k_val);
 
 void top_p_renorm_probs(
     at::Tensor probs, at::Tensor renorm_probs, std::optional<at::Tensor> maybe_top_p_arr, double top_p_val);

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -417,7 +417,10 @@ void min_p_sampling_from_probs(
     std::optional<at::Generator> gen);
 
 void top_k_renorm_probs(
-    const at::Tensor& probs, at::Tensor& renorm_probs, const std::optional<at::Tensor>& maybe_top_k_arr, int64_t top_k_val);
+    const at::Tensor& probs,
+    at::Tensor& renorm_probs,
+    const std::optional<at::Tensor>& maybe_top_k_arr,
+    int64_t top_k_val);
 
 void top_p_renorm_probs(
     at::Tensor probs, at::Tensor renorm_probs, std::optional<at::Tensor> maybe_top_p_arr, double top_p_val);

--- a/python/sgl_kernel/sampling.py
+++ b/python/sgl_kernel/sampling.py
@@ -10,7 +10,7 @@ def _top_k_renorm_probs_internal(
     top_k_val: int,
 ) -> torch.Tensor:
     probs = probs.float()
-    maybe_top_k_arr = maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
+    maybe_top_k_arr = maybe_top_k_arr.long() if maybe_top_k_arr is not None else None
     renorm_probs = torch.empty_like(probs)
     torch.ops.sgl_kernel.top_k_renorm_probs.default(
         probs, renorm_probs, maybe_top_k_arr, top_k_val

--- a/src/sycl/TopKRenormProbs.cpp
+++ b/src/sycl/TopKRenormProbs.cpp
@@ -1,0 +1,338 @@
+#include <ATen/ATen.h>
+#include <c10/xpu/XPUStream.h>
+#include <torch/all.h>
+
+#include <cstdlib>
+#include <optional>
+#include <sycl/sycl.hpp>
+
+#include "MemoryAccess.h"
+#include "SYCLHelpers.h"
+#include "Utils.h"
+
+//----------------- set element type options --------------------//
+
+template <typename T>
+struct ToSyclElementType {
+  using type = T;
+};
+
+template <>
+struct ToSyclElementType<at::Half> {
+  using type = sycl::half;
+};
+
+template <>
+struct ToSyclElementType<at::BFloat16> {
+  using type = sycl::ext::oneapi::bfloat16;
+};
+
+//----------------- radix traits for bit-pattern transformation --------------------//
+
+template <typename T>
+struct RadixTopKTraits;
+
+template <>
+struct RadixTopKTraits<float> {
+  using DType = float;
+  using OrderedType = uint32_t;
+  static constexpr uint32_t kRadixBits = 8;
+  static constexpr uint32_t kRadix = 1u << kRadixBits;
+  static constexpr uint32_t kNumRounds = 4;
+
+  static inline OrderedType to_ordered(float val) {
+    uint32_t bits = sycl::bit_cast<uint32_t>(val);
+    return (bits & 0x80000000u) ? ~bits : (bits ^ 0x80000000u);
+  }
+
+  static inline float from_ordered(OrderedType ordered) {
+    uint32_t bits = (ordered & 0x80000000u) ? (ordered ^ 0x80000000u) : ~ordered;
+    return sycl::bit_cast<float>(bits);
+  }
+};
+
+template <>
+struct RadixTopKTraits<sycl::half> {
+  using DType = sycl::half;
+  using OrderedType = uint16_t;
+  static constexpr uint32_t kRadixBits = 8;
+  static constexpr uint32_t kRadix = 256;
+  static constexpr uint32_t kNumRounds = 2;
+
+  static inline OrderedType to_ordered(sycl::half val) {
+    uint16_t bits = sycl::bit_cast<uint16_t>(val);
+    return (bits & 0x8000u) ? ~bits : (bits ^ 0x8000u);
+  }
+
+  static inline sycl::half from_ordered(OrderedType ordered) {
+    uint16_t bits = (ordered & 0x8000u) ? (ordered ^ 0x8000u) : ~ordered;
+    return sycl::bit_cast<sycl::half>(bits);
+  }
+};
+
+template <>
+struct RadixTopKTraits<sycl::ext::oneapi::bfloat16> {
+  using DType = sycl::ext::oneapi::bfloat16;
+  using OrderedType = uint16_t;
+  static constexpr uint32_t kRadixBits = 8;
+  static constexpr uint32_t kRadix = 256;
+  static constexpr uint32_t kNumRounds = 2;
+
+  static inline OrderedType to_ordered(sycl::ext::oneapi::bfloat16 val) {
+    uint16_t bits = sycl::bit_cast<uint16_t>(val);
+    return (bits & 0x8000u) ? ~bits : (bits ^ 0x8000u);
+  }
+
+  static inline sycl::ext::oneapi::bfloat16 from_ordered(OrderedType ordered) {
+    uint16_t bits = (ordered & 0x8000u) ? (ordered ^ 0x8000u) : ~ordered;
+    return sycl::bit_cast<sycl::ext::oneapi::bfloat16>(bits);
+  }
+};
+
+//----------------- single-cta kernel implementation --------------------//
+
+template <typename DType>
+struct TopKRenormProbsSingleCTA : public __SYCL_KER_CONFIG_CONVENTION__ {
+  using Traits = RadixTopKTraits<DType>;
+  using OrderedType = typename Traits::OrderedType;
+  static constexpr uint32_t kOrderedBits = sizeof(OrderedType) * 8;
+  static constexpr uint32_t kWgSize = 1024;
+  static constexpr uint32_t kRadix = Traits::kRadix;
+  static constexpr uint32_t kNumRounds = Traits::kNumRounds;
+  static constexpr uint32_t kNumSubGroups = kWgSize / 32;
+
+  const DType* probs;
+  DType* renorm_probs;
+  const int64_t* maybe_top_k_arr;
+  int top_k_val;
+  int batch_size;
+  int vocab_size;
+
+  sycl::local_accessor<uint32_t, 1> subgroup_hist_;
+  sycl::local_accessor<uint32_t, 1> scalars_;
+  sycl::local_accessor<float, 1> block_sum_;
+
+  void sycl_ker_config_convention(sycl::handler& cgh) {
+    subgroup_hist_ = sycl::local_accessor<uint32_t, 1>(sycl::range<1>(kNumSubGroups * kRadix), cgh);
+    scalars_ = sycl::local_accessor<uint32_t, 1>(sycl::range<1>(2), cgh);
+    block_sum_ = sycl::local_accessor<float, 1>(sycl::range<1>(1), cgh);
+  }
+
+  TopKRenormProbsSingleCTA(
+      const DType* probs,
+      DType* renorm_probs,
+      const int64_t* maybe_top_k_arr,
+      int top_k_val,
+      int batch_size,
+      int vocab_size)
+      : probs(probs),
+        renorm_probs(renorm_probs),
+        maybe_top_k_arr(maybe_top_k_arr),
+        top_k_val(top_k_val),
+        batch_size(batch_size),
+        vocab_size(vocab_size) {}
+
+  [[sycl::reqd_sub_group_size(32)]]
+  void operator()(sycl::nd_item<1> item) const {
+    const uint32_t row_idx = item.get_group(0);
+    if (row_idx >= static_cast<uint32_t>(batch_size)) return;
+
+    const uint32_t tid = item.get_local_id(0);
+    const uint32_t vocab_u32 = static_cast<uint32_t>(vocab_size);
+
+    uint32_t k = maybe_top_k_arr ? static_cast<uint32_t>(maybe_top_k_arr[row_idx]) : static_cast<uint32_t>(top_k_val);
+    if (k > vocab_u32) k = vocab_u32;
+
+    const size_t row_offset = static_cast<size_t>(row_idx) * static_cast<size_t>(vocab_u32);
+    sycl::sub_group sg = item.get_sub_group();
+    const uint32_t sg_id = sg.get_group_id()[0];
+    const uint32_t sg_lid = sg.get_local_id()[0];
+
+    if (tid == 0) {
+      scalars_[0] = 0u;
+      scalars_[1] = k;
+    }
+    item.barrier(sycl::access::fence_space::local_space);
+
+    for (uint32_t round = 0u; round < kNumRounds; ++round) {
+      const uint32_t prefix = scalars_[0];
+      const uint32_t remaining_k = scalars_[1];
+      const uint32_t shift = kOrderedBits - (round + 1u) * Traits::kRadixBits;
+
+      const OrderedType prefix_mask =
+          (round == 0) ? OrderedType(0)
+                       : static_cast<OrderedType>(~OrderedType(0) << (kOrderedBits - round * Traits::kRadixBits));
+
+      for (uint32_t i = tid; i < kNumSubGroups * kRadix; i += kWgSize) {
+        subgroup_hist_[i] = 0u;
+      }
+      item.barrier(sycl::access::fence_space::local_space);
+
+      const uint32_t hist_base = sg_id * kRadix;
+
+      for (uint32_t col = tid; col < vocab_u32; col += kWgSize) {
+        const OrderedType ordered = Traits::to_ordered(probs[row_offset + col]);
+        if ((ordered & prefix_mask) == static_cast<OrderedType>(prefix)) {
+          const uint32_t bucket = (ordered >> shift) & 0xFFu;
+          sycl::atomic_ref<
+              uint32_t,
+              sycl::memory_order::relaxed,
+              sycl::memory_scope::work_group,
+              sycl::access::address_space::local_space>(subgroup_hist_[hist_base + bucket])
+              .fetch_add(1u);
+        }
+      }
+      item.barrier(sycl::access::fence_space::local_space);
+
+      for (uint32_t bin = tid; bin < kRadix; bin += kWgSize) {
+        uint32_t total = 0u;
+        for (uint32_t s = 0; s < kNumSubGroups; ++s) {
+          total += subgroup_hist_[s * kRadix + bin];
+        }
+        subgroup_hist_[bin] = total;
+      }
+      item.barrier(sycl::access::fence_space::local_space);
+
+      if (tid == 0) {
+        uint32_t bucket = 0u;
+        uint32_t suffix = 0u;
+        for (int i = kRadix - 1; i >= 0; --i) {
+          suffix += subgroup_hist_[i];
+          if (suffix >= remaining_k) {
+            bucket = static_cast<uint32_t>(i);
+            break;
+          }
+        }
+        const uint32_t count_above = suffix - subgroup_hist_[bucket];
+        scalars_[0] = prefix | (bucket << shift);
+        scalars_[1] = remaining_k - count_above;
+      }
+      item.barrier(sycl::access::fence_space::local_space);
+    }
+
+    const float pivot = static_cast<float>(Traits::from_ordered(static_cast<OrderedType>(scalars_[0])));
+
+    if (tid == 0) block_sum_[0] = 0.0f;
+    item.barrier(sycl::access::fence_space::local_space);
+
+    constexpr uint32_t kVecSize = 4;
+    using vec_in = vec_t<DType, kVecSize>;
+    const uint32_t num_vec_elems = vocab_u32 / kVecSize;
+    const uint32_t vec_tail_start = num_vec_elems * kVecSize;
+
+    float thread_sum = 0.0f;
+    for (uint32_t i = tid; i < num_vec_elems; i += kWgSize) {
+      vec_in v;
+      v.load(0, sycl::multi_ptr<const DType, sycl::access::address_space::global_space>(
+                    probs + row_offset + i * kVecSize));
+      #pragma unroll
+      for (uint32_t j = 0; j < kVecSize; ++j) {
+        float val = static_cast<float>(v[j]);
+        thread_sum += sycl::select(0.0f, val, val >= pivot);
+      }
+    }
+    for (uint32_t col = vec_tail_start + tid; col < vocab_u32; col += kWgSize) {
+      const float val = static_cast<float>(probs[row_offset + col]);
+      thread_sum += sycl::select(0.0f, val, val >= pivot);
+    }
+
+    float warp_sum = sycl::reduce_over_group(sg, thread_sum, sycl::plus<float>());
+    if (sg_lid == 0) {
+      sycl::atomic_ref<
+          float,
+          sycl::memory_order::relaxed,
+          sycl::memory_scope::work_group,
+          sycl::access::address_space::local_space>(block_sum_[0])
+          .fetch_add(warp_sum);
+    }
+    item.barrier(sycl::access::fence_space::local_space);
+
+    const float inv_sum = (block_sum_[0] > 0.0f) ? (1.0f / block_sum_[0]) : 0.0f;
+
+    using vec_out = vec_t<DType, kVecSize>;
+    for (uint32_t i = tid; i < num_vec_elems; i += kWgSize) {
+      vec_in v;
+      v.load(0, sycl::multi_ptr<const DType, sycl::access::address_space::global_space>(
+                    probs + row_offset + i * kVecSize));
+      vec_out out;
+      #pragma unroll
+      for (uint32_t j = 0; j < kVecSize; ++j) {
+        float val = static_cast<float>(v[j]);
+        out[j] = static_cast<DType>(sycl::select(0.0f, val * inv_sum, val >= pivot));
+      }
+      out.store(0, sycl::multi_ptr<DType, sycl::access::address_space::global_space>(
+                       renorm_probs + row_offset + i * kVecSize));
+    }
+    for (uint32_t col = vec_tail_start + tid; col < vocab_u32; col += kWgSize) {
+      const float val = static_cast<float>(probs[row_offset + col]);
+      renorm_probs[row_offset + col] = static_cast<DType>(sycl::select(0.0f, val * inv_sum, val >= pivot));
+    }
+  }
+};
+
+template <typename TensorDType>
+void launch_single_cta_kernel(
+    at::Tensor probs,
+    at::Tensor renorm_probs,
+    const int64_t* maybe_top_k_ptr,
+    int top_k_val,
+    int batch_size,
+    int vocab_size,
+    sycl::queue& queue) {
+  using KernelDType = typename ToSyclElementType<TensorDType>::type;
+
+  auto* probs_ptr = reinterpret_cast<KernelDType*>(probs.data_ptr<TensorDType>());
+  auto* renorm_probs_ptr = reinterpret_cast<KernelDType*>(renorm_probs.data_ptr<TensorDType>());
+
+  const int local_size = 1024;
+  const int global_size = batch_size * local_size;
+
+  auto kernel = TopKRenormProbsSingleCTA<KernelDType>(
+      probs_ptr, renorm_probs_ptr, maybe_top_k_ptr, top_k_val, batch_size, vocab_size);
+
+  sycl_kernel_submit(global_size, local_size, queue, kernel);
+}
+
+void top_k_renorm_probs(
+    const at::Tensor& probs, at::Tensor& renorm_probs, const std::optional<at::Tensor>& maybe_top_k_arr, int64_t top_k_val) {
+  CHECK_INPUT(probs);
+  CHECK_INPUT(renorm_probs);
+  TORCH_CHECK(probs.dim() == 2, "probs must be a 2D tensor [batch_size, vocab_size]");
+  TORCH_CHECK(renorm_probs.dim() == 2, "renorm_probs must be a 2D tensor [batch_size, vocab_size]");
+  TORCH_CHECK(probs.sizes() == renorm_probs.sizes(), "Input tensors must have the same shape");
+  TORCH_CHECK(probs.scalar_type() == renorm_probs.scalar_type(), "Input tensors must have the same dtype");
+  TORCH_CHECK(
+      probs.scalar_type() == torch::kFloat32 || probs.scalar_type() == torch::kHalf ||
+          probs.scalar_type() == torch::kBFloat16,
+      "Input tensors must be float32, float16, or bfloat16");
+
+  if (maybe_top_k_arr.has_value()) {
+    CHECK_INPUT((*maybe_top_k_arr));
+    TORCH_CHECK(maybe_top_k_arr->dim() == 1, "maybe_top_k_arr must be a 1D tensor [batch_size]");
+    TORCH_CHECK(maybe_top_k_arr->size(0) == probs.size(0), "maybe_top_k_arr size must match batch_size");
+    TORCH_CHECK(maybe_top_k_arr->scalar_type() == torch::kInt64, "maybe_top_k_arr must be int64");
+    TORCH_CHECK(maybe_top_k_arr->min().item<int64_t>() >= 1, "maybe_top_k_arr values must be >= 1");
+  } else {
+    TORCH_CHECK(top_k_val > 0, "top_k_val must be positive");
+  }
+
+  auto stream = at::xpu::getCurrentXPUStream();
+  auto queue = stream.queue();
+  int batch_size = probs.size(0);
+  int vocab_size = probs.size(1);
+
+  const int64_t* maybe_top_k_ptr = maybe_top_k_arr.has_value() ? maybe_top_k_arr->data_ptr<int64_t>() : nullptr;
+
+  auto dtype = probs.scalar_type();
+
+  if (dtype == torch::kFloat32) {
+    launch_single_cta_kernel<float>(
+        probs, renorm_probs, maybe_top_k_ptr, static_cast<int>(top_k_val), batch_size, vocab_size, queue);
+  } else if (dtype == torch::kHalf) {
+    launch_single_cta_kernel<at::Half>(
+        probs, renorm_probs, maybe_top_k_ptr, static_cast<int>(top_k_val), batch_size, vocab_size, queue);
+  } else if (dtype == torch::kBFloat16) {
+    launch_single_cta_kernel<at::BFloat16>(
+        probs, renorm_probs, maybe_top_k_ptr, static_cast<int>(top_k_val), batch_size, vocab_size, queue);
+  }
+}

--- a/src/sycl/TopKRenormProbs.cpp
+++ b/src/sycl/TopKRenormProbs.cpp
@@ -281,7 +281,7 @@ void launch_single_cta_kernel(
     sycl::queue& queue) {
   using KernelDType = typename ToSyclElementType<TensorDType>::type;
 
-  auto* probs_ptr = reinterpret_cast<KernelDType*>(probs.data_ptr<TensorDType>());
+  const KernelDType* probs_ptr = reinterpret_cast<const KernelDType*>(probs.data_ptr<TensorDType>());
   auto* renorm_probs_ptr = reinterpret_cast<KernelDType*>(renorm_probs.data_ptr<TensorDType>());
 
   const int local_size = 1024;
@@ -311,7 +311,6 @@ void top_k_renorm_probs(
     TORCH_CHECK(maybe_top_k_arr->dim() == 1, "maybe_top_k_arr must be a 1D tensor [batch_size]");
     TORCH_CHECK(maybe_top_k_arr->size(0) == probs.size(0), "maybe_top_k_arr size must match batch_size");
     TORCH_CHECK(maybe_top_k_arr->scalar_type() == torch::kInt64, "maybe_top_k_arr must be int64");
-    TORCH_CHECK(maybe_top_k_arr->min().item<int64_t>() >= 1, "maybe_top_k_arr values must be >= 1");
   } else {
     TORCH_CHECK(top_k_val > 0, "top_k_val must be positive");
   }

--- a/src/sycl/TopKRenormProbs.cpp
+++ b/src/sycl/TopKRenormProbs.cpp
@@ -223,9 +223,10 @@ struct TopKRenormProbsSingleCTA : public __SYCL_KER_CONFIG_CONVENTION__ {
     float thread_sum = 0.0f;
     for (uint32_t i = tid; i < num_vec_elems; i += kWgSize) {
       vec_in v;
-      v.load(0, sycl::multi_ptr<const DType, sycl::access::address_space::global_space>(
-                    probs + row_offset + i * kVecSize));
-      #pragma unroll
+      v.load(
+          0,
+          sycl::multi_ptr<const DType, sycl::access::address_space::global_space>(probs + row_offset + i * kVecSize));
+#pragma unroll
       for (uint32_t j = 0; j < kVecSize; ++j) {
         float val = static_cast<float>(v[j]);
         thread_sum += sycl::select(0.0f, val, val >= pivot);
@@ -252,16 +253,18 @@ struct TopKRenormProbsSingleCTA : public __SYCL_KER_CONFIG_CONVENTION__ {
     using vec_out = vec_t<DType, kVecSize>;
     for (uint32_t i = tid; i < num_vec_elems; i += kWgSize) {
       vec_in v;
-      v.load(0, sycl::multi_ptr<const DType, sycl::access::address_space::global_space>(
-                    probs + row_offset + i * kVecSize));
+      v.load(
+          0,
+          sycl::multi_ptr<const DType, sycl::access::address_space::global_space>(probs + row_offset + i * kVecSize));
       vec_out out;
-      #pragma unroll
+#pragma unroll
       for (uint32_t j = 0; j < kVecSize; ++j) {
         float val = static_cast<float>(v[j]);
         out[j] = static_cast<DType>(sycl::select(0.0f, val * inv_sum, val >= pivot));
       }
-      out.store(0, sycl::multi_ptr<DType, sycl::access::address_space::global_space>(
-                       renorm_probs + row_offset + i * kVecSize));
+      out.store(
+          0,
+          sycl::multi_ptr<DType, sycl::access::address_space::global_space>(renorm_probs + row_offset + i * kVecSize));
     }
     for (uint32_t col = vec_tail_start + tid; col < vocab_u32; col += kWgSize) {
       const float val = static_cast<float>(probs[row_offset + col]);
@@ -294,7 +297,10 @@ void launch_single_cta_kernel(
 }
 
 void top_k_renorm_probs(
-    const at::Tensor& probs, at::Tensor& renorm_probs, const std::optional<at::Tensor>& maybe_top_k_arr, int64_t top_k_val) {
+    const at::Tensor& probs,
+    at::Tensor& renorm_probs,
+    const std::optional<at::Tensor>& maybe_top_k_arr,
+    int64_t top_k_val) {
   CHECK_INPUT(probs);
   CHECK_INPUT(renorm_probs);
   TORCH_CHECK(probs.dim() == 2, "probs must be a 2D tensor [batch_size, vocab_size]");

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -48,6 +48,9 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def("topk_softmax(Tensor! topk_weights, Tensor! topk_indices, Tensor gating_output, bool renormalize) -> ()");
   m.impl("topk_softmax", torch::kXPU, &at::native::xpu::topk_softmax);
 
+  m.def("top_k_renorm_probs(Tensor probs, Tensor! renorm_probs, Tensor? maybe_top_k_arr, int top_k_val) -> ()");
+  m.impl("top_k_renorm_probs", torch::kXPU, &top_k_renorm_probs);
+
   m.def("swiglu_gpt_oss_sigmoid_alpha(Tensor x, float alpha, float limit) -> Tensor");
   m.impl("swiglu_gpt_oss_sigmoid_alpha", torch::kXPU, &swiglu_gpt_oss_sigmoid_alpha);
   m.def(

--- a/tests/run_suite.py
+++ b/tests/run_suite.py
@@ -33,6 +33,7 @@ suites = {
         TestFile("test_per_token_group_quant_8bit_v2.py"),
         TestFile("test_activation.py"),
         TestFile("test_scatter_tokens_to_experts.py"),
+        TestFile("test_sampling.py"),
     ],
 }
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -91,9 +91,10 @@ def torch_top_k_renorm_probs(normalized_prob, k):
     if isinstance(k, torch.Tensor):
         # Per-row k array
         batch_size = normalized_prob.size(0)
+        k_cpu = k.to("cpu").tolist()
         renorm_prob_ground_truth = torch.zeros_like(normalized_prob)
         for i in range(batch_size):
-            k_i = k[i].item()
+            k_i = k_cpu[i]
             sorted_prob, _ = torch.sort(normalized_prob[i:i+1], descending=True)
             pivot = sorted_prob[:, k_i - 1].unsqueeze(-1)
             mask = (normalized_prob[i:i+1] >= pivot).int()
@@ -150,6 +151,8 @@ def test_top_k_renorm_probs_array(batch_size, vocab_size, k_range):
 
     # Create per-row top-k array with varied values
     top_k_arr = torch.randint(k_min, k_max, (batch_size,), dtype=torch.int64, device=f"{device}:0")
+    if torch.any(top_k_arr <= 0):
+        pytest.skip("top_k_arr values should be greater than 0")
 
     # Compute ground truth using unified function
     renorm_prob_ground_truth = torch_top_k_renorm_probs(normalized_prob, top_k_arr)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -131,6 +131,7 @@ def test_top_k_renorm_probs(batch_size, vocab_size, k):
     renorm_prob_ground_truth = torch_top_k_renorm_probs(normalized_prob, k)
 
     renorm_prob = sgl_kernel.top_k_renorm_prob(normalized_prob, k)
+
     torch.testing.assert_close(
         renorm_prob_ground_truth,
         renorm_prob,

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -9,7 +9,7 @@ import utils
 
 device = utils.get_device()
 
-
+@pytest.mark.skip(reason="not implemented")
 @pytest.mark.parametrize("batch_size", [1, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("p", [0.1, 0.5])
@@ -54,6 +54,7 @@ def test_top_k_top_p_joint_sampling_from_probs(batch_size, vocab_size, p):
         ]
 
 
+@pytest.mark.skip(reason="not implemented")
 @pytest.mark.parametrize("batch_size", [1, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("p", [0.1, 0.5, 0.9])
@@ -164,6 +165,7 @@ def test_top_k_renorm_probs_array(batch_size, vocab_size, k_range):
     )
 
 
+@pytest.mark.skip(reason="not implemented")
 @pytest.mark.parametrize("batch_size", [1, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("p", [0.05, 0.1, 0.2, 0.7, 1])

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -9,6 +9,7 @@ import utils
 
 device = utils.get_device()
 
+
 @pytest.mark.skip(reason="not implemented")
 @pytest.mark.parametrize("batch_size", [1, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
@@ -95,10 +96,10 @@ def torch_top_k_renorm_probs(normalized_prob, k):
         renorm_prob_ground_truth = torch.zeros_like(normalized_prob)
         for i in range(batch_size):
             k_i = k_cpu[i]
-            sorted_prob, _ = torch.sort(normalized_prob[i:i+1], descending=True)
+            sorted_prob, _ = torch.sort(normalized_prob[i : i + 1], descending=True)
             pivot = sorted_prob[:, k_i - 1].unsqueeze(-1)
-            mask = (normalized_prob[i:i+1] >= pivot).int()
-            row_result = normalized_prob[i:i+1].clone()
+            mask = (normalized_prob[i : i + 1] >= pivot).int()
+            row_result = normalized_prob[i : i + 1].clone()
             row_result[mask == 0] = 0
             row_result = row_result / row_result.sum(dim=-1, keepdim=True)
             renorm_prob_ground_truth[i] = row_result[0]
@@ -110,8 +111,9 @@ def torch_top_k_renorm_probs(normalized_prob, k):
         mask = (normalized_prob >= pivot).int()
         renorm_prob_ground_truth = normalized_prob.clone()
         renorm_prob_ground_truth[mask == 0] = 0
-        renorm_prob_ground_truth = renorm_prob_ground_truth / renorm_prob_ground_truth.sum(
-            dim=-1, keepdim=True
+        renorm_prob_ground_truth = (
+            renorm_prob_ground_truth
+            / renorm_prob_ground_truth.sum(dim=-1, keepdim=True)
         )
         return renorm_prob_ground_truth
 
@@ -150,7 +152,9 @@ def test_top_k_renorm_probs_array(batch_size, vocab_size, k_range):
     normalized_prob = pre_norm_prob / pre_norm_prob.sum(dim=-1, keepdim=True)
 
     # Create per-row top-k array with varied values
-    top_k_arr = torch.randint(k_min, k_max, (batch_size,), dtype=torch.int64, device=f"{device}:0")
+    top_k_arr = torch.randint(
+        k_min, k_max, (batch_size,), dtype=torch.int64, device=f"{device}:0"
+    )
     if torch.any(top_k_arr <= 0):
         pytest.skip("top_k_arr values should be greater than 0")
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -80,32 +80,88 @@ def test_top_p_renorm_probs(batch_size, vocab_size, p):
     )
 
 
+def torch_top_k_renorm_probs(normalized_prob, k):
+    """Compute ground truth for top-k renormalization.
+
+    Args:
+        normalized_prob: [batch_size, vocab_size] probabilities
+        k: int or [batch_size] tensor of per-row k values
+    """
+    if isinstance(k, torch.Tensor):
+        # Per-row k array
+        batch_size = normalized_prob.size(0)
+        renorm_prob_ground_truth = torch.zeros_like(normalized_prob)
+        for i in range(batch_size):
+            k_i = k[i].item()
+            sorted_prob, _ = torch.sort(normalized_prob[i:i+1], descending=True)
+            pivot = sorted_prob[:, k_i - 1].unsqueeze(-1)
+            mask = (normalized_prob[i:i+1] >= pivot).int()
+            row_result = normalized_prob[i:i+1].clone()
+            row_result[mask == 0] = 0
+            row_result = row_result / row_result.sum(dim=-1, keepdim=True)
+            renorm_prob_ground_truth[i] = row_result[0]
+        return renorm_prob_ground_truth
+    else:
+        # Scalar k
+        sorted_prob, indices = torch.sort(normalized_prob, descending=True)
+        pivot = sorted_prob[:, k - 1].unsqueeze(-1)
+        mask = (normalized_prob >= pivot).int()
+        renorm_prob_ground_truth = normalized_prob.clone()
+        renorm_prob_ground_truth[mask == 0] = 0
+        renorm_prob_ground_truth = renorm_prob_ground_truth / renorm_prob_ground_truth.sum(
+            dim=-1, keepdim=True
+        )
+        return renorm_prob_ground_truth
+
+
 @pytest.mark.parametrize("batch_size", [1, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("k", [10, 100, 500])
 def test_top_k_renorm_probs(batch_size, vocab_size, k):
+    # Note: SYCL kernel clamps k > vocab_size to vocab_size
     if k > vocab_size:
         pytest.skip("k should be less than vocab_size")
     torch.manual_seed(42)
     pre_norm_prob = torch.rand(batch_size, vocab_size, device=f"{device}:0")
     normalized_prob = pre_norm_prob / pre_norm_prob.sum(dim=-1, keepdim=True)
-    sorted_prob, _ = torch.sort(normalized_prob, descending=True)
-    pivot = sorted_prob[:, k - 1]
-    mask = (normalized_prob >= pivot.unsqueeze(-1)).int()
-    renorm_prob_ground_truth = normalized_prob.clone()
-    renorm_prob_ground_truth[mask == 0] = 0
-    renorm_prob_ground_truth = renorm_prob_ground_truth / renorm_prob_ground_truth.sum(
-        dim=-1, keepdim=True
-    )
+    renorm_prob_ground_truth = torch_top_k_renorm_probs(normalized_prob, k)
 
     renorm_prob = sgl_kernel.top_k_renorm_prob(normalized_prob, k)
-    for i in range(batch_size):
-        torch.testing.assert_close(
-            renorm_prob_ground_truth[i],
-            renorm_prob[i],
-            rtol=1e-3,
-            atol=1e-3,
-        )
+    torch.testing.assert_close(
+        renorm_prob_ground_truth,
+        renorm_prob,
+        rtol=1e-3,
+        atol=1e-3,
+    )
+
+
+@pytest.mark.parametrize("batch_size", [1, 16, 128])
+@pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
+@pytest.mark.parametrize("k_range", [(10, 50), (50, 200)])
+def test_top_k_renorm_probs_array(batch_size, vocab_size, k_range):
+    # Note: SYCL kernel clamps k > vocab_size to vocab_size
+    k_min, k_max = k_range
+    if k_max > vocab_size:
+        pytest.skip("k_max should be less than vocab_size")
+    torch.manual_seed(42)
+    pre_norm_prob = torch.rand(batch_size, vocab_size, device=f"{device}:0")
+    normalized_prob = pre_norm_prob / pre_norm_prob.sum(dim=-1, keepdim=True)
+
+    # Create per-row top-k array with varied values
+    top_k_arr = torch.randint(k_min, k_max, (batch_size,), dtype=torch.int64, device=f"{device}:0")
+
+    # Compute ground truth using unified function
+    renorm_prob_ground_truth = torch_top_k_renorm_probs(normalized_prob, top_k_arr)
+
+    # Test with per-row k array
+    renorm_prob = sgl_kernel.top_k_renorm_prob(normalized_prob, top_k_arr)
+
+    torch.testing.assert_close(
+        renorm_prob_ground_truth,
+        renorm_prob,
+        rtol=1e-3,
+        atol=1e-3,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 99, 989])


### PR DESCRIPTION
**Overview**
This PR adds support for Top-K renormalization kernel on XPU for probability tensors. Supports both scalar top_k value shared across batch and per-row top_k tensor for variable thresholds. The kernel uses a pivot-threshold top-k renormalization strategy per row. 
Radix-select algorithm is used to find the top-k threshold. For each row, a single CTA handles the full selection pipeline: radix passes compute the k-th order statistic (pivot), then the same CTA applies thresholding and renormalization.

**Tests**
`tests/test_sampling.py::test_top_k_renorm_probs`
`tests/test_sampling.py::test_top_k_renorm_probs_array`

**Benchmarking**
|  sl. num  |   batch_size |   vocab_size |   top_k | provider   |   bandwidth_gb_s |       ms |
|---:|-------------:|-------------:|--------:|:-----------|-----------------:|---------:|
|  1 |           99 |         1024 |      10 | sgl_kernel |        12.8259   | 0.063232 |
|  2 |           99 |         1024 |     100 | sgl_kernel |        13.7959   | 0.058786 |
|  3 |           99 |         1024 |     500 | sgl_kernel |        12.3682   | 0.065572 |
|  4 |           99 |        32000 |      10 | sgl_kernel |       105.244    | 0.240812 |
|  5 |           99 |        32000 |     100 | sgl_kernel |       105.586    | 0.240032 |
|  6 |           99 |        32000 |     500 | sgl_kernel |       104.142    | 0.24336  |
|  7 |           99 |       128256 |      10 | sgl_kernel |       144.812    | 0.701454 |
|  8 |           99 |       128256 |     100 | sgl_kernel |       149.311    | 0.680316 |
|  9 |           99 |       128256 |     500 | sgl_kernel |       143.078    | 0.709956 |
| 10 |          989 |         1024 |      10 | sgl_kernel |        16.9926   | 0.476788 |
| 11 |          989 |         1024 |     100 | sgl_kernel |        18.5593   | 0.43654  |
| 12 |          989 |         1024 |     500 | sgl_kernel |        15.6651   | 0.517192 |
| 13 |          989 |        32000 |      10 | sgl_kernel |       128.975    | 1.96305  |
| 14 |          989 |        32000 |     100 | sgl_kernel |       125.892    | 2.01113  |
| 15 |          989 |        32000 |     500 | sgl_kernel |       125.41     | 2.01885  |
| 16 |          989 |       128256 |      10 | sgl_kernel |       156.807    | 6.4714   |
| 17 |          989 |       128256 |     100 | sgl_kernel |       159.63     | 6.35695  |
| 18 |          989 |       128256 |     500 | sgl_kernel |       157.035    | 6.46199  |

**TODO**
Multi-CTA per-row handling will be explored in upcoming PRs to further parallelize radix counting across each row and improve device occupancy, especially for large vocabulary sizes.
