### PR TITLE
Fix RoPE kernel buffer overflow with multi-dimensional positions tensor

### DIFF
--- a/src/sycl/Rope.cpp
+++ b/src/sycl/Rope.cpp
@@ -465,6 +465,11 @@ std::tuple<at::Tensor, at::Tensor> rotary_embedding(
   TORCH_CHECK(
       input_dim == 2 || input_dim == 3,
       " Query/Key must be 2D [num_tokens, num_heads*head_size] or 3D [num_tokens, num_heads, head_size] tensor");
+  TORCH_CHECK(
+      positions.dim() == 1 || positions.dim() == 2,
+      "positions must be 1D [num_tokens] or 2D [num_dims, num_tokens], got ",
+      positions.dim(),
+      "D");
   if (input_dim == 2) {
     rotary_embedding_2D_kernel_impl(positions, query, key, head_size, cos_sin_cache, is_neox, rotary_dim);
     return {query, key};

--- a/src/sycl/Rope.cpp
+++ b/src/sycl/Rope.cpp
@@ -235,6 +235,7 @@ void launch_rotary_embedding(
     cgh.parallel_for(range, task);
   };
   Q.submit(cgf);
+  Q.wait_and_throw();
 }
 
 template <typename T>
@@ -332,7 +333,7 @@ void rotary_embedding_2D_kernel_impl(
     const at::Tensor& cos_sin_cache,  // [max_position, rot_dim]
     bool is_neox,
     int64_t rot_dim) {
-  int64_t num_tokens = positions.view(-1).size(0);
+  int64_t num_tokens = query.size(0);
   int64_t num_heads = query.size(-1) / head_size;
   int64_t num_kv_heads = key.size(-1) / head_size;
   int64_t query_stride = query.stride(-2);
@@ -387,6 +388,7 @@ void rotary_embedding_2D_kernel_impl(
           }
         };
         dpcppGetCurrentQueue().submit(cgf);
+        dpcppGetCurrentQueue().wait_and_throw();
       });
 }
 

--- a/src/sycl/Rope.cpp
+++ b/src/sycl/Rope.cpp
@@ -235,7 +235,6 @@ void launch_rotary_embedding(
     cgh.parallel_for(range, task);
   };
   Q.submit(cgf);
-  Q.wait_and_throw();
 }
 
 template <typename T>
@@ -388,7 +387,6 @@ void rotary_embedding_2D_kernel_impl(
           }
         };
         dpcppGetCurrentQueue().submit(cgf);
-        dpcppGetCurrentQueue().wait_and_throw();
       });
 }
 

--- a/tests/test_rotary_embedding.py
+++ b/tests/test_rotary_embedding.py
@@ -449,6 +449,7 @@ def test_deepseek_v2_rope():
             torch.testing.assert_close(k_pe, k_pe_clone, atol=atol, rtol=rtol)
 
 
+# Qwen/Qwen2.5-VL-3B-Instruct (Encode-Prefill-Decode(EPD) mode)
 @pytest.mark.parametrize(
     "num_tokens, num_q_heads, num_kv_heads, head_size, num_position_dims",
     [
@@ -512,7 +513,7 @@ def test_rope_multimodal_noncontiguous(
     query_ref = query.clone().contiguous()
     key_ref = key.clone().contiguous()
 
-    # Run the kernel — before the fix, this would overflow and corrupt positions
+    # Run the kernel
     query_out, key_out = torch.ops.sgl_kernel.rotary_embedding(
         positions,
         query,
@@ -522,7 +523,7 @@ def test_rope_multimodal_noncontiguous(
         is_neox_style,
     )
 
-    # Verify positions tensor was NOT corrupted (the primary regression check)
+    # Verify positions tensor was NOT corrupted
     assert torch.equal(positions, positions_clone), (
         f"BUFFER OVERFLOW DETECTED: positions tensor was corrupted by RoPE kernel!\n"
         f"Corrupted entries: {(positions != positions_clone).sum().item()} / {positions.numel()}"

--- a/tests/test_rotary_embedding.py
+++ b/tests/test_rotary_embedding.py
@@ -449,5 +449,100 @@ def test_deepseek_v2_rope():
             torch.testing.assert_close(k_pe, k_pe_clone, atol=atol, rtol=rtol)
 
 
+@pytest.mark.parametrize(
+    "num_tokens, num_q_heads, num_kv_heads, head_size, num_position_dims",
+    [
+        (54, 16, 2, 128, 3),
+        (50, 16, 2, 128, 3),
+        (32, 8, 1, 64, 2),
+        (128, 32, 8, 128, 3),
+    ],
+)
+def test_rope_multimodal_noncontiguous(
+    num_tokens: int,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    num_position_dims: int,
+):
+    """
+    Regression test for buffer overflow when:
+    1. positions is multi-dimensional [num_dims, num_tokens] (multimodal)
+    2. query/key are non-contiguous views (stride != shape) from a shared QKV buffer
+
+    """
+    torch.manual_seed(42)
+    max_position = 256
+    rotary_dim = head_size
+    is_neox_style = True
+
+    # Build cos_sin_cache
+    inv_freq = 1.0 / (
+        10000 ** (torch.arange(0, rotary_dim, 2, dtype=torch.float) / rotary_dim)
+    )
+    t = torch.arange(max_position, dtype=torch.float)
+    freqs = torch.einsum("i,j->ij", t, inv_freq)
+    cos_sin_cache = (
+        torch.cat((freqs.cos(), freqs.sin()), dim=-1).to(torch.bfloat16).to(device)
+    )
+
+    # Multi-dimensional positions tensor [num_dims, num_tokens] — the trigger
+    positions = torch.randint(
+        0, max_position, (num_position_dims, num_tokens), device=device
+    )
+    positions_clone = positions.clone()
+
+    # Simulate the real scenario: q and k are non-contiguous slices of a shared QKV buffer
+    # Total dim per token = num_q_heads * head_size + num_kv_heads * head_size
+    q_dim = num_q_heads * head_size
+    k_dim = num_kv_heads * head_size
+    total_dim = q_dim + k_dim  # stride will be total_dim, but q/k shapes are subsets
+
+    qkv = torch.randn(num_tokens, total_dim, dtype=torch.bfloat16, device=device)
+    query = qkv[:, :q_dim]  # shape [N, q_dim], stride (total_dim, 1)
+    key = qkv[:, q_dim : q_dim + k_dim]  # shape [N, k_dim], stride (total_dim, 1)
+
+    assert not query.is_contiguous(), "query must be non-contiguous for this test"
+    assert not key.is_contiguous(), "key must be non-contiguous for this test"
+    assert (
+        query.stride(0) == total_dim
+    ), f"Expected stride {total_dim}, got {query.stride(0)}"
+
+    # Save contiguous copies BEFORE calling the kernel (2D path modifies in-place)
+    query_ref = query.clone().contiguous()
+    key_ref = key.clone().contiguous()
+
+    # Run the kernel — before the fix, this would overflow and corrupt positions
+    query_out, key_out = torch.ops.sgl_kernel.rotary_embedding(
+        positions,
+        query,
+        key,
+        head_size,
+        cos_sin_cache,
+        is_neox_style,
+    )
+
+    # Verify positions tensor was NOT corrupted (the primary regression check)
+    assert torch.equal(positions, positions_clone), (
+        f"BUFFER OVERFLOW DETECTED: positions tensor was corrupted by RoPE kernel!\n"
+        f"Corrupted entries: {(positions != positions_clone).sum().item()} / {positions.numel()}"
+    )
+
+    # Verify correctness: compare against reference implementation using first position dim
+    # (The 2D kernel uses positions[token_id] sequentially — for multi-dim positions the
+    # underlying flat memory starts with the first row.)
+    pos_flat = positions[0]
+    rope = RotaryEmbedding(
+        head_size, rotary_dim, max_position, 10000, is_neox_style, torch.bfloat16
+    ).to(device)
+    rope.cos_sin_cache = cos_sin_cache
+
+    query_ref_out, key_ref_out = rope.forward_native(pos_flat, query_ref, key_ref)
+
+    atol = rtol = precision[torch.bfloat16]
+    torch.testing.assert_close(query_out, query_ref_out, atol=atol, rtol=rtol)
+    torch.testing.assert_close(key_out, key_ref_out, atol=atol, rtol=rtol)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))

--- a/tests/test_rotary_embedding.py
+++ b/tests/test_rotary_embedding.py
@@ -494,14 +494,25 @@ def test_rope_multimodal_noncontiguous(
     positions_clone = positions.clone()
 
     # Simulate the real scenario: q and k are non-contiguous slices of a shared QKV buffer
-    # Total dim per token = num_q_heads * head_size + num_kv_heads * head_size
+    # Allocate extra guard rows beyond num_tokens filled with a sentinel value.
+    # If the kernel overflows (writes past valid rows), the guard region gets corrupted.
     q_dim = num_q_heads * head_size
     k_dim = num_kv_heads * head_size
-    total_dim = q_dim + k_dim  # stride will be total_dim, but q/k shapes are subsets
+    total_dim = q_dim + k_dim
+    guard_rows = num_tokens * (
+        num_position_dims - 1
+    )  # exact overflow the bug would cause
+    sentinel = -31.75  # arbitrary value unlikely to appear from RoPE math
 
-    qkv = torch.randn(num_tokens, total_dim, dtype=torch.bfloat16, device=device)
-    query = qkv[:, :q_dim]  # shape [N, q_dim], stride (total_dim, 1)
-    key = qkv[:, q_dim : q_dim + k_dim]  # shape [N, k_dim], stride (total_dim, 1)
+    qkv = torch.randn(
+        num_tokens + guard_rows, total_dim, dtype=torch.bfloat16, device=device
+    )
+    qkv[num_tokens:, :] = sentinel  # fill guard region
+
+    query = qkv[:num_tokens, :q_dim]  # shape [N, q_dim], stride (total_dim, 1)
+    key = qkv[
+        :num_tokens, q_dim : q_dim + k_dim
+    ]  # shape [N, k_dim], stride (total_dim, 1)
 
     assert not query.is_contiguous(), "query must be non-contiguous for this test"
     assert not key.is_contiguous(), "key must be non-contiguous for this test"
@@ -523,10 +534,12 @@ def test_rope_multimodal_noncontiguous(
         is_neox_style,
     )
 
-    # Verify positions tensor was NOT corrupted
-    assert torch.equal(positions, positions_clone), (
-        f"BUFFER OVERFLOW DETECTED: positions tensor was corrupted by RoPE kernel!\n"
-        f"Corrupted entries: {(positions != positions_clone).sum().item()} / {positions.numel()}"
+    # Deterministic overflow check: guard rows in the same storage must be untouched
+    guard_region = qkv[num_tokens:, :]
+    corrupted = (guard_region != sentinel).sum().item()
+    assert corrupted == 0, (
+        f"BUFFER OVERFLOW DETECTED: guard region after valid rows was overwritten!\n"
+        f"Corrupted elements: {corrupted} / {guard_region.numel()}"
     )
 
     # Verify correctness: compare against reference implementation using first position dim


### PR DESCRIPTION
- Fix buffer overflow in the 2D RoPE kernel that corrupts adjacent memory (positions tensor) when `positions` is multi-dimensional `[num_dims, num_tokens]` (multimodal disaggregation)
- Root cause: `num_tokens` was computed as `positions.view(-1).size(0)` which flattens all dims, launching 3× too many work-groups for a `[3, N]` positions tensor
- Fix: use `query.size(0)` to get the actual token count
- Add regression test with multi-dimensional positions + non-contiguous q/k layout
