### PR TITLE
[Norm] enable different data types of input and weight

### DIFF
--- a/src/sycl/RMSNorm.cpp
+++ b/src/sycl/RMSNorm.cpp
@@ -496,20 +496,23 @@ void rmsnorm(torch::Tensor& output, torch::Tensor& input, torch::Tensor& weight,
 
   SYCL_DISPATCH_FLOATING_TYPES(
       at::ScalarType::Half, at::ScalarType::BFloat16, input.scalar_type(), "RMSNormKernelImpl", [&]() {
-        RMSNormKernelImplInternal<scalar_t, scalar_t>(
-            input,
-            weight_,
-            M,
-            N,
-            static_cast<acc_type<scalar_t>>(eps),
-            output,
-            rstd,
-            in_strides.batch_stride,
-            out_strides.batch_stride,
-            in_strides.inner_size,
-            in_strides.inner_stride,
-            out_strides.inner_size,
-            out_strides.inner_stride);
+        SYCL_DISPATCH_WEIGHT_TYPES(
+            at::ScalarType::Half, at::ScalarType::BFloat16, weight_.scalar_type(), "RMSNormKernelImpl", [&]() {
+              RMSNormKernelImplInternal<scalar_t, weight_t>(
+                  input,
+                  weight_,
+                  M,
+                  N,
+                  static_cast<acc_type<scalar_t>>(eps),
+                  output,
+                  rstd,
+                  in_strides.batch_stride,
+                  out_strides.batch_stride,
+                  in_strides.inner_size,
+                  in_strides.inner_stride,
+                  out_strides.inner_size,
+                  out_strides.inner_stride);
+            });
       });
 }
 
@@ -527,8 +530,11 @@ void fused_add_rmsnorm(torch::Tensor input, torch::Tensor residual, torch::Tenso
 
   SYCL_DISPATCH_FLOATING_TYPES(
       at::ScalarType::Half, at::ScalarType::BFloat16, input_.scalar_type(), "FusedAddRMSNormKernelImpl", [&]() {
-        FusedAddRMSNormKernelImplInternal<scalar_t, scalar_t>(
-            input_, weight, M, N, static_cast<acc_type<scalar_t>>(eps), rstd, residual_);
+        SYCL_DISPATCH_WEIGHT_TYPES(
+            at::ScalarType::Half, at::ScalarType::BFloat16, weight.scalar_type(), "FusedAddRMSNormKernelImpl", [&]() {
+              FusedAddRMSNormKernelImplInternal<scalar_t, weight_t>(
+                  input_, weight, M, N, static_cast<acc_type<scalar_t>>(eps), rstd, residual_);
+            });
       });
 }
 
@@ -544,20 +550,23 @@ void gemma_rmsnorm(torch::Tensor& output, torch::Tensor& input, torch::Tensor& w
 
   SYCL_DISPATCH_FLOATING_TYPES(
       at::ScalarType::Half, at::ScalarType::BFloat16, input.scalar_type(), "GemmaRMSNormKernelImpl", [&]() {
-        GemmaRMSNormKernelImplInternal<scalar_t, scalar_t>(
-            input,
-            weight_,
-            M,
-            N,
-            static_cast<acc_type<scalar_t>>(eps),
-            output,
-            rstd,
-            in_strides.batch_stride,
-            out_strides.batch_stride,
-            in_strides.inner_size,
-            in_strides.inner_stride,
-            out_strides.inner_size,
-            out_strides.inner_stride);
+        SYCL_DISPATCH_WEIGHT_TYPES(
+            at::ScalarType::Half, at::ScalarType::BFloat16, weight_.scalar_type(), "GemmaRMSNormKernelImpl", [&]() {
+              GemmaRMSNormKernelImplInternal<scalar_t, weight_t>(
+                  input,
+                  weight_,
+                  M,
+                  N,
+                  static_cast<acc_type<scalar_t>>(eps),
+                  output,
+                  rstd,
+                  in_strides.batch_stride,
+                  out_strides.batch_stride,
+                  in_strides.inner_size,
+                  in_strides.inner_stride,
+                  out_strides.inner_size,
+                  out_strides.inner_stride);
+            });
       });
 }
 
@@ -576,8 +585,12 @@ void gemma_fused_add_rmsnorm(torch::Tensor& input, torch::Tensor& residual, torc
 
   SYCL_DISPATCH_FLOATING_TYPES(
       at::ScalarType::Half, at::ScalarType::BFloat16, input_.scalar_type(), "GemmaFusedAddRMSNormKernelImpl", [&]() {
-        GemmaFusedAddRMSNormKernelImplInternal<scalar_t, scalar_t>(
-            input_, weight_, M, N, static_cast<acc_type<scalar_t>>(eps), rstd, residual_);
+        SYCL_DISPATCH_WEIGHT_TYPES(
+            at::ScalarType::Half, at::ScalarType::BFloat16, weight_.scalar_type(), "GemmaFusedAddRMSNormKernelImpl",
+            [&]() {
+              GemmaFusedAddRMSNormKernelImplInternal<scalar_t, weight_t>(
+                  input_, weight_, M, N, static_cast<acc_type<scalar_t>>(eps), rstd, residual_);
+            });
       });
 }
 

--- a/src/sycl/RMSNorm.cpp
+++ b/src/sycl/RMSNorm.cpp
@@ -586,7 +586,10 @@ void gemma_fused_add_rmsnorm(torch::Tensor& input, torch::Tensor& residual, torc
   SYCL_DISPATCH_FLOATING_TYPES(
       at::ScalarType::Half, at::ScalarType::BFloat16, input_.scalar_type(), "GemmaFusedAddRMSNormKernelImpl", [&]() {
         SYCL_DISPATCH_WEIGHT_TYPES(
-            at::ScalarType::Half, at::ScalarType::BFloat16, weight_.scalar_type(), "GemmaFusedAddRMSNormKernelImpl",
+            at::ScalarType::Half,
+            at::ScalarType::BFloat16,
+            weight_.scalar_type(),
+            "GemmaFusedAddRMSNormKernelImpl",
             [&]() {
               GemmaFusedAddRMSNormKernelImplInternal<scalar_t, weight_t>(
                   input_, weight_, M, N, static_cast<acc_type<scalar_t>>(eps), rstd, residual_);

--- a/src/sycl/Utils.h
+++ b/src/sycl/Utils.h
@@ -262,6 +262,27 @@ inline void check_shape(const at::Tensor& a, const at::Tensor& b, const char* a_
     break;                                               \
   }
 
+#define PRIVATE_CASE_WEIGHT_TYPE(enum_type, type, ...) \
+  case enum_type: {                                    \
+    using weight_t = type;                             \
+    __VA_ARGS__();                                     \
+    break;                                             \
+  }
+
+#define SYCL_DISPATCH_WEIGHT_TYPES(SCALARTYPE1, SCALARTYPE2, TYPE, NAME, ...)                             \
+  {                                                                                                       \
+    const auto& the_weight_type = TYPE;                                                                   \
+    at::ScalarType _wt = ::detail::scalar_type(the_weight_type);                                          \
+    switch (_wt) {                                                                                        \
+      PRIVATE_CASE_WEIGHT_TYPE(at::ScalarType::Double, double, __VA_ARGS__)                               \
+      PRIVATE_CASE_WEIGHT_TYPE(at::ScalarType::Float, float, __VA_ARGS__)                                 \
+      PRIVATE_CASE_WEIGHT_TYPE(SCALARTYPE1, decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE1>::t), __VA_ARGS__) \
+      PRIVATE_CASE_WEIGHT_TYPE(SCALARTYPE2, decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE2>::t), __VA_ARGS__) \
+      default:                                                                                            \
+        AT_ERROR(#NAME, " not implemented for weight type '", toString(TYPE), "'");                       \
+    }                                                                                                     \
+  }
+
 #define SYCL_DISPATCH_FLOATING_TYPES_AND2(SCALARTYPE1, SCALARTYPE2, TYPE, NAME, ...)    \
   {                                                                                     \
     const auto& the_type = TYPE;                                                        \

--- a/src/sycl/Utils.h
+++ b/src/sycl/Utils.h
@@ -269,18 +269,18 @@ inline void check_shape(const at::Tensor& a, const at::Tensor& b, const char* a_
     break;                                             \
   }
 
-#define SYCL_DISPATCH_WEIGHT_TYPES(SCALARTYPE1, SCALARTYPE2, TYPE, NAME, ...)                             \
-  {                                                                                                       \
-    const auto& the_weight_type = TYPE;                                                                   \
-    at::ScalarType _wt = ::detail::scalar_type(the_weight_type);                                          \
-    switch (_wt) {                                                                                        \
-      PRIVATE_CASE_WEIGHT_TYPE(at::ScalarType::Double, double, __VA_ARGS__)                               \
-      PRIVATE_CASE_WEIGHT_TYPE(at::ScalarType::Float, float, __VA_ARGS__)                                 \
+#define SYCL_DISPATCH_WEIGHT_TYPES(SCALARTYPE1, SCALARTYPE2, TYPE, NAME, ...)                                      \
+  {                                                                                                                \
+    const auto& the_weight_type = TYPE;                                                                            \
+    at::ScalarType _wt = ::detail::scalar_type(the_weight_type);                                                   \
+    switch (_wt) {                                                                                                 \
+      PRIVATE_CASE_WEIGHT_TYPE(at::ScalarType::Double, double, __VA_ARGS__)                                        \
+      PRIVATE_CASE_WEIGHT_TYPE(at::ScalarType::Float, float, __VA_ARGS__)                                          \
       PRIVATE_CASE_WEIGHT_TYPE(SCALARTYPE1, decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE1>::t), __VA_ARGS__) \
       PRIVATE_CASE_WEIGHT_TYPE(SCALARTYPE2, decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE2>::t), __VA_ARGS__) \
-      default:                                                                                            \
-        AT_ERROR(#NAME, " not implemented for weight type '", toString(TYPE), "'");                       \
-    }                                                                                                     \
+      default:                                                                                                     \
+        AT_ERROR(#NAME, " not implemented for weight type '", toString(TYPE), "'");                                \
+    }                                                                                                              \
   }
 
 #define SYCL_DISPATCH_FLOATING_TYPES_AND2(SCALARTYPE1, SCALARTYPE2, TYPE, NAME, ...)    \

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -379,5 +379,110 @@ def test_gemma_norm_3d_non_flattenable(
     torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
 
 
+###############################################################################
+# Mixed input/weight dtype tests
+###############################################################################
+
+
+@pytest.mark.parametrize("batch_size", [1, 19])
+@pytest.mark.parametrize("hidden_size", [512, 1024, 4096])
+@pytest.mark.parametrize(
+    "input_dtype,weight_dtype",
+    [
+        (torch.float16, torch.float32),
+        (torch.bfloat16, torch.float32),
+    ],
+)
+def test_norm_mixed_dtype(batch_size, hidden_size, input_dtype, weight_dtype):
+    x = torch.randn(batch_size, hidden_size, device=device, dtype=input_dtype)
+    w = torch.randn(hidden_size, device=device, dtype=weight_dtype)
+
+    y_ref = llama_rms_norm(x, w)
+    y = sgl_kernel.rmsnorm(x, w)
+
+    torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("batch_size", [1, 19])
+@pytest.mark.parametrize("hidden_size", [512, 1024, 4096])
+@pytest.mark.parametrize(
+    "input_dtype,weight_dtype",
+    [
+        (torch.float16, torch.float32),
+        (torch.bfloat16, torch.float32),
+    ],
+)
+def test_fused_add_rmsnorm_mixed_dtype(
+    batch_size, hidden_size, input_dtype, weight_dtype
+):
+    eps = 1e-6
+
+    x = torch.randn(batch_size, hidden_size, dtype=input_dtype, device=device)
+    residual = torch.randn_like(x)
+    weight = torch.randn(hidden_size, dtype=weight_dtype, device=device)
+
+    x_native, residual_native = fused_add_rms_norm(
+        x.clone(), residual.clone(), weight, eps
+    )
+
+    x_fused = x.clone()
+    residual_fused = residual.clone()
+    sgl_kernel.fused_add_rmsnorm(x_fused, residual_fused, weight, eps)
+
+    tol = 1e-2 if input_dtype == torch.bfloat16 else 1e-3
+    torch.testing.assert_close(x_fused, x_native, rtol=tol, atol=tol)
+    torch.testing.assert_close(residual_fused, residual_native, rtol=tol, atol=tol)
+
+
+@pytest.mark.parametrize("batch_size", [1, 19])
+@pytest.mark.parametrize("hidden_size", [512, 1024, 4096])
+@pytest.mark.parametrize(
+    "input_dtype,weight_dtype",
+    [
+        (torch.float16, torch.float32),
+        (torch.bfloat16, torch.float32),
+    ],
+)
+def test_gemma_norm_mixed_dtype(batch_size, hidden_size, input_dtype, weight_dtype):
+    x = torch.randn(batch_size, hidden_size, device=device, dtype=input_dtype)
+    w = torch.randn(hidden_size, device=device, dtype=weight_dtype)
+
+    y_ref = gemma_rms_norm(x, w)
+    y = sgl_kernel.gemma_rmsnorm(x, w)
+
+    torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("batch_size", [1, 19])
+@pytest.mark.parametrize("hidden_size", [512, 1024, 4096])
+@pytest.mark.parametrize(
+    "input_dtype,weight_dtype",
+    [
+        (torch.float16, torch.float32),
+        (torch.bfloat16, torch.float32),
+    ],
+)
+def test_gemma_fused_add_rmsnorm_mixed_dtype(
+    batch_size, hidden_size, input_dtype, weight_dtype
+):
+    eps = 1e-6
+
+    x = torch.randn(batch_size, hidden_size, dtype=input_dtype, device=device)
+    residual = torch.randn_like(x)
+    weight = torch.randn(hidden_size, dtype=weight_dtype, device=device)
+
+    x_native, residual_native = gemma_fused_add_rms_norm(
+        x.clone(), residual.clone(), weight, eps
+    )
+
+    x_fused = x.clone()
+    residual_fused = residual.clone()
+    sgl_kernel.gemma_fused_add_rmsnorm(x_fused, residual_fused, weight, eps)
+
+    tol = 1e-2 if input_dtype == torch.bfloat16 else 1e-3
+    torch.testing.assert_close(x_fused, x_native, rtol=tol, atol=tol)
+    torch.testing.assert_close(residual_fused, residual_native, rtol=tol, atol=tol)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
In gemma4, weight tensors are always f32. The PR infactor norm kernels to accept f32 weight natively.