### PR TITLE
Update max experts to 256 for topk_softmax

### DIFF
--- a/src/sycl/TopKSoftMax.cpp
+++ b/src/sycl/TopKSoftMax.cpp
@@ -248,10 +248,32 @@ void topk_softmax(at::Tensor& topk_weights, at::Tensor& topk_indices, at::Tensor
   TORCH_CHECK(topk_weights.scalar_type() == at::kFloat, "topk_weights should be Float");
   TORCH_CHECK(topk_indices.scalar_type() == at::kInt, "topk_indices should be Int");
 
-  constexpr int64_t alignment = 8;
-  int64_t n_experts_aligned = div_up(n_experts, alignment) * alignment;  // align to 8
+  // Validate output tensor shapes
+  TORCH_CHECK(topk_weights.dim() == 2, "topk_weights must be 2D tensor, but got ", topk_weights.dim(), "D");
+  TORCH_CHECK(topk_indices.dim() == 2, "topk_indices must be 2D tensor, but got ", topk_indices.dim(), "D");
+  TORCH_CHECK(
+      topk_weights.size(0) == n_tokens,
+      "topk_weights.size(0) must equal n_tokens, but got ",
+      topk_weights.size(0),
+      " vs ",
+      n_tokens);
+  TORCH_CHECK(
+      topk_indices.size(0) == n_tokens,
+      "topk_indices.size(0) must equal n_tokens, but got ",
+      topk_indices.size(0),
+      " vs ",
+      n_tokens);
 
   int64_t n_topk = topk_weights.size(1);
+  TORCH_CHECK(
+      topk_indices.size(1) == n_topk,
+      "topk_indices.size(1) must equal topk_weights.size(1), but got ",
+      topk_indices.size(1),
+      " vs ",
+      n_topk);
+
+  constexpr int64_t alignment = 8;
+  int64_t n_experts_aligned = div_up(n_experts, alignment) * alignment;  // align to 8
   constexpr int64_t kernel_max_topk = TopKSoftmaxImpl::FusedTopkSoftmax<float>::malloc_per_item;
   auto max_topk = n_experts < kernel_max_topk ? n_experts : kernel_max_topk;
   TORCH_CHECK(

--- a/src/sycl/TopKSoftMax.cpp
+++ b/src/sycl/TopKSoftMax.cpp
@@ -252,9 +252,16 @@ void topk_softmax(at::Tensor& topk_weights, at::Tensor& topk_indices, at::Tensor
   int64_t n_experts_aligned = div_up(n_experts, alignment) * alignment;  // align to 8
 
   int64_t n_topk = topk_weights.size(1);
-  // The max topk value is 8, which is constrained by 'malloc_per_item'.
-  auto max_topk = n_experts < 8 ? n_experts : 8;
-  TORCH_CHECK(0 < n_topk && n_topk <= max_topk, "topk must be less than or equal to num_experts and 8");
+  constexpr int64_t kernel_max_topk = TopKSoftmaxImpl::FusedTopkSoftmax<float>::malloc_per_item;
+  auto max_topk = n_experts < kernel_max_topk ? n_experts : kernel_max_topk;
+  TORCH_CHECK(
+      0 < n_topk && n_topk <= max_topk,
+      "n_topk must satisfy 0 < n_topk <= min(n_experts, ",
+      kernel_max_topk,
+      "), but got n_topk=",
+      n_topk,
+      " and n_experts=",
+      n_experts);
 
   AT_DISPATCH_REDUCED_FLOATING_TYPES(gating_output.scalar_type(), "fused_topk_softmax_kernel", [&]() {
     TopKSoftmaxImpl::fused_topk_softmax<scalar_t>(

--- a/src/sycl/TopKSoftMax.cpp
+++ b/src/sycl/TopKSoftMax.cpp
@@ -243,7 +243,7 @@ void topk_softmax(at::Tensor& topk_weights, at::Tensor& topk_indices, at::Tensor
   int64_t n_tokens = shape[0];
   int64_t n_experts = shape[1];
 
-  TORCH_CHECK(n_experts <= 128, "n_experts only support up to 128, but got ", n_experts);
+  TORCH_CHECK(n_experts <= 256, "n_experts only support up to 256, but got ", n_experts);
 
   TORCH_CHECK(topk_weights.scalar_type() == at::kFloat, "topk_weights should be Float");
   TORCH_CHECK(topk_indices.scalar_type() == at::kInt, "topk_indices should be Int");
@@ -252,6 +252,9 @@ void topk_softmax(at::Tensor& topk_weights, at::Tensor& topk_indices, at::Tensor
   int64_t n_experts_aligned = div_up(n_experts, alignment) * alignment;  // align to 8
 
   int64_t n_topk = topk_weights.size(1);
+  // The max topk value is 8, which is constrained by 'malloc_per_item'.
+  auto max_topk = n_experts < 8 ? n_experts : 8;
+  TORCH_CHECK(0 < n_topk && n_topk <= max_topk, "topk must be less than or equal to num_experts and 8");
 
   AT_DISPATCH_REDUCED_FLOATING_TYPES(gating_output.scalar_type(), "fused_topk_softmax_kernel", [&]() {
     TopKSoftmaxImpl::fused_topk_softmax<scalar_t>(

--- a/tests/test_topk_softmax.py
+++ b/tests/test_topk_softmax.py
@@ -32,7 +32,7 @@ def fused_topk_torch_native(
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("n_token", [2, 32, 4096])
-@pytest.mark.parametrize("n_expert", [8, 32])
+@pytest.mark.parametrize("n_expert", [8, 32, 256])
 @pytest.mark.parametrize("n_topk", [1, 2, 4])
 @pytest.mark.parametrize("renormalize", [False, True])
 def test_topk_softmax(dtype, n_token, n_topk, n_expert, renormalize):


### PR DESCRIPTION
Some models have larger num experts than 128, such as Qwen3.5-35B-A3B(256).