### PR TITLE
Fix chunkprefill kernel for asymmetric Q/K and V head dimensions

### DIFF
--- a/src/sycl/kernels/chunk_prefill/xe_flash_attn_chunk_prefill_epilogue.hpp
+++ b/src/sycl/kernels/chunk_prefill/xe_flash_attn_chunk_prefill_epilogue.hpp
@@ -297,8 +297,15 @@ class FlashChunkPrefillEpilogue<
     }
     auto store_traits = static_cast<traits_store_O const&>(params.xe_store_o);
     ElementO* base_ptr = (ElementO*)store_traits.base_ptr;
-    auto shape_o = make_shape(static_cast<int>(seq_len_qo), num_heads_q * head_size_vo, 1);
-    StrideO stride_o = cutlass::make_cute_packed_stride(StrideO{}, shape_o);
+    // Use single-head width for O surface so that when TileShapeOutput_N > head_size_vo
+    // (asymmetric head dim), OOB stores are dropped by hardware instead of
+    // overwriting adjacent head output data.
+    // Pitch must remain num_heads_q * head_size_vo (physical stride between seq positions).
+    auto shape_o = make_shape(static_cast<int>(seq_len_qo), static_cast<int>(head_size_vo), 1);
+    StrideO stride_o = make_stride(
+        static_cast<int64_t>(num_heads_q * head_size_vo),
+        cute::Int<1>{},
+        static_cast<int64_t>(num_heads_q * head_size_vo) * static_cast<int64_t>(seq_len_qo));
     auto tensorO = make_tensor(make_gmem_ptr(base_ptr + offset_o), make_layout(shape_o, stride_o));
     XE_Copy_O xe_store_o{XE_Copy_O{}.with(tensorO)};
     return Params{xe_store_o, params.ptr_sink};

--- a/src/sycl/kernels/chunk_prefill/xe_flash_attn_chunk_prefill_mma.hpp
+++ b/src/sycl/kernels/chunk_prefill/xe_flash_attn_chunk_prefill_mma.hpp
@@ -460,9 +460,18 @@ struct FlashChunkPrefillMma<
     auto shape_k_cache = make_shape(
         static_cast<int>(PagedKV ? total_seq_len_kv_cache : seq_len_kv_cache), head_size_qk * num_heads_kv, 1);
     StrideK stride_k_cache = cutlass::make_cute_packed_stride(StrideK{}, shape_k_cache);
+    // Use single-head width for V surface so that when TileShapeOutput_N > head_size_vo
+    // (asymmetric head dim, e.g. d=192, dv=128), OOB reads hit the real surface boundary
+    // and get zero-padded by hardware, instead of reading adjacent head data.
+    // We must NOT use packed stride here because the pitch (stride between seq positions)
+    // is num_heads_kv * head_size_vo (interleaved heads), not head_size_vo.
     auto shape_v_cache = make_shape(
-        head_size_vo * num_heads_kv, static_cast<int>(PagedKV ? total_seq_len_kv_cache : seq_len_kv_cache), 1);
-    StrideV stride_v_cache = cutlass::make_cute_packed_stride(StrideV{}, shape_v_cache);
+        static_cast<int>(head_size_vo), static_cast<int>(PagedKV ? total_seq_len_kv_cache : seq_len_kv_cache), 1);
+    StrideV stride_v_cache = make_stride(
+        cute::Int<1>{},
+        static_cast<int64_t>(num_heads_kv * head_size_vo),
+        static_cast<int64_t>(num_heads_kv * head_size_vo) *
+            static_cast<int64_t>(PagedKV ? total_seq_len_kv_cache : seq_len_kv_cache));
     auto tensorQ = make_tensor(make_gmem_ptr(q_ptr + offset_q), make_layout(shape_q, stride_q));
     auto tensorK_cache =
         make_tensor(make_gmem_ptr(k_cache_ptr + offset_k_cache), make_layout(shape_k_cache, stride_k_cache));

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -347,8 +347,9 @@ def generate_qkv(
     assert not (kvpacked and qkvpacked)
     batch_size, seqlen_q, nheads, d = q.shape
     _, seqlen_k, nheads_k, _ = k.shape
+    dv = v.shape[-1]
     assert k.shape == (batch_size, seqlen_k, nheads_k, d)
-    assert v.shape == (batch_size, seqlen_k, nheads_k, d)
+    assert v.shape == (batch_size, seqlen_k, nheads_k, dv)
     if query_unused_mask is not None or key_unused_mask is not None:
         assert not kvpacked
         assert not qkvpacked
@@ -1530,7 +1531,7 @@ def _generate_block_kvcache(
 # @pytest.mark.parametrize('d', [32, 40, 64, 80, 96, 128])
 # @pytest.mark.parametrize("d", [64, 96, 128])
 # @pytest.mark.parametrize("d", COMPILED_HDIMS)
-@pytest.mark.parametrize("d", [128])
+@pytest.mark.parametrize("d", [128, 192])
 @pytest.mark.parametrize(
     "seqlen_q,seqlen_k",
     [


### PR DESCRIPTION
When Q/K head_dim (d) differs from V head_dim (dv), e.g. d=192, dv=128 as used in MLA ragged prefill, the chunkprefill kernel produced incorrect results.

Root cause: The V load and O store 2D surfaces in get_updated_copies() used multi-head width (num_heads_kv * dv for V, num_heads_q * dv for O) even though the base pointer was already offset to the current head. When TileShapeOutput_N (set to d=192) exceeded dv (128), the extra tile coordinates fell within the valid surface but accessed data from adjacent heads instead of being zero-padded by hardware OOB handling.

Fix: Narrow V and O surface widths to single-head (dv) while preserving the physical pitch (num_heads * dv) via explicit strides instead of packed strides. This ensures coordinates beyond dv hit the real surface boundary, triggering hardware zero-padding for V reads and silent drop for O stores.

Also adds d=192 to test_flash_attn_varlen_output parametrization and fixes generate_qkv() to accept asymmetric V head dimensions (dv != d).