### PR TITLE
Embedding LoRA A Fwd Kernel

### DIFF
--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -75,6 +75,7 @@ jobs:
               python3 bench_scatter_tokens_to_experts.py 2>&1 | tee bench_scatter_tokens_to_experts.py.log \
               python3 bench_top_k_renorm_probs.py 2>&1 | tee bench_top_k_renorm_probs.py.log \
               python3 bench_hc_split_sinkhorn.py 2>&1 | tee bench_hc_split_sinkhorn.py.log \
+              python3 bench_embedding_lora_a_fwd.py.py 2>&1 | tee bench_embedding_lora_a_fwd.py.log \
             "
 
       - name: Copy logs from container

--- a/benchmark/bench_embedding_lora_a_fwd.py
+++ b/benchmark/bench_embedding_lora_a_fwd.py
@@ -1,5 +1,4 @@
 import argparse
-import math
 from typing import Any, Dict, List, Tuple
 
 import pandas as pd
@@ -420,33 +419,7 @@ def _count_token_classes(
     return base, extra, oor
 
 
-def _estimate_bytes_sgl(
-    num_tokens: int,
-    num_segments: int,
-    max_rank: int,
-    elem_size: int,
-    rank_sum: int,
-) -> float:
-    """Memory traffic estimate for the C++ SGL kernel."""
-    binary_iters = math.ceil(math.log2(max(num_segments, 1)))
-    bytes_seg_indptr = num_tokens * 2 * binary_iters * 4
-    bytes_input_ids = num_tokens * 8
-    bytes_weight_indices = num_tokens * 4
-    bytes_lora_ranks = num_tokens * 4
-    bytes_embedding_reads = rank_sum * elem_size
-    bytes_out = num_tokens * max_rank * elem_size
-
-    return (
-        bytes_seg_indptr
-        + bytes_input_ids
-        + bytes_weight_indices
-        + bytes_lora_ranks
-        + bytes_embedding_reads
-        + bytes_out
-    )
-
-
-def _estimate_bytes_triton(
+def _estimate_bytes(
     num_tokens: int,
     num_segments: int,
     max_rank: int,
@@ -717,14 +690,7 @@ def benchmark(case_id, provider):
     num_segments = min(case["num_segments"], case["num_tokens"])
     elem_size = torch.tensor([], dtype=dtype).element_size()
 
-    # total_bytes_sgl = _estimate_bytes_sgl(
-    # 	num_tokens=case["num_tokens"],
-    # 	num_segments=num_segments,
-    # 	max_rank=case["max_rank"],
-    # 	elem_size=elem_size,
-    # 	rank_sum=rank_sum,
-    # )
-    total_bytes = _estimate_bytes_triton(
+    total_bytes = _estimate_bytes(
         num_tokens=case["num_tokens"],
         num_segments=num_segments,
         max_rank=case["max_rank"],

--- a/benchmark/bench_embedding_lora_a_fwd.py
+++ b/benchmark/bench_embedding_lora_a_fwd.py
@@ -1,0 +1,871 @@
+import argparse
+import math
+from typing import Any, Dict, List, Tuple
+
+import pandas as pd
+import torch
+import triton
+import triton.language as tl
+from sgl_kernel.lora import embedding_lora_a_fwd
+
+all_results = []
+
+DEFAULT_CASES: List[Dict[str, int]] = [
+    {
+        "num_tokens": 384,
+        "num_segments": 1,
+        "num_loras": 2,
+        "max_rank": 48,
+        "vocab_size": 36864,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 512,
+        "num_segments": 1,
+        "num_loras": 4,
+        "max_rank": 64,
+        "vocab_size": 40960,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 3072,
+        "num_segments": 2,
+        "num_loras": 4,
+        "max_rank": 77,
+        "vocab_size": 49152,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 4608,
+        "num_segments": 8,
+        "num_loras": 2,
+        "max_rank": 96,
+        "vocab_size": 57344,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 6144,
+        "num_segments": 4,
+        "num_loras": 4,
+        "max_rank": 123,
+        "vocab_size": 65536,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 8192,
+        "num_segments": 16,
+        "num_loras": 8,
+        "max_rank": 128,
+        "vocab_size": 73728,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 9216,
+        "num_segments": 32,
+        "num_loras": 4,
+        "max_rank": 175,
+        "vocab_size": 81920,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 10240,
+        "num_segments": 8,
+        "num_loras": 4,
+        "max_rank": 192,
+        "vocab_size": 98304,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 11264,
+        "num_segments": 32,
+        "num_loras": 2,
+        "max_rank": 221,
+        "vocab_size": 65536,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 12288,
+        "num_segments": 64,
+        "num_loras": 8,
+        "max_rank": 256,
+        "vocab_size": 86016,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 14336,
+        "num_segments": 16,
+        "num_loras": 4,
+        "max_rank": 320,
+        "vocab_size": 98304,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 15872,
+        "num_segments": 64,
+        "num_loras": 2,
+        "max_rank": 365,
+        "vocab_size": 110592,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 16384,
+        "num_segments": 32,
+        "num_loras": 4,
+        "max_rank": 448,
+        "vocab_size": 122880,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 18432,
+        "num_segments": 64,
+        "num_loras": 2,
+        "max_rank": 512,
+        "vocab_size": 114688,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 6144,
+        "num_segments": 2,
+        "num_loras": 4,
+        "max_rank": 69,
+        "vocab_size": 53248,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 10240,
+        "num_segments": 4,
+        "num_loras": 2,
+        "max_rank": 144,
+        "vocab_size": 69632,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 14336,
+        "num_segments": 32,
+        "num_loras": 2,
+        "max_rank": 192,
+        "vocab_size": 86016,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 16384,
+        "num_segments": 16,
+        "num_loras": 4,
+        "max_rank": 576,
+        "vocab_size": 98304,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 19456,
+        "num_segments": 64,
+        "num_loras": 4,
+        "max_rank": 640,
+        "vocab_size": 122880,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 5050,
+        "num_segments": 1,
+        "num_loras": 2,
+        "max_rank": 288,
+        "vocab_size": 120832,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 7000,
+        "num_segments": 1,
+        "num_loras": 1,
+        "max_rank": 95,
+        "vocab_size": 118784,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 9500,
+        "num_segments": 2,
+        "num_loras": 4,
+        "max_rank": 230,
+        "vocab_size": 116736,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 12000,
+        "num_segments": 4,
+        "num_loras": 2,
+        "max_rank": 704,
+        "vocab_size": 122880,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 13824,
+        "num_segments": 8,
+        "num_loras": 4,
+        "max_rank": 460,
+        "vocab_size": 110592,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 16384,
+        "num_segments": 16,
+        "num_loras": 8,
+        "max_rank": 384,
+        "vocab_size": 98304,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+    {
+        "num_tokens": 21504,
+        "num_segments": 32,
+        "num_loras": 2,
+        "max_rank": 731,
+        "vocab_size": 121856,
+        "num_extra_tokens": 0,
+        "extra_token_ratio_percent": 0,
+        "out_of_range_ratio_percent": 0,
+    },
+]
+
+
+@triton.jit
+def _embedding_lora_a_kernel(
+    # Pointers to tensors
+    input_ids,
+    weights,
+    output,
+    extra_embeddings,
+    # Dimensions
+    vocab_size,
+    rank,
+    num_loras,
+    # Strides
+    w_stride_0,  # stride for lora index
+    w_stride_1,  # stride for rank
+    w_stride_2,  # stride for vocab
+    output_stride_0,
+    output_stride_1,
+    extra_emb_stride_0,  # stride for lora index
+    extra_emb_stride_1,  # stride for token
+    extra_emb_stride_2,  # stride for hidden dim (= rank for extra embeddings)
+    # Batch info
+    seg_lens,
+    seg_indptr,
+    weight_indices,
+    lora_ranks,
+    # Meta-parameters
+    BLOCK_RANK: tl.constexpr,
+    HAS_EXTRA_EMBEDDINGS: tl.constexpr,
+):
+    """
+    Embedding lookup for LoRA A weights with support for extra tokens.
+
+    Each program handles one token across a block of rank dimensions.
+    Grid: (cdiv(max_len, 1), bs) - one program per token in each batch
+    """
+    batch_id = tl.program_id(axis=1)
+    token_idx = tl.program_id(axis=0)
+
+    w_index = tl.load(weight_indices + batch_id)
+    rank_val = tl.load(lora_ranks + w_index)
+
+    # If rank is 0, skip
+    if rank_val == 0:
+        return
+
+    seg_start = tl.load(seg_indptr + batch_id)
+    seg_len = tl.load(seg_lens + batch_id)
+
+    # Check if this token is within the segment
+    if token_idx >= seg_len:
+        return
+
+    # Load the token ID
+    token_id = tl.load(input_ids + seg_start + token_idx)
+
+    # Process in chunks of BLOCK_RANK dimensions
+    num_blocks = tl.cdiv(rank_val, BLOCK_RANK)
+
+    for block_id in range(num_blocks):
+        rank_offset = tl.arange(0, BLOCK_RANK) + block_id * BLOCK_RANK
+        rank_mask = rank_offset < rank_val
+
+        # Check if this is an extra token
+        is_extra_token = token_id >= vocab_size
+
+        if HAS_EXTRA_EMBEDDINGS and is_extra_token:
+            # Use extra embeddings
+            extra_token_id = token_id - vocab_size
+            extra_emb_ptr = (
+                extra_embeddings
+                + w_index * extra_emb_stride_0
+                + extra_token_id * extra_emb_stride_1
+                + rank_offset * extra_emb_stride_2
+            )
+            emb_values = tl.load(extra_emb_ptr, mask=rank_mask, other=0.0)
+        else:
+            # Use regular LoRA A weights
+            # weights shape: (num_loras, rank, vocab_size)
+            # We need to load weights[w_index, rank_offset, token_id]
+            token_id_clamped = tl.minimum(token_id, vocab_size - 1)
+            weight_ptr = (
+                weights
+                + w_index * w_stride_0
+                + rank_offset * w_stride_1
+                + token_id_clamped * w_stride_2
+            )
+            emb_values = tl.load(weight_ptr, mask=rank_mask, other=0.0)
+
+        # Write to output
+        output_ptr = (
+            output
+            + (seg_start + token_idx) * output_stride_0
+            + rank_offset * output_stride_1
+        )
+        tl.store(output_ptr, emb_values, mask=rank_mask)
+
+
+def _build_seg_indptr(
+    num_tokens: int, num_segments: int, device: torch.device
+) -> torch.Tensor:
+    seg = min(num_segments, num_tokens)
+    lengths = torch.full((seg,), num_tokens // seg, dtype=torch.int32)
+    lengths[: num_tokens % seg] += 1
+    seg_indptr = torch.zeros(seg + 1, dtype=torch.int32)
+    seg_indptr[1:] = torch.cumsum(lengths, dim=0)
+    return seg_indptr.to(device)
+
+
+def _build_seg_lens(seg_indptr: torch.Tensor) -> torch.Tensor:
+    return (seg_indptr[1:] - seg_indptr[:-1]).to(torch.int32)
+
+
+def _compute_rank_sum_by_segment(
+    seg_lens: torch.Tensor,
+    weight_indices: torch.Tensor,
+    lora_ranks: torch.Tensor,
+) -> int:
+    seg_lens_cpu = seg_lens.to("cpu")
+    weight_indices_cpu = weight_indices.to("cpu")
+    lora_ranks_cpu = lora_ranks.to("cpu")
+
+    total_rank = 0
+    for seg_idx in range(weight_indices_cpu.numel()):
+        seg_len = int(seg_lens_cpu[seg_idx].item())
+        lora = int(weight_indices_cpu[seg_idx].item())
+        rank = int(lora_ranks_cpu[lora].item())
+        total_rank += seg_len * rank
+    return total_rank
+
+
+def _count_token_classes(
+    input_ids: torch.Tensor,
+    vocab_size: int,
+    num_extra_tokens: int,
+) -> Tuple[int, int, int]:
+    ids = input_ids.to("cpu")
+    base = int((ids < vocab_size).sum().item())
+    if num_extra_tokens > 0:
+        extra_hi = vocab_size + num_extra_tokens
+        extra = int(((ids >= vocab_size) & (ids < extra_hi)).sum().item())
+    else:
+        extra = 0
+    oor = ids.numel() - base - extra
+    return base, extra, oor
+
+
+def _estimate_bytes_sgl(
+    num_tokens: int,
+    num_segments: int,
+    max_rank: int,
+    elem_size: int,
+    rank_sum: int,
+) -> float:
+    """Memory traffic estimate for the C++ SGL kernel."""
+    binary_iters = math.ceil(math.log2(max(num_segments, 1)))
+    bytes_seg_indptr = num_tokens * 2 * binary_iters * 4
+    bytes_input_ids = num_tokens * 8
+    bytes_weight_indices = num_tokens * 4
+    bytes_lora_ranks = num_tokens * 4
+    bytes_embedding_reads = rank_sum * elem_size
+    bytes_out = num_tokens * max_rank * elem_size
+
+    return (
+        bytes_seg_indptr
+        + bytes_input_ids
+        + bytes_weight_indices
+        + bytes_lora_ranks
+        + bytes_embedding_reads
+        + bytes_out
+    )
+
+
+def _estimate_bytes_triton(
+    num_tokens: int,
+    num_segments: int,
+    max_rank: int,
+    max_len: int,
+    elem_size: int,
+    rank_sum: int,
+) -> float:
+    """Memory traffic estimate for Triton launch semantics."""
+    launched_programs = max_len * num_segments
+    bytes_per_program_meta = 4 + 4 + 4 + 4
+    bytes_metadata = launched_programs * bytes_per_program_meta
+
+    bytes_input_ids = num_tokens * 8
+    bytes_embedding_reads = rank_sum * elem_size
+    bytes_out = num_tokens * max_rank * elem_size
+
+    return bytes_metadata + bytes_input_ids + bytes_embedding_reads + bytes_out
+
+
+def calc_metrics(total_bytes: float, time_ms: float) -> Dict[str, float]:
+    time_s = time_ms / 1e3
+    if time_s <= 0:
+        raise RuntimeError("Measured time must be > 0")
+
+    bandwidth_gbs = (total_bytes / 1e9) / time_s
+    total_bytes_mb = total_bytes / 1e6
+
+    return {
+        "total_bytes": total_bytes,
+        "total_bytes_mb": total_bytes_mb,
+        "bandwidth_gbs": bandwidth_gbs,
+    }
+
+
+def _make_inputs(
+    case: Dict[str, int], dtype: torch.dtype, device: torch.device
+) -> Dict[str, Any]:
+    num_tokens = case["num_tokens"]
+    num_segments = min(case["num_segments"], num_tokens)
+    num_loras = case["num_loras"]
+    max_rank = case["max_rank"]
+    vocab_size = case["vocab_size"]
+    num_extra_tokens = case["num_extra_tokens"]
+    extra_ratio = case["extra_token_ratio_percent"]
+    out_of_range_ratio = case["out_of_range_ratio_percent"]
+
+    input_ids = torch.randint(
+        0, vocab_size, (num_tokens,), dtype=torch.int64, device=device
+    )
+    if num_extra_tokens > 0 and extra_ratio > 0:
+        num_extra = num_tokens * extra_ratio // 100
+        num_extra = min(num_extra, num_tokens)
+        if num_extra > 0:
+            idx = torch.randperm(num_tokens, device=device)[:num_extra]
+            input_ids[idx] = vocab_size + torch.randint(
+                0, num_extra_tokens, (num_extra,), dtype=torch.int64, device=device
+            )
+
+        num_oor = num_tokens * out_of_range_ratio // 100
+        num_oor = min(num_oor, num_tokens)
+        if num_oor > 0:
+            idx_oor = torch.randperm(num_tokens, device=device)[:num_oor]
+            input_ids[idx_oor] = (
+                vocab_size
+                + num_extra_tokens
+                + torch.randint(0, 16, (num_oor,), dtype=torch.int64, device=device)
+            )
+
+    weights = torch.randn(num_loras, max_rank, vocab_size, dtype=dtype, device=device)
+    extra_embeddings = None
+    if num_extra_tokens > 0:
+        extra_embeddings = torch.randn(
+            num_loras, num_extra_tokens, max_rank, dtype=dtype, device=device
+        )
+
+    seg_indptr = _build_seg_indptr(num_tokens, num_segments, device)
+    seg_lens = _build_seg_lens(seg_indptr)
+    weight_indices = torch.randint(
+        0, num_loras, (num_segments,), dtype=torch.int32, device=device
+    )
+    lora_ranks = torch.tensor([max_rank] * num_loras, dtype=torch.int32, device=device)
+
+    return {
+        "input_ids": input_ids,
+        "weights": weights,
+        "vocab_size": vocab_size,
+        "seg_indptr": seg_indptr,
+        "seg_lens": seg_lens,
+        "weight_indices": weight_indices,
+        "lora_ranks": lora_ranks,
+        "extra_embeddings": extra_embeddings,
+    }
+
+
+def _run_sgl_once(args: Dict[str, Any]):
+    return embedding_lora_a_fwd(
+        input_ids=args["input_ids"],
+        weights=args["weights"],
+        vocab_size=int(args["vocab_size"]),
+        seg_indptr=args["seg_indptr"],
+        weight_indices=args["weight_indices"],
+        lora_ranks=args["lora_ranks"],
+        extra_embeddings=args["extra_embeddings"],
+        seg_lens=args["seg_lens"],
+    )
+
+
+def _run_triton_once(args: Dict[str, Any]):
+    input_ids = args["input_ids"]
+    weights = args["weights"]
+    seg_lens = args["seg_lens"]
+    seg_indptr = args["seg_indptr"]
+    weight_indices = args["weight_indices"]
+    lora_ranks = args["lora_ranks"]
+    extra_embeddings = args["extra_embeddings"]
+    vocab_size = int(args["vocab_size"])
+
+    rank = weights.shape[1]
+    max_len = int(seg_lens.max().item()) if seg_lens.numel() > 0 else 0
+    bs = int(seg_lens.numel())
+
+    has_extra_embeddings = extra_embeddings is not None
+    if has_extra_embeddings:
+        extra_embeddings = extra_embeddings.contiguous()
+        extra_emb_stride = (
+            extra_embeddings.stride(0),
+            extra_embeddings.stride(1),
+            extra_embeddings.stride(2),
+        )
+    else:
+        extra_embeddings = torch.empty(
+            (1, 1, 1), device=input_ids.device, dtype=weights.dtype
+        )
+        extra_emb_stride = (1, 1, 1)
+
+    output = torch.zeros(
+        (input_ids.shape[0], rank), device=input_ids.device, dtype=weights.dtype
+    )
+    if max_len == 0 or bs == 0:
+        return output
+
+    grid = (max_len, bs)
+    if has_extra_embeddings:
+        _embedding_lora_a_kernel[grid](
+            input_ids,
+            weights,
+            output,
+            extra_embeddings,
+            vocab_size,
+            rank,
+            weights.shape[0],
+            weights.stride(0),
+            weights.stride(1),
+            weights.stride(2),
+            output.stride(0),
+            output.stride(1),
+            extra_emb_stride[0],
+            extra_emb_stride[1],
+            extra_emb_stride[2],
+            seg_lens,
+            seg_indptr,
+            weight_indices,
+            lora_ranks,
+            BLOCK_RANK=128,  # pyright: ignore[reportArgumentType]
+            HAS_EXTRA_EMBEDDINGS=True,  # pyright: ignore[reportArgumentType]
+        )
+    else:
+        _embedding_lora_a_kernel[grid](
+            input_ids,
+            weights,
+            output,
+            extra_embeddings,
+            vocab_size,
+            rank,
+            weights.shape[0],
+            weights.stride(0),
+            weights.stride(1),
+            weights.stride(2),
+            output.stride(0),
+            output.stride(1),
+            extra_emb_stride[0],
+            extra_emb_stride[1],
+            extra_emb_stride[2],
+            seg_lens,
+            seg_indptr,
+            weight_indices,
+            lora_ranks,
+            BLOCK_RANK=128,  # pyright: ignore[reportArgumentType]
+            HAS_EXTRA_EMBEDDINGS=False,  # pyright: ignore[reportArgumentType]
+        )
+
+    return output
+
+
+def _dtype_from_provider(provider: str) -> torch.dtype:
+    if provider == "fp16":
+        return torch.float16
+    if provider == "bf16":
+        return torch.bfloat16
+    return torch.float32
+
+
+def _case_label(case: Dict[str, int]) -> str:
+    return (
+        f"tok={case['num_tokens']},seg={case['num_segments']},lora={case['num_loras']},"
+        f"r={case['max_rank']},vocab={case['vocab_size']},extra={case['num_extra_tokens']}"
+    )
+
+
+CASES = DEFAULT_CASES
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["case_id"],
+        x_vals=list(range(len(CASES))),
+        x_log=False,
+        line_arg="provider",
+        line_vals=[
+            "sgl_fp16",
+            "triton_fp16",
+            "sgl_bf16",
+            "triton_bf16",
+            "sgl_fp32",
+            "triton_fp32",
+        ],
+        line_names=[
+            "SGL fp16",
+            "Triton fp16",
+            "SGL bf16",
+            "Triton bf16",
+            "SGL fp32",
+            "Triton fp32",
+        ],
+        styles=[
+            ("green", "-"),
+            ("green", "--"),
+            ("blue", "-"),
+            ("blue", "--"),
+            ("orange", "-"),
+            ("orange", "--"),
+        ],
+        ylabel="GB/s",
+        plot_name="embedding-lora-a-fwd-sgl-vs-triton",
+        args={},
+    )
+)
+def benchmark(case_id, provider):
+    device = torch.device("xpu")
+    backend, dtype_name = provider.split("_", 1)
+    dtype = _dtype_from_provider(dtype_name)
+
+    case = CASES[case_id]
+    inputs = _make_inputs(case, dtype, device)
+    rank_sum = _compute_rank_sum_by_segment(
+        inputs["seg_lens"],
+        inputs["weight_indices"],
+        inputs["lora_ranks"],
+    )
+    _, num_extra_in_range, _ = _count_token_classes(
+        inputs["input_ids"],
+        inputs["vocab_size"],
+        case["num_extra_tokens"],
+    )
+    max_len = (
+        int(inputs["seg_lens"].max().item()) if inputs["seg_lens"].numel() > 0 else 0
+    )
+    num_segments = min(case["num_segments"], case["num_tokens"])
+    elem_size = torch.tensor([], dtype=dtype).element_size()
+
+    # total_bytes_sgl = _estimate_bytes_sgl(
+    # 	num_tokens=case["num_tokens"],
+    # 	num_segments=num_segments,
+    # 	max_rank=case["max_rank"],
+    # 	elem_size=elem_size,
+    # 	rank_sum=rank_sum,
+    # )
+    total_bytes = _estimate_bytes_triton(
+        num_tokens=case["num_tokens"],
+        num_segments=num_segments,
+        max_rank=case["max_rank"],
+        max_len=max_len,
+        elem_size=elem_size,
+        rank_sum=rank_sum,
+    )
+    quantiles = [0.5, 0.2, 0.8]
+
+    bench_res = triton.testing.do_bench(
+        (
+            (lambda: _run_sgl_once(inputs))
+            if backend == "sgl"
+            else (lambda: _run_triton_once(inputs))
+        ),
+        quantiles=quantiles,
+    )
+    if bench_res is None:
+        raise RuntimeError("triton.testing.do_bench returned no result")
+    ms, min_ms, max_ms = bench_res
+
+    # metrics = calc_metrics(total_bytes_sgl if backend == "sgl" else total_bytes_triton, ms)
+    metrics = calc_metrics(total_bytes, ms)
+
+    all_results.append(
+        {
+            "case_id": case_id,
+            "case_label": _case_label(case),
+            "provider": provider,
+            "backend": backend,
+            "dtype": str(dtype),
+            "time_us": 1e3 * ms,
+            "time_min_us": 1e3 * min_ms,
+            "time_max_us": 1e3 * max_ms,
+            "bandwidth_gbs": metrics["bandwidth_gbs"],
+            "total_bytes_mb": metrics["total_bytes_mb"],
+            "max_len": max_len,
+            "rank_sum": rank_sum,
+            "extra_tokens_in_range": num_extra_in_range,
+            "num_tokens": case["num_tokens"],
+            "num_segments": case["num_segments"],
+            "num_loras": case["num_loras"],
+            "max_rank": case["max_rank"],
+            "vocab_size": case["vocab_size"],
+        }
+    )
+
+    gbps = lambda t_ms: metrics["total_bytes"] * 1e-9 / (t_ms * 1e-3)
+    return gbps(ms), gbps(max_ms), gbps(min_ms)
+
+
+def _sanity_check() -> None:
+    torch.manual_seed(123)
+    device = torch.device("xpu")
+    case = DEFAULT_CASES[0]
+    args = _make_inputs(case, torch.float32, device)
+    out = _run_sgl_once(args)
+    out_triton = _run_triton_once(args)
+    if out.shape != (case["num_tokens"], case["max_rank"]):
+        raise RuntimeError(
+            f"Unexpected output shape: got {tuple(out.shape)}, expected {(case['num_tokens'], case['max_rank'])}"
+        )
+    if out_triton.shape != out.shape:
+        raise RuntimeError(
+            f"Unexpected Triton output shape: got {tuple(out_triton.shape)}, expected {tuple(out.shape)}"
+        )
+    print("Sanity check passed: output shape looks correct.")
+
+
+def print_summary(title: str = "Embedding LoRA Benchmark Results"):
+    """Print detailed benchmark results in tabular format."""
+    print("\n" + "=" * 120)
+    print(title)
+    print("=" * 120)
+
+    if not all_results:
+        print("No results collected.")
+        return
+
+    df = pd.DataFrame(all_results)
+
+    # Round numeric columns for display
+    for col in ["time_us", "bandwidth_gbs", "total_bytes_mb"]:
+        if col in df.columns:
+            df[col] = df[col].round(2)
+
+    # Select key columns for display
+    display_cols = [
+        col
+        for col in [
+            "case_id",
+            "case_label",
+            "provider",
+            "time_us",
+            "bandwidth_gbs",
+            "total_bytes_mb",
+        ]
+        if col in df.columns
+    ]
+
+    print("\nDetailed Results:")
+    print(df[display_cols].to_string(index=False))
+
+    # Print summary statistics by provider
+    if "provider" in df.columns and "bandwidth_gbs" in df.columns:
+        print("\n" + "=" * 120)
+        print("Summary Statistics by Provider")
+        print("=" * 120)
+        summary = df.groupby("provider")[["bandwidth_gbs", "time_us"]].agg(
+            ["mean", "min", "max", "std"]
+        )
+        print(summary.to_string())
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Benchmark embedding_lora_a_fwd on XPU"
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for reproducible input generation.",
+    )
+    parser.add_argument(
+        "--print-cases",
+        action="store_true",
+        help="Print selected benchmark cases before running.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    torch.manual_seed(args.seed)
+    CASES = DEFAULT_CASES
+    if args.print_cases:
+        for i, c in enumerate(CASES):
+            print(f"case {i}: {_case_label(c)}")
+
+    _sanity_check()
+    benchmark.run(print_data=True)
+    print_summary()
+    print("Benchmark finished!")

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -587,3 +587,18 @@ void qserve_w4a8_per_group_gemm(
     torch::Tensor& _out_feats);
 
 std::tuple<int64_t, int64_t> query_device(int64_t device_index = -1);
+
+/*
+ * From LoRA
+ */
+void embedding_lora_a_fwd(
+    torch::Tensor& output,           // [num_tokens, max_rank]
+    const torch::Tensor& input_ids,  // [num_tokens,]
+    const torch::Tensor& weights,    // [num_loras, max_rank, vocab_size]
+    const int64_t vocab_size,
+    const torch::Tensor& seg_indptr,                       // [num_segments + 1,]
+    const torch::Tensor& weight_indices,                   // [num_segments,]
+    const torch::Tensor& lora_ranks,                       // [num_loras,]
+    const std::optional<torch::Tensor>& extra_embeddings,  // [num_loras, num_extra_tokens, max_rank]
+    const std::optional<torch::Tensor>& seg_lens           // [num_segments,]
+);

--- a/python/sgl_kernel/__init__.py
+++ b/python/sgl_kernel/__init__.py
@@ -50,6 +50,7 @@ from sgl_kernel.gemm import (
     sgl_per_token_quant_fp8,
 )
 from sgl_kernel.grammar import apply_token_bitmask_inplace_cuda
+from sgl_kernel.lora import embedding_lora_a_fwd
 from sgl_kernel.mhc import hc_split_sinkhorn
 from sgl_kernel.moe import (
     apply_shuffle_mul_sum,

--- a/python/sgl_kernel/lora.py
+++ b/python/sgl_kernel/lora.py
@@ -1,0 +1,78 @@
+from typing import Optional
+
+import torch
+
+
+def embedding_lora_a_fwd(
+    input_ids: torch.Tensor,
+    weights: torch.Tensor,
+    vocab_size: int,
+    seg_indptr: torch.Tensor,
+    weight_indices: torch.Tensor,
+    lora_ranks: torch.Tensor,
+    extra_embeddings: Optional[torch.Tensor] = None,
+    seg_lens: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    r"""LoRA embedding forward pass.
+
+    This kernel computes the forward pass for the LoRA embedding layer. Each token
+    is processed independently, and the output is computed based on the LoRA adapter
+    for the corresponding segment.
+
+    Each token `tok = input_ids[i]` belongs to a segment identified by the `seg_indptr` tensor.
+    Corresponding to each segment, there is a LoRA adapter defined by the `weight_indices` tensor.
+    Once the LoRA adapter `l` is identified for a token, the output is computed as follows:
+
+    - The rank of the adapter is determined by `lora_ranks[l]`.
+    - The embedding is zero-padded to match the maximum rank.
+    - If `extra_embeddings` is provided, tokens beyond the vocabulary size are mapped to the extra embeddings.
+
+    Parameters
+    ----------
+    input_ids : torch.Tensor
+        Input tensor containing token IDs, shape ``(num_tokens,)``.
+    weights : torch.Tensor
+        Weight tensor for embeddings, shape ``(num_loras, max_rank, vocab_size)``.
+    vocab_size : int
+        Vocabulary size.
+    seg_indptr : torch.Tensor
+        Segment index pointer tensor, shape ``(num_segments + 1,)``.
+    weight_indices : torch.Tensor
+        Weight indices tensor, shape ``(num_segments,)``.
+    lora_ranks : torch.Tensor
+        LoRA ranks tensor, shape ``(num_loras,)``.
+    extra_embeddings : Optional[torch.Tensor], optional
+        Optional extra embeddings tensor, shape ``(num_loras, num_extra_tokens, max_rank)``.
+    seg_lens : Optional[torch.Tensor], optional
+        Optional segment lengths tensor, shape ``(num_segments,)``.
+
+    Returns
+    -------
+    output : torch.Tensor
+        Output tensor containing the computed embeddings, shape ``(num_tokens, max_rank)``.
+
+    Notes
+    -----
+    - The output tensor is created with zeros in torch and is allocated by the C++ kernel
+    - The output tensor is zero-padded for ranks smaller than `max_rank`.
+    - Tokens with IDs beyond the vocabulary size are mapped to `extra_embeddings` if provided else zero-padded.
+    - Tokens with negative IDs are treated as invalid and their output embeddings are zeroed out.
+    """
+    # Create zero output tensor
+    output = torch.zeros(
+        (input_ids.size(0), weights.size(1)), dtype=weights.dtype, device=weights.device
+    )
+    # Call the kernel
+    torch.ops.sgl_kernel.embedding_lora_a_fwd(
+        output,
+        input_ids,
+        weights,
+        vocab_size,
+        seg_indptr,
+        weight_indices,
+        lora_ranks,
+        extra_embeddings,
+        seg_lens,
+    )
+
+    return output

--- a/src/sycl/EmbeddingLoraAFwd.cpp
+++ b/src/sycl/EmbeddingLoraAFwd.cpp
@@ -27,8 +27,8 @@
 //
 // Notes:
 //   - Negative token ids are skipped (no write).
-//   - This kernel writes only active rank entries; output tail handling
-//     (padding/initialization) is expected to be managed by caller policy.
+//   - Initializes output tensor to zeros to pad inactive rank entries
+//   - Work items write only active rank entries;
 //
 // ============================================================
 
@@ -178,23 +178,14 @@ void launch_embedding_lora_a_fwd(
     const torch::Tensor& weight_indices,
     const torch::Tensor& lora_ranks,
     const std::optional<torch::Tensor>& extra_embeddings,
-    const std::optional<torch::Tensor>& seg_lens,
     torch::Tensor& output,
-    int num_tokens,
-    int max_rank,
-    int num_segments,
-    int num_extra_tokens,
+    const int num_tokens,
+    const int max_rank,
+    const int num_segments,
+    const int num_extra_tokens,
+    const int max_len,
     sycl::queue& queue) {
   using KernelDType = typename ToSyclElementType<TensorDType>::type;
-  // max_len = maximum segment length of all segments
-  int max_len = 0;
-  if (seg_lens.has_value()) {
-    max_len = seg_lens->max().item<int>();
-  } else {
-    auto seg_len_tensor = seg_indptr.slice(0, 1) - seg_indptr.slice(0, 0, seg_indptr.size(0) - 1);
-    max_len = seg_len_tensor.max().item<int>();
-  }
-
   constexpr int BLOCK_TOK = EmbeddingLoRAAFwd<KernelDType>::BLOCK_TOK;
   const int num_tok_blocks = (max_len + BLOCK_TOK - 1) / BLOCK_TOK;
 
@@ -212,7 +203,7 @@ void launch_embedding_lora_a_fwd(
       lora_ranks.data_ptr<int>(),
       extra_embeddings.has_value() ? reinterpret_cast<const KernelDType*>(extra_embeddings->data_ptr<TensorDType>())
                                    : nullptr,
-      seg_lens.has_value() ? seg_lens->data_ptr<int>() : nullptr,
+      nullptr,
       reinterpret_cast<KernelDType*>(output.data_ptr<TensorDType>()),
       vocab_size,
       num_segments,
@@ -265,22 +256,29 @@ void embedding_lora_a_fwd(
   const int64_t num_segments_i64 = seg_indptr.numel() - 1;
   TORCH_CHECK(weight_indices.numel() == num_segments_i64, "weight_indices.numel() must equal seg_indptr.numel() - 1");
   if (num_segments_i64 > 0) {
-    const int64_t min_weight_index = weight_indices.min().item<int64_t>();
-    const int64_t max_weight_index = weight_indices.max().item<int64_t>();
+    auto [min_wi, max_wi] = torch::aminmax(weight_indices);
     TORCH_CHECK(
-        min_weight_index >= 0 && max_weight_index < num_loras_i64,
+        min_wi.item<int64_t>() >= 0 && max_wi.item<int64_t>() < num_loras_i64,
         "weight_indices values must be in [0, weights.size(0))");
   }
-  if (num_tokens_i64 > 0) {
-    TORCH_CHECK(seg_indptr[0].item<int64_t>() == 0, "seg_indptr[0] must be 0");
-    TORCH_CHECK(
-        seg_indptr[seg_indptr.numel() - 1].item<int64_t>() == num_tokens_i64, "seg_indptr[-1] must equal num_tokens");
+  // Validate output tensor size and dtype
+  TORCH_CHECK(
+      output.size(0) == num_tokens_i64 && output.size(1) == max_rank_i64,
+      "Output tensor must have shape (num_tokens, max_rank)");
+  TORCH_CHECK(output.scalar_type() == weights.scalar_type(), "Output tensor dtype must match weights dtype");
+  output.zero_();
+  if (num_tokens_i64 == 0) {
+    return;
   }
-  if (seg_lens.has_value()) {
-    CHECK_INPUT(seg_lens.value());
-    TORCH_CHECK(seg_lens->dim() == 1, "seg_lens must be a 1D tensor");
-    TORCH_CHECK(seg_lens->numel() == num_segments_i64, "seg_lens.numel() must equal num_segments");
-  }
+
+  TORCH_CHECK(seg_indptr[0].item<int64_t>() == 0, "seg_indptr[0] must be 0");
+  TORCH_CHECK(
+      seg_indptr[seg_indptr.numel() - 1].item<int64_t>() == num_tokens_i64, "seg_indptr[-1] must equal num_tokens");
+  auto seg_len_tensor = seg_indptr.slice(0, 1) - seg_indptr.slice(0, 0, seg_indptr.size(0) - 1);
+  auto [seg_len_min, seg_len_max] = torch::aminmax(seg_len_tensor);
+  TORCH_CHECK(seg_len_min.item<int>() >= 0, "seg_indptr must be non-decreasing");
+  const int max_len =
+      static_cast<int>(seg_len_max.item<int64_t>());  // max_len = maximum segment length of all segments
 
   if (extra_embeddings.has_value()) {
     TORCH_CHECK(extra_embeddings->dim() == 3, "extra_embeddings must be a 3D tensor");
@@ -290,28 +288,24 @@ void embedding_lora_a_fwd(
     TORCH_CHECK(
         extra_embeddings->scalar_type() == weights.scalar_type(), "extra_embeddings dtype must match weights dtype");
   }
-
+  auto [min_lr, max_lr] = torch::aminmax(lora_ranks);
   TORCH_CHECK(
-      lora_ranks.min().item<int>() >= 0 && lora_ranks.max().item<int>() <= max_rank_i64,
+      min_lr.item<int64_t>() >= 0 && max_lr.item<int>() <= max_rank_i64,
       "All values in lora_ranks must be within the range [0, max_rank]");
+
+  // Cast to int32 and validate the bounds
+  auto seg_indptr_i32 = seg_indptr.scalar_type() == torch::kInt32 ? seg_indptr : seg_indptr.to(torch::kInt32);
+  auto weight_indices_i32 =
+      weight_indices.scalar_type() == torch::kInt32 ? weight_indices : weight_indices.to(torch::kInt32);
+  auto lora_ranks_i32 = lora_ranks.scalar_type() == torch::kInt32 ? lora_ranks : lora_ranks.to(torch::kInt32);
 
   auto stream = at::xpu::getCurrentXPUStream();
   auto queue = stream.queue();
 
-  int num_tokens = num_tokens_i64;
-  int max_rank = max_rank_i64;
-  int num_segments = num_segments_i64;
-  int num_extra_tokens = extra_embeddings.has_value() ? extra_embeddings->size(1) : 0;
-
-  if (num_tokens == 0) {
-    return;
-  }
-
-  // Validate output tensor size and dtype
-  TORCH_CHECK(
-      output.size(0) == num_tokens && output.size(1) == max_rank,
-      "Output tensor must have shape (num_tokens, max_rank)");
-  TORCH_CHECK(output.scalar_type() == weights.scalar_type(), "Output tensor dtype must match weights dtype");
+  const int num_tokens = num_tokens_i64;
+  const int max_rank = max_rank_i64;
+  const int num_segments = num_segments_i64;
+  const int num_extra_tokens = extra_embeddings.has_value() ? extra_embeddings->size(1) : 0;
 
   // Dispatch kernel based on data type
   if (weights.scalar_type() == torch::kFloat32) {
@@ -323,12 +317,12 @@ void embedding_lora_a_fwd(
         weight_indices,
         lora_ranks,
         extra_embeddings,
-        seg_lens,
         output,
         num_tokens,
         max_rank,
         num_segments,
         num_extra_tokens,
+        max_len,
         queue);
   } else if (weights.scalar_type() == torch::kHalf) {
     launch_embedding_lora_a_fwd<at::Half>(
@@ -339,12 +333,12 @@ void embedding_lora_a_fwd(
         weight_indices,
         lora_ranks,
         extra_embeddings,
-        seg_lens,
         output,
         num_tokens,
         max_rank,
         num_segments,
         num_extra_tokens,
+        max_len,
         queue);
   } else if (weights.scalar_type() == torch::kBFloat16) {
     launch_embedding_lora_a_fwd<at::BFloat16>(
@@ -355,12 +349,12 @@ void embedding_lora_a_fwd(
         weight_indices,
         lora_ranks,
         extra_embeddings,
-        seg_lens,
         output,
         num_tokens,
         max_rank,
         num_segments,
         num_extra_tokens,
+        max_len,
         queue);
   } else {
     TORCH_CHECK(false, "Unsupported data type for weights");

--- a/src/sycl/EmbeddingLoraAFwd.cpp
+++ b/src/sycl/EmbeddingLoraAFwd.cpp
@@ -1,0 +1,368 @@
+#include <ATen/ATen.h>
+#include <c10/xpu/XPUStream.h>
+#include <torch/all.h>
+
+#include <sycl/sycl.hpp>
+
+#include "SYCLHelpers.h"
+#include "Utils.h"
+
+// ============================================================
+// EmbeddingLoRAAFwd Kernel
+// ------------------------------------------------------------
+// This kernel computes LoRA embedding A values using a 3D launch:
+//   - group(0): segment index
+//   - group(1): rank index
+//   - group(2): token block within the segment
+// and local_id(2): token lane inside the block.
+//
+// Per work-item flow:
+//   1. Resolve (segment, rank_idx, token_idx) from launch geometry.
+//   2. Read adapter id from weight_indices[segment] and clamp rank via lora_ranks.
+//   3. Read segment length from seg_lens[segment] when provided, otherwise
+//      derive it from seg_indptr.
+//   4. Skip padded work-items (token_idx >= seg_len or rank_idx >= rank).
+//   5. For valid tokens, write one output element from either base weights
+//      or extra_embeddings (for token ids >= vocab_size).
+//
+// Notes:
+//   - Negative token ids are skipped (no write).
+//   - This kernel writes only active rank entries; output tail handling
+//     (padding/initialization) is expected to be managed by caller policy.
+//
+// ============================================================
+
+//----------------- set element type options --------------------//
+
+template <typename T>
+struct ToSyclElementType {
+  using type = T;
+};
+
+template <>
+struct ToSyclElementType<at::Half> {
+  using type = sycl::half;
+};
+
+template <>
+struct ToSyclElementType<at::BFloat16> {
+  using type = sycl::ext::oneapi::bfloat16;
+};
+
+//----------------- Kernel definition --------------------//
+
+template <typename DType>
+struct EmbeddingLoRAAFwd : public __SYCL_KER_CONFIG_CONVENTION__ {
+  const int64_t* input_ids;
+  const DType* weights;
+  const int* seg_indptr;
+  const int* weight_indices;
+  const int* lora_ranks;
+  const DType* extra_embeddings;
+  // seg_lens: optional per-segment token counts.
+  // seg_lens[s] = seg_indptr[s+1] - seg_indptr[s] for each segment s (in general).
+  const int* seg_lens;
+  DType* output;
+
+  int64_t vocab_size;
+  int num_segments;
+  int max_rank;
+  int num_extra_tokens;
+  int num_tokens;
+
+  EmbeddingLoRAAFwd(
+      const int64_t* input_ids,
+      const DType* weights,
+      const int* seg_indptr,
+      const int* weight_indices,
+      const int* lora_ranks,
+      const DType* extra_embeddings,
+      const int* seg_lens,
+      DType* output,
+      const int64_t vocab_size,
+      const int num_segments,
+      const int max_rank,
+      const int num_extra_tokens,
+      const int num_tokens)
+      : input_ids(input_ids),
+        weights(weights),
+        seg_indptr(seg_indptr),
+        weight_indices(weight_indices),
+        lora_ranks(lora_ranks),
+        extra_embeddings(extra_embeddings),
+        seg_lens(seg_lens),
+        output(output),
+        vocab_size(vocab_size),
+        num_segments(num_segments),
+        max_rank(max_rank),
+        num_extra_tokens(num_extra_tokens),
+        num_tokens(num_tokens) {}
+
+  static constexpr int BLOCK_TOK = 16;
+  static constexpr int sub_group_size = 16;
+
+  [[sycl::reqd_sub_group_size(sub_group_size)]]
+  void operator()(sycl::nd_item<3> item) const {
+    // group ids choose: which segment, which rank_idx in that segment, which token block
+    const int seg = static_cast<int>(item.get_group(0));
+    const int rank_idx = static_cast<int>(item.get_group(1));
+    const int tok_block = static_cast<int>(item.get_group(2));
+
+    // local thread id chooses: which token lane inside this token block
+    const int lane = static_cast<int>(item.get_local_id(2));
+    const int token_idx = tok_block * BLOCK_TOK + lane;
+
+    if (seg >= num_segments) {
+      return;
+    }
+
+    // Each segment maps directly to one LoRA adapter
+    const int lora = weight_indices[seg];
+    int rank = lora_ranks[lora];
+    rank = sycl::clamp(rank, 0, max_rank);
+
+    if (rank == 0) {
+      return;
+    }
+
+    // Segment start and length
+    const int seg_start = seg_indptr[seg];
+    const int seg_len = (seg_lens != nullptr) ? seg_lens[seg] : (seg_indptr[seg + 1] - seg_indptr[seg]);
+
+    // Some launched workgroups are padding because token_idx runs up to multiples of BLOCK_TOK
+    if (token_idx >= seg_len) {
+      return;
+    }
+
+    // Some local threads are padding because rank_idx runs up to max_rank
+    if (rank_idx >= rank) {
+      return;
+    }
+
+    const int token_pos = seg_start + token_idx;
+
+    const int64_t tok = input_ids[token_pos];
+    DType* out_row = output + static_cast<int64_t>(token_pos) * max_rank;
+
+    // Negative token: Early return
+    if (tok < 0) {
+      return;
+    }
+
+    // Base vocab path
+    if (tok < vocab_size) {
+      const int64_t idx = (static_cast<int64_t>(lora) * max_rank + rank_idx) * vocab_size + tok;
+      out_row[rank_idx] = weights[idx];
+      return;
+    }
+
+    // Extra token path
+    const int64_t e = tok - vocab_size;
+    if (extra_embeddings != nullptr && e >= 0 && e < num_extra_tokens) {
+      const int64_t idx = (static_cast<int64_t>(lora) * num_extra_tokens + e) * max_rank + rank_idx;
+      out_row[rank_idx] = extra_embeddings[idx];
+    }
+  }
+
+  void sycl_ker_config_convention(sycl::handler& cgh) const {}
+};
+
+//----------------- Kernel launch --------------------//
+
+template <typename TensorDType>
+void launch_embedding_lora_a_fwd(
+    const torch::Tensor& input_ids,
+    const torch::Tensor& weights,
+    const int64_t vocab_size,
+    const torch::Tensor& seg_indptr,
+    const torch::Tensor& weight_indices,
+    const torch::Tensor& lora_ranks,
+    const std::optional<torch::Tensor>& extra_embeddings,
+    const std::optional<torch::Tensor>& seg_lens,
+    torch::Tensor& output,
+    int num_tokens,
+    int max_rank,
+    int num_segments,
+    int num_extra_tokens,
+    sycl::queue& queue) {
+  using KernelDType = typename ToSyclElementType<TensorDType>::type;
+  // max_len = maximum segment length of all segments
+  int max_len = 0;
+  if (seg_lens.has_value()) {
+    max_len = seg_lens->max().item<int>();
+  } else {
+    auto seg_len_tensor = seg_indptr.slice(0, 1) - seg_indptr.slice(0, 0, seg_indptr.size(0) - 1);
+    max_len = seg_len_tensor.max().item<int>();
+  }
+
+  constexpr int BLOCK_TOK = EmbeddingLoRAAFwd<KernelDType>::BLOCK_TOK;
+  const int num_tok_blocks = (max_len + BLOCK_TOK - 1) / BLOCK_TOK;
+
+  sycl::range<3> local(1, 1, BLOCK_TOK);
+  sycl::range<3> global(
+      static_cast<size_t>(num_segments),
+      static_cast<size_t>(max_rank),
+      static_cast<size_t>(num_tok_blocks * BLOCK_TOK));
+
+  auto kernel = EmbeddingLoRAAFwd<KernelDType>(
+      input_ids.data_ptr<int64_t>(),
+      reinterpret_cast<const KernelDType*>(weights.data_ptr<TensorDType>()),
+      seg_indptr.data_ptr<int>(),
+      weight_indices.data_ptr<int>(),
+      lora_ranks.data_ptr<int>(),
+      extra_embeddings.has_value() ? reinterpret_cast<const KernelDType*>(extra_embeddings->data_ptr<TensorDType>())
+                                   : nullptr,
+      seg_lens.has_value() ? seg_lens->data_ptr<int>() : nullptr,
+      reinterpret_cast<KernelDType*>(output.data_ptr<TensorDType>()),
+      vocab_size,
+      num_segments,
+      max_rank,
+      num_extra_tokens,
+      num_tokens);
+  sycl_kernel_submit(global, local, queue, kernel);
+}
+
+//----------------- Main API function --------------------//
+
+void embedding_lora_a_fwd(
+    torch::Tensor& output,           // [num_tokens, max_rank]
+    const torch::Tensor& input_ids,  // [num_tokens,]
+    const torch::Tensor& weights,    // [num_loras, max_rank, vocab_size]
+    const int64_t vocab_size,
+    const torch::Tensor& seg_indptr,                       // [num_segments + 1,]
+    const torch::Tensor& weight_indices,                   // [num_segments,]
+    const torch::Tensor& lora_ranks,                       // [num_loras,]
+    const std::optional<torch::Tensor>& extra_embeddings,  // [num_loras, num_extra_tokens, max_rank]
+    const std::optional<torch::Tensor>&
+        seg_lens  // [num_segments,] optional; currently unused, reserved for future per-segment optimizations
+) {
+  CHECK_INPUT(input_ids);
+  CHECK_INPUT(weights);
+  CHECK_INPUT(seg_indptr);
+  CHECK_INPUT(weight_indices);
+  CHECK_INPUT(lora_ranks);
+  CHECK_INPUT(output);
+  if (extra_embeddings.has_value()) {
+    CHECK_INPUT(extra_embeddings.value());
+  }
+
+  TORCH_CHECK(input_ids.dim() == 1, "input_ids must be a 1D tensor");
+  TORCH_CHECK(weights.dim() == 3, "weights must be a 3D tensor");
+  TORCH_CHECK(weights.size(2) == vocab_size, "weights' vocab_size dimension must match the provided vocab_size");
+  TORCH_CHECK(seg_indptr.dim() == 1, "seg_indptr must be a 1D tensor");
+  TORCH_CHECK(weight_indices.dim() == 1, "weight_indices must be a 1D tensor");
+  TORCH_CHECK(lora_ranks.dim() == 1, "lora_ranks must be a 1D tensor");
+  TORCH_CHECK(output.dim() == 2, "output must be a 2D tensor");
+
+  const int64_t num_loras_i64 = weights.size(0);
+  const int64_t max_rank_i64 = weights.size(1);
+  const int64_t num_tokens_i64 = input_ids.size(0);
+
+  TORCH_CHECK(lora_ranks.numel() == num_loras_i64, "lora_ranks.numel() must equal weights.size(0)");
+  TORCH_CHECK(num_loras_i64 > 0, "weights.size(0) and lora_ranks.numel() must be greater than 0");
+  TORCH_CHECK(
+      num_tokens_i64 == 0 || seg_indptr.numel() >= 2, "seg_indptr must have at least 2 elements when num_tokens > 0");
+  const int64_t num_segments_i64 = seg_indptr.numel() - 1;
+  TORCH_CHECK(weight_indices.numel() == num_segments_i64, "weight_indices.numel() must equal seg_indptr.numel() - 1");
+  if (num_segments_i64 > 0) {
+    const int64_t min_weight_index = weight_indices.min().item<int64_t>();
+    const int64_t max_weight_index = weight_indices.max().item<int64_t>();
+    TORCH_CHECK(
+        min_weight_index >= 0 && max_weight_index < num_loras_i64,
+        "weight_indices values must be in [0, weights.size(0))");
+  }
+  if (num_tokens_i64 > 0) {
+    TORCH_CHECK(seg_indptr[0].item<int64_t>() == 0, "seg_indptr[0] must be 0");
+    TORCH_CHECK(
+        seg_indptr[seg_indptr.numel() - 1].item<int64_t>() == num_tokens_i64, "seg_indptr[-1] must equal num_tokens");
+  }
+  if (seg_lens.has_value()) {
+    CHECK_INPUT(seg_lens.value());
+    TORCH_CHECK(seg_lens->dim() == 1, "seg_lens must be a 1D tensor");
+    TORCH_CHECK(seg_lens->numel() == num_segments_i64, "seg_lens.numel() must equal num_segments");
+  }
+
+  if (extra_embeddings.has_value()) {
+    TORCH_CHECK(extra_embeddings->dim() == 3, "extra_embeddings must be a 3D tensor");
+    TORCH_CHECK(extra_embeddings->size(0) == num_loras_i64, "extra_embeddings.size(0) must equal weights.size(0)");
+    TORCH_CHECK(
+        extra_embeddings->size(2) == max_rank_i64, "extra_embeddings.size(2) must equal max_rank (weights.size(1))");
+    TORCH_CHECK(
+        extra_embeddings->scalar_type() == weights.scalar_type(), "extra_embeddings dtype must match weights dtype");
+  }
+
+  TORCH_CHECK(
+      lora_ranks.min().item<int>() >= 0 && lora_ranks.max().item<int>() <= max_rank_i64,
+      "All values in lora_ranks must be within the range [0, max_rank]");
+
+  auto stream = at::xpu::getCurrentXPUStream();
+  auto queue = stream.queue();
+
+  int num_tokens = num_tokens_i64;
+  int max_rank = max_rank_i64;
+  int num_segments = num_segments_i64;
+  int num_extra_tokens = extra_embeddings.has_value() ? extra_embeddings->size(1) : 0;
+
+  if (num_tokens == 0) {
+    return;
+  }
+
+  // Validate output tensor size and dtype
+  TORCH_CHECK(
+      output.size(0) == num_tokens && output.size(1) == max_rank,
+      "Output tensor must have shape (num_tokens, max_rank)");
+  TORCH_CHECK(output.scalar_type() == weights.scalar_type(), "Output tensor dtype must match weights dtype");
+
+  // Dispatch kernel based on data type
+  if (weights.scalar_type() == torch::kFloat32) {
+    launch_embedding_lora_a_fwd<float>(
+        input_ids,
+        weights,
+        vocab_size,
+        seg_indptr,
+        weight_indices,
+        lora_ranks,
+        extra_embeddings,
+        seg_lens,
+        output,
+        num_tokens,
+        max_rank,
+        num_segments,
+        num_extra_tokens,
+        queue);
+  } else if (weights.scalar_type() == torch::kHalf) {
+    launch_embedding_lora_a_fwd<at::Half>(
+        input_ids,
+        weights,
+        vocab_size,
+        seg_indptr,
+        weight_indices,
+        lora_ranks,
+        extra_embeddings,
+        seg_lens,
+        output,
+        num_tokens,
+        max_rank,
+        num_segments,
+        num_extra_tokens,
+        queue);
+  } else if (weights.scalar_type() == torch::kBFloat16) {
+    launch_embedding_lora_a_fwd<at::BFloat16>(
+        input_ids,
+        weights,
+        vocab_size,
+        seg_indptr,
+        weight_indices,
+        lora_ranks,
+        extra_embeddings,
+        seg_lens,
+        output,
+        num_tokens,
+        max_rank,
+        num_segments,
+        num_extra_tokens,
+        queue);
+  } else {
+    TORCH_CHECK(false, "Unsupported data type for weights");
+  }
+}

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -19,7 +19,6 @@ limitations under the License.
 #include "sgl_flash_kernel_ops.h"
 #include "sgl_kernel_ops.h"
 #include "sgl_kernel_torch_shim.h"
-
 TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def("awq_dequantize(Tensor qweight, Tensor scales, Tensor qzeros) -> Tensor");
   m.impl("awq_dequantize", torch::kXPU, &awq_dequantize);
@@ -100,6 +99,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 
   m.def("merge_state_v2(Tensor v_a, Tensor s_a, Tensor v_b, Tensor s_b, Tensor! v_merged, Tensor! s_merged) -> ()");
   m.impl("merge_state_v2", torch::kXPU, &merge_state_v2);
+#ifdef BUILD_FMHA
   /*
    * From cutlass attention
    */
@@ -133,6 +133,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "    bool?    pack_gqa,"
       "    int      sm_margin) -> Tensor[]");
   m.impl("fwd", torch::kXPU, make_pytorch_shim(&mha_fwd));
+#endif
 
   m.def("flash_mla_get_workspace_size", &flash_mla_get_workspace_size);
 
@@ -186,6 +187,15 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "Tensor! pre, Tensor! post, Tensor! comb, "
       "int hc_mult, int sinkhorn_iters, float eps) -> ()");
   m.impl("hc_split_sinkhorn", torch::kXPU, &hc_split_sinkhorn);
+
+  /*
+   * From LoRA
+   */
+  m.def(
+      "embedding_lora_a_fwd(Tensor! output, Tensor input_ids, Tensor weights, int vocab_size, Tensor seg_indptr, "
+      "Tensor weight_indices, "
+      "Tensor lora_ranks, Tensor? extra_embeddings, Tensor? seg_lens) -> ()");
+  m.impl("embedding_lora_a_fwd", torch::kXPU, &embedding_lora_a_fwd);
 }
 
 REGISTER_EXTENSION(common_ops)

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -99,7 +99,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 
   m.def("merge_state_v2(Tensor v_a, Tensor s_a, Tensor v_b, Tensor s_b, Tensor! v_merged, Tensor! s_merged) -> ()");
   m.impl("merge_state_v2", torch::kXPU, &merge_state_v2);
-#ifdef BUILD_FMHA
+
   /*
    * From cutlass attention
    */
@@ -133,7 +133,6 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "    bool?    pack_gqa,"
       "    int      sm_margin) -> Tensor[]");
   m.impl("fwd", torch::kXPU, make_pytorch_shim(&mha_fwd));
-#endif
 
   m.def("flash_mla_get_workspace_size", &flash_mla_get_workspace_size);
 

--- a/tests/test_embedding_lora_a_fwd.py
+++ b/tests/test_embedding_lora_a_fwd.py
@@ -1,0 +1,472 @@
+import sys
+from typing import Optional
+
+import pytest
+import torch
+from sgl_kernel.lora import embedding_lora_a_fwd
+
+
+def _tolerances(dtype: torch.dtype):
+    if dtype == torch.float32:
+        return 1e-5, 1e-5
+    if dtype in (torch.float16, torch.bfloat16):
+        return 1e-3, 1e-3
+    return 1e-5, 1e-5
+
+
+def _find_segment(token_pos: int, seg_indptr_cpu: torch.Tensor) -> int:
+    lo = 0
+    hi = seg_indptr_cpu.numel() - 2
+    while lo <= hi:
+        mid = (lo + hi) >> 1
+        left = int(seg_indptr_cpu[mid].item())
+        right = int(seg_indptr_cpu[mid + 1].item())
+        if token_pos < left:
+            hi = mid - 1
+        elif token_pos >= right:
+            lo = mid + 1
+        else:
+            return mid
+    return seg_indptr_cpu.numel() - 2
+
+
+def _reference_embedding_lora_a_fwd(
+    input_ids: torch.Tensor,
+    weights: torch.Tensor,
+    vocab_size: int,
+    seg_indptr: torch.Tensor,
+    weight_indices: torch.Tensor,
+    lora_ranks: torch.Tensor,
+    extra_embeddings: Optional[torch.Tensor],
+) -> torch.Tensor:
+    input_ids_cpu = input_ids.cpu()
+    weights_cpu = weights.cpu()
+    seg_indptr_cpu = seg_indptr.cpu()
+    weight_indices_cpu = weight_indices.cpu()
+    lora_ranks_cpu = lora_ranks.cpu()
+    extra_cpu = None if extra_embeddings is None else extra_embeddings.cpu()
+
+    num_tokens = input_ids_cpu.numel()
+    max_rank = weights_cpu.size(1)
+
+    out = torch.zeros((num_tokens, max_rank), dtype=weights_cpu.dtype)
+
+    num_extra_tokens = 0 if extra_cpu is None else extra_cpu.size(1)
+
+    for gid in range(num_tokens):
+        seg = _find_segment(gid, seg_indptr_cpu)
+        lora = int(weight_indices_cpu[seg].item())
+        rank = int(lora_ranks_cpu[lora].item())
+        tok = int(input_ids_cpu[gid].item())
+
+        if tok < vocab_size:
+            out[gid, :rank] = weights_cpu[lora, :rank, tok]
+        else:
+            e = tok - vocab_size
+            if extra_cpu is not None and e < num_extra_tokens:
+                out[gid, :rank] = extra_cpu[lora, e, :rank]
+            # else remains zeros
+
+        # Tail [rank:max_rank] remains zeros
+    return out
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("vocab_size", [128, 32000, 128256])
+def test_embedding_lora_a_fwd_large_vocab_boundaries(dtype, vocab_size):
+    torch.manual_seed(11)
+
+    max_rank = 8
+    num_loras = 3
+    num_extra_tokens = 4
+
+    # Boundary-heavy token ids:
+    # base low/high, extra low/high, and out-of-range extra.
+    input_ids = torch.tensor(
+        [
+            0,
+            vocab_size - 1,
+            vocab_size,
+            vocab_size + num_extra_tokens - 1,
+            vocab_size + num_extra_tokens,
+        ],
+        dtype=torch.int64,
+        device="xpu",
+    )
+
+    weights = torch.randn(num_loras, max_rank, vocab_size, dtype=dtype, device="xpu")
+    extra_embeddings = torch.randn(
+        num_loras, num_extra_tokens, max_rank, dtype=dtype, device="xpu"
+    )
+
+    seg_indptr = torch.tensor([0, 2, 5], dtype=torch.int32, device="xpu")
+    weight_indices = torch.tensor([0, 2], dtype=torch.int32, device="xpu")
+    lora_ranks = torch.tensor([8, 4, 3], dtype=torch.int32, device="xpu")
+
+    out = embedding_lora_a_fwd(
+        input_ids=input_ids,
+        weights=weights,
+        vocab_size=vocab_size,
+        seg_indptr=seg_indptr,
+        weight_indices=weight_indices,
+        lora_ranks=lora_ranks,
+        extra_embeddings=extra_embeddings,
+        seg_lens=None,
+    )
+
+    ref = _reference_embedding_lora_a_fwd(
+        input_ids,
+        weights,
+        vocab_size,
+        seg_indptr,
+        weight_indices,
+        lora_ranks,
+        extra_embeddings,
+    ).to("xpu")
+
+    rtol, atol = _tolerances(dtype)
+    torch.testing.assert_close(out, ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("num_tokens", [1024, 8192, 16384])
+def test_embedding_lora_a_fwd_large_num_tokens_many_small_segments(num_tokens):
+    torch.manual_seed(12)
+
+    dtype = torch.float32
+    vocab_size = 4096
+    max_rank = 8
+    num_loras = 4
+
+    input_ids = torch.randint(
+        0, vocab_size, (num_tokens,), dtype=torch.int64, device="xpu"
+    )
+    weights = torch.randn(num_loras, max_rank, vocab_size, dtype=dtype, device="xpu")
+
+    # One-token-per-segment stress: maximum segment count for the token count.
+    seg_indptr = torch.arange(0, num_tokens + 1, dtype=torch.int32, device="xpu")
+    weight_indices = torch.randint(
+        0, num_loras, (num_tokens,), dtype=torch.int32, device="xpu"
+    )
+    lora_ranks = torch.tensor([1, 3, 5, 8], dtype=torch.int32, device="xpu")
+
+    out = embedding_lora_a_fwd(
+        input_ids=input_ids,
+        weights=weights,
+        vocab_size=vocab_size,
+        seg_indptr=seg_indptr,
+        weight_indices=weight_indices,
+        lora_ranks=lora_ranks,
+        extra_embeddings=None,
+        seg_lens=None,
+    )
+
+    ref = _reference_embedding_lora_a_fwd(
+        input_ids, weights, vocab_size, seg_indptr, weight_indices, lora_ranks, None
+    ).to("xpu")
+
+    torch.testing.assert_close(out, ref, rtol=1e-5, atol=1e-5)
+
+
+def test_embedding_lora_a_fwd_empty_input():
+    torch.manual_seed(13)
+
+    vocab_size = 32
+    max_rank = 4
+
+    input_ids = torch.empty((0,), dtype=torch.int64, device="xpu")
+    weights = torch.randn(1, max_rank, vocab_size, dtype=torch.float32, device="xpu")
+    seg_indptr = torch.tensor([0], dtype=torch.int32, device="xpu")
+    weight_indices = torch.empty((0,), dtype=torch.int32, device="xpu")
+    lora_ranks = torch.tensor([max_rank], dtype=torch.int32, device="xpu")
+
+    out = embedding_lora_a_fwd(
+        input_ids=input_ids,
+        weights=weights,
+        vocab_size=vocab_size,
+        seg_indptr=seg_indptr,
+        weight_indices=weight_indices,
+        lora_ranks=lora_ranks,
+        extra_embeddings=None,
+        seg_lens=None,
+    )
+
+    assert out.shape == (0, max_rank)
+    assert out.numel() == 0
+
+
+def test_embedding_lora_a_fwd_zero_rank_all_zero_output():
+    torch.manual_seed(14)
+
+    vocab_size = 64
+    max_rank = 8
+
+    input_ids = torch.tensor([1, 5, 10, 63], dtype=torch.int64, device="xpu")
+    weights = torch.randn(2, max_rank, vocab_size, dtype=torch.float32, device="xpu")
+    seg_indptr = torch.tensor([0, 2, 4], dtype=torch.int32, device="xpu")
+    weight_indices = torch.tensor([0, 1], dtype=torch.int32, device="xpu")
+    lora_ranks = torch.tensor([0, 0], dtype=torch.int32, device="xpu")
+
+    out = embedding_lora_a_fwd(
+        input_ids=input_ids,
+        weights=weights,
+        vocab_size=vocab_size,
+        seg_indptr=seg_indptr,
+        weight_indices=weight_indices,
+        lora_ranks=lora_ranks,
+        extra_embeddings=None,
+        seg_lens=None,
+    )
+
+    assert torch.count_nonzero(out).item() == 0
+
+
+def test_embedding_lora_a_fwd_segment_boundaries_precise_routing():
+    torch.manual_seed(15)
+
+    dtype = torch.float32
+    vocab_size = 128
+    max_rank = 4
+
+    # Segment sizes: 3,1,5
+    input_ids = torch.tensor(
+        [7, 8, 9, 10, 11, 12, 13, 14, 15], dtype=torch.int64, device="xpu"
+    )
+    seg_indptr = torch.tensor([0, 3, 4, 9], dtype=torch.int32, device="xpu")
+    weight_indices = torch.tensor([2, 1, 0], dtype=torch.int32, device="xpu")
+    lora_ranks = torch.tensor([4, 2, 3], dtype=torch.int32, device="xpu")
+    weights = torch.randn(3, max_rank, vocab_size, dtype=dtype, device="xpu")
+
+    out = embedding_lora_a_fwd(
+        input_ids=input_ids,
+        weights=weights,
+        vocab_size=vocab_size,
+        seg_indptr=seg_indptr,
+        weight_indices=weight_indices,
+        lora_ranks=lora_ranks,
+        extra_embeddings=None,
+        seg_lens=None,
+    )
+
+    ref = _reference_embedding_lora_a_fwd(
+        input_ids, weights, vocab_size, seg_indptr, weight_indices, lora_ranks, None
+    ).to("xpu")
+
+    torch.testing.assert_close(out, ref, rtol=1e-5, atol=1e-5)
+
+
+def test_embedding_lora_a_fwd_extra_tokens_without_extra_embeddings_are_zero():
+    torch.manual_seed(16)
+
+    vocab_size = 32
+    max_rank = 4
+
+    input_ids = torch.tensor(
+        [vocab_size, vocab_size + 3, vocab_size + 99], dtype=torch.int64, device="xpu"
+    )
+    weights = torch.randn(1, max_rank, vocab_size, dtype=torch.float32, device="xpu")
+    seg_indptr = torch.tensor([0, 3], dtype=torch.int32, device="xpu")
+    weight_indices = torch.tensor([0], dtype=torch.int32, device="xpu")
+    lora_ranks = torch.tensor([4], dtype=torch.int32, device="xpu")
+
+    out = embedding_lora_a_fwd(
+        input_ids=input_ids,
+        weights=weights,
+        vocab_size=vocab_size,
+        seg_indptr=seg_indptr,
+        weight_indices=weight_indices,
+        lora_ranks=lora_ranks,
+        extra_embeddings=None,
+        seg_lens=None,
+    )
+
+    assert torch.count_nonzero(out).item() == 0
+
+
+def test_embedding_lora_a_fwd_rank_padding_zero_tail():
+    torch.manual_seed(1)
+
+    input_ids = torch.tensor([2, 5, 1, 3], dtype=torch.int64, device="xpu")
+    vocab_size = 8
+    max_rank = 4
+
+    # Two loras with different effective ranks.
+    weights = torch.randn(2, max_rank, vocab_size, dtype=torch.float32, device="xpu")
+    seg_indptr = torch.tensor([0, 2, 4], dtype=torch.int32, device="xpu")
+    weight_indices = torch.tensor([0, 1], dtype=torch.int32, device="xpu")
+    lora_ranks = torch.tensor([1, 3], dtype=torch.int32, device="xpu")
+
+    out = embedding_lora_a_fwd(
+        input_ids=input_ids,
+        weights=weights,
+        vocab_size=vocab_size,
+        seg_indptr=seg_indptr,
+        weight_indices=weight_indices,
+        lora_ranks=lora_ranks,
+        extra_embeddings=None,
+        seg_lens=None,
+    )
+
+    # token 0,1 -> lora 0 rank=1 ; token 2,3 -> lora 1 rank=3
+    expected_ranks = [1, 1, 3, 3]
+    for i, rank in enumerate(expected_ranks):
+        tail = out[i, rank:]
+        assert torch.count_nonzero(tail).item() == 0, f"Tail not zero for token {i}"
+
+
+def test_embedding_lora_a_fwd_extra_embeddings_in_range():
+    torch.manual_seed(2)
+
+    vocab_size = 6
+    max_rank = 4
+    num_extra_tokens = 2
+
+    # Includes base tokens and extra tokens: vocab+0 and vocab+1.
+    input_ids = torch.tensor([1, 6, 3, 7], dtype=torch.int64, device="xpu")
+    weights = torch.randn(2, max_rank, vocab_size, dtype=torch.float32, device="xpu")
+    extra_embeddings = torch.randn(
+        2, num_extra_tokens, max_rank, dtype=torch.float32, device="xpu"
+    )
+
+    seg_indptr = torch.tensor([0, 2, 4], dtype=torch.int32, device="xpu")
+    weight_indices = torch.tensor([0, 1], dtype=torch.int32, device="xpu")
+    lora_ranks = torch.tensor([4, 2], dtype=torch.int32, device="xpu")
+
+    out = embedding_lora_a_fwd(
+        input_ids=input_ids,
+        weights=weights,
+        vocab_size=vocab_size,
+        seg_indptr=seg_indptr,
+        weight_indices=weight_indices,
+        lora_ranks=lora_ranks,
+        extra_embeddings=extra_embeddings,
+        seg_lens=None,
+    )
+
+    ref = _reference_embedding_lora_a_fwd(
+        input_ids,
+        weights,
+        vocab_size,
+        seg_indptr,
+        weight_indices,
+        lora_ranks,
+        extra_embeddings,
+    ).to("xpu")
+
+    torch.testing.assert_close(out, ref, rtol=1e-5, atol=1e-5)
+
+
+def test_embedding_lora_a_fwd_extra_token_out_of_range_zeroed():
+    torch.manual_seed(3)
+
+    vocab_size = 6
+    max_rank = 4
+
+    # vocab+5 is out of range when num_extra_tokens=2.
+    input_ids = torch.tensor([11], dtype=torch.int64, device="xpu")
+    weights = torch.randn(1, max_rank, vocab_size, dtype=torch.float32, device="xpu")
+    extra_embeddings = torch.randn(1, 2, max_rank, dtype=torch.float32, device="xpu")
+
+    seg_indptr = torch.tensor([0, 1], dtype=torch.int32, device="xpu")
+    weight_indices = torch.tensor([0], dtype=torch.int32, device="xpu")
+    lora_ranks = torch.tensor([4], dtype=torch.int32, device="xpu")
+
+    out = embedding_lora_a_fwd(
+        input_ids=input_ids,
+        weights=weights,
+        vocab_size=vocab_size,
+        seg_indptr=seg_indptr,
+        weight_indices=weight_indices,
+        lora_ranks=lora_ranks,
+        extra_embeddings=extra_embeddings,
+        seg_lens=None,
+    )
+
+    assert (
+        torch.count_nonzero(out).item() == 0
+    ), "Out-of-range extra token must produce zeros"
+
+
+def test_embedding_lora_a_fwd_negative_token_id_zero_row():
+    torch.manual_seed(17)
+
+    vocab_size = 16
+    max_rank = 4
+
+    # Includes one negative token to exercise the dedicated kernel branch.
+    input_ids = torch.tensor([3, -1, vocab_size + 1], dtype=torch.int64, device="xpu")
+    weights = torch.randn(1, max_rank, vocab_size, dtype=torch.float32, device="xpu")
+    extra_embeddings = torch.randn(1, 2, max_rank, dtype=torch.float32, device="xpu")
+
+    seg_indptr = torch.tensor([0, 3], dtype=torch.int32, device="xpu")
+    weight_indices = torch.tensor([0], dtype=torch.int32, device="xpu")
+    lora_ranks = torch.tensor([4], dtype=torch.int32, device="xpu")
+
+    out = embedding_lora_a_fwd(
+        input_ids=input_ids,
+        weights=weights,
+        vocab_size=vocab_size,
+        seg_indptr=seg_indptr,
+        weight_indices=weight_indices,
+        lora_ranks=lora_ranks,
+        extra_embeddings=extra_embeddings,
+        seg_lens=None,
+    )
+
+    # Negative token row must be fully zero.
+    assert torch.count_nonzero(out[1]).item() == 0
+
+    # Neighboring rows should still follow normal base/extra paths.
+    torch.testing.assert_close(out[0], weights[0, :, 3], rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(out[2], extra_embeddings[0, 1, :], rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "bad_case, expected_msg",
+    [
+        ("input_ids_dim", "input_ids must be a 1D tensor"),
+        ("weights_dim", "weights must be a 3D tensor"),
+        ("seg_indptr_dim", "seg_indptr must be a 1D tensor"),
+        ("weight_indices_dim", "weight_indices must be a 1D tensor"),
+        ("lora_ranks_dim", "lora_ranks must be a 1D tensor"),
+        (
+            "vocab_mismatch",
+            "weights' vocab_size dimension must match the provided vocab_size",
+        ),
+    ],
+)
+def test_embedding_lora_a_fwd_input_validation(bad_case, expected_msg):
+    input_ids = torch.tensor([1, 2], dtype=torch.int64, device="xpu")
+    weights = torch.randn(1, 4, 8, dtype=torch.float32, device="xpu")
+    seg_indptr = torch.tensor([0, 2], dtype=torch.int32, device="xpu")
+    weight_indices = torch.tensor([0], dtype=torch.int32, device="xpu")
+    lora_ranks = torch.tensor([4], dtype=torch.int32, device="xpu")
+    vocab_size = 8
+
+    if bad_case == "input_ids_dim":
+        input_ids = input_ids.view(1, 2)
+    elif bad_case == "weights_dim":
+        weights = weights.view(1, -1)
+    elif bad_case == "seg_indptr_dim":
+        seg_indptr = seg_indptr.view(1, 2)
+    elif bad_case == "weight_indices_dim":
+        weight_indices = weight_indices.view(1, 1)
+    elif bad_case == "lora_ranks_dim":
+        lora_ranks = lora_ranks.view(1, 1)
+    elif bad_case == "vocab_mismatch":
+        vocab_size = 7
+
+    with pytest.raises(RuntimeError, match=expected_msg):
+        embedding_lora_a_fwd(
+            input_ids=input_ids,
+            weights=weights,
+            vocab_size=vocab_size,
+            seg_indptr=seg_indptr,
+            weight_indices=weight_indices,
+            lora_ranks=lora_ranks,
+            extra_embeddings=None,
+            seg_lens=None,
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))

--- a/tests/test_embedding_lora_a_fwd.py
+++ b/tests/test_embedding_lora_a_fwd.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import pytest
 import torch
+
 from sgl_kernel.lora import embedding_lora_a_fwd
 
 

--- a/tests/test_embedding_lora_a_fwd.py
+++ b/tests/test_embedding_lora_a_fwd.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 import pytest
 import torch
-
 from sgl_kernel.lora import embedding_lora_a_fwd
 
 


### PR DESCRIPTION
## Summary
Adds an XPU (SYCL) `embedding_lora_a_fwd` kernel for LoRA A embedding lookup with segment-based adapter selection. Integrated with PyTorch API for XPU.

## Changes
- Registers new `sgl_kernel.lora.embedding_lora_a_fwd` torch op for XPU
- Adds new SYCL kernel: `embedding_lora_a_fwd.cpp`
- Adds test: `test_embedding_lora_a_fwd.py` to validate against reference results (including multiple corner cases)
- Adds benchmarking: `bench_embedding_lora_a_fwd.py` to benchmark XPU kernel against the triton op (triton reference is taken from `frameworks.ai.pytorch.sglang` repo)

## Key Features
- Supports segment-based routing (`seg_indptr`, `weight_indices`)
- Handles multiple LoRA adapters with variable ranks
- Supports base vocab and extra token embeddings
- Zero-padding to `max_rank`

## Implementation Details
- 3D grid mapping directly assigns work across **segment / token-lane / rank-block** dimensions.
- Adapter selection is performed directly per segment using segment metadata.
- Output handling is performed in-kernel:
  - Writes gathered values from base embeddings or extra embeddings when valid.
  - Writes zeros for rank-tail padding, invalid tokens, and unsupported extra-token cases.

## Current Limitation
- The weight tensor layout is fixed as `(num_lora, max_rank, vocab_size)`, causing inherently strided reads across the rank dimension. This significantly impacts achievable memory bandwidth.

## Trade-offs
### Triton Op
- Uses `BLOCK_RANK` in the third grid dimension.
- Work-items are contiguous across the **rank dimension**.
- **Reads** are highly strided by `vocab_size` (large stride).
- **Writes** remain naturally coalesced.

### XPU Op
- Uses `BLOCK_TOK` in the third grid dimension.
- Work-items are contiguous across **token positions**.
- Since token IDs are arbitrary, reads are still irregular, but larger token batches may improve cache locality.
- **Writes** are strided by `max_rank`, making them less coalesced compared to Triton.

### Observation
- Benchmarking suggests that as token count and vocab size increase, the XPU op tends to outperform the Triton op due to improved cache behavior and better token-level scaling.


## Benchmarking
<details>
<summary><strong>Detailed Report</strong></summary>

| num_tokens | num_segments | num_adapters | max_rank | vocab_size | XPU FP16 (GB/s) | Triton FP16 (GB/s) | XPU BF16 (GB/s) | Triton BF16 (GB/s) | XPU FP32 (GB/s) | Triton FP32 (GB/s) |
|-----------:|-------------:|-------------:|---------:|-----------:|----------------:|-------------------:|----------------:|-------------------:|----------------:|-------------------:|
| 384   | 1  | 2 | 48  | 36864  | 0.42 | 0.77 | 0.48 | 0.78 | 0.87 | 1.46 |
| 512   | 1  | 4 | 64  | 40960  | 0.83 | 1.40 | 0.79 | 1.38 | 1.59 | 2.71 |
| 3072  | 2  | 4 | 77  | 49152  | 5.61 | 9.38 | 5.59 | 9.12 | 9.23 | 16.66 |
| 4608  | 8  | 2 | 96  | 57344  | 6.96 | 12.34 | 7.90 | 9.65 | 10.58 | 15.28 |
| 6144  | 4  | 4 | 123 | 65536  | 10.32 | 13.61 | 10.34 | 13.69 | 14.41 | 14.41 |
| 8192  | 16 | 8 | 128 | 73728  | 6.84 | 9.24 | 7.41 | 7.76 | 11.53 | 11.75 |
| 9216  | 32 | 4 | 175 | 81920  | 6.44 | 7.15 | 6.73 | 6.93 | 11.18 | 11.01 |
| 10240 | 8  | 4 | 192 | 98304  | 9.50 | 7.96 | 9.66 | 7.73 | 13.95 | 11.03 |
| 11264 | 32 | 2 | 221 | 65536  | 8.33 | 8.81 | 8.22 | 8.68 | 12.19 | 12.35 |
| 12288 | 64 | 8 | 256 | 86016  | 5.98 | 5.57 | 5.92 | 5.57 | 10.61 | 9.50 |
| 14336 | 16 | 4 | 320 | 98304  | 8.64 | 6.22 | 8.74 | 6.28 | 13.35 | 9.70 |
| 15872 | 64 | 2 | 365 | 110592 | 5.98 | 5.35 | 5.98 | 5.33 | 10.82 | 9.11 |
| 16384 | 32 | 4 | 448 | 122880 | 6.69 | 5.06 | 6.58 | 5.03 | 11.37 | 8.73 |
| 18432 | 64 | 2 | 512 | 114688 | 6.49 | 5.20 | 6.44 | 5.05 | 11.52 | 8.89 |
| 6144  | 2  | 4 | 69  | 53248  | 10.38 | 15.96 | 10.26 | 15.94 | 16.27 | 27.79 |
| 10240 | 4  | 2 | 144 | 69632  | 16.71 | 14.94 | 16.69 | 14.21 | 20.92 | 15.03 |
| 14336 | 32 | 2 | 192 | 86016  | 7.27 | 8.20 | 7.58 | 8.11 | 11.72 | 11.67 |
| 16384 | 16 | 4 | 576 | 98304  | 9.48 | 5.19 | 9.44 | 5.09 | 14.18 | 8.60 |
| 19456 | 64 | 4 | 640 | 122880 | 5.80 | 4.46 | 5.59 | 4.52 | 10.19 | 8.12 |
| 5050  | 1  | 2 | 288 | 120832 | 17.30 | 6.28 | 17.23 | 6.26 | 22.33 | 9.88 |
| 7000  | 1  | 1 | 95  | 118784 | 14.36 | 11.10 | 14.31 | 11.03 | 20.28 | 13.28 |
| 9500  | 2  | 4 | 230 | 116736 | 19.06 | 7.04 | 19.23 | 7.14 | 23.73 | 10.10 |
| 12000 | 4  | 2 | 704 | 122880 | 16.28 | 4.60 | 16.12 | 4.65 | 19.88 | 8.15 |
| 13824 | 8  | 4 | 460 | 110592 | 11.76 | 5.36 | 11.81 | 5.42 | 15.94 | 9.09 |
| 16384 | 16 | 8 | 384 | 98304  | 9.52 | 5.91 | 9.40 | 5.85 | 13.91 | 9.53 |
| 21504 | 32 | 2 | 731 | 121856 | 7.42 | 4.84 | 7.43 | 4.86 | 12.18 | 8.73 |

</details>

<details>
<summary><strong>Summary</strong></summary>

| Provider | Mean Bandwidth (GB/s) | Mean Time (ms) |
|----------|----------------------:|---------------:|
| XPU FP16    | 9.01  | 2.107 |
| XPU BF16    | 9.07  | 2.118 |
| XPU FP32    | 13.26 | 2.592 |
| Triton FP16 | 7.38  | 3.071 |
| Triton BF16 | 7.16  | 3.084 |
| Triton FP32 | 10.87 | 3.616 |

</details>

### Key Takeaway
The XPU implementation consistently improves as token count and workload size increase. In larger token-heavy cases, token-oriented execution shows better effective cache behavior and outperforms Triton despite non-coalesced writes.

## TODO / Follow-up Optimization
- Explore shared memory (local memory) based tiling as a follow-up optimization.
- Investigate reading weight tiles in a token-parallel manner to improve cache locality / partial read coalescing where possible.
- Use local memory as a temporary transpose buffer, followed by a barrier, to remap data and make output writes more coalesced across the rank dimension.
- Benchmark this approach against the current implementation to evaluate whether the added synchronization and local memory overhead provide a net bandwidth gain.