### PR TITLE
Implement 'fused_qk_rope' kernel with cos_sin_cache

### DIFF
--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -69,6 +69,7 @@ jobs:
               python3 bench_merge_states_v2.py 2>&1 | tee merge_states.py.log \
               python3 bench_swiglu_alpha_limit.py 2>&1 | tee swiglu_alpha_limit.py.log \
               python3 bench_fused_qk_norm_rope.py 2>&1 | tee fused_qk_norm_rope.py.log \
+              python3 bench_fused_qk_rope_with_cache.py 2>&1 | tee bench_fused_qk_rope_with_cache.py.log \
               python3 bench_per_token_group_quant_8bit.py 2>&1 | tee per_token_group_quant_8bit.py.log \
               python3 bench_per_token_group_quant_mxfp4.py 2>&1 | tee per_token_group_quant_mxfp4.py.log \
               python3 bench_per_token_group_quant_8bit_v2.py 2>&1 | tee bench_per_token_group_quant_8bit_v2.py.log \

--- a/benchmark/bench_fused_qk_rope_with_cache.py
+++ b/benchmark/bench_fused_qk_rope_with_cache.py
@@ -1,8 +1,9 @@
 import itertools
 
+import pandas as pd
 import torch
 import triton
-from sgl_kernel import fused_qk_rope_with_cos_sin_cache
+from sgl_kernel import fused_qk_rope_with_cos_sin_cache_inplace
 
 DEVICE = "xpu"
 MAX_SEQ_LEN = 131072  # common seq length
@@ -32,66 +33,6 @@ def create_cos_sin_cache(
     return cache
 
 
-def apply_rotary_emb(
-    x: torch.Tensor,
-    cos: torch.Tensor,
-    sin: torch.Tensor,
-    is_neox_style: bool,
-) -> torch.Tensor:
-    """
-    Args:
-        x: [num_tokens, num_heads, head_size]
-        cos: [num_tokens, head_size // 2]
-        sin: [num_tokens, head_size // 2]
-        is_neox_style: Whether to use the Neox-style or GPT-J-style rotary
-            positional embeddings.
-    """
-    cos = cos.unsqueeze(-2).to(x.dtype)
-    sin = sin.unsqueeze(-2).to(x.dtype)
-    if is_neox_style:
-        x1, x2 = torch.chunk(x, 2, dim=-1)
-    else:
-        x1 = x[..., ::2]
-        x2 = x[..., 1::2]
-    o1 = x1 * cos - x2 * sin
-    o2 = x2 * cos + x1 * sin
-    if is_neox_style:
-        return torch.cat((o1, o2), dim=-1)
-    else:
-        return torch.stack((o1, o2), dim=-1).flatten(-2)
-
-
-def native_fused_qk_rope_with_cache(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    cos_sin_cache: torch.Tensor,
-    positions: torch.Tensor,
-    rotary_dim: int,
-    is_neox: bool,
-):
-    head_size = q.shape[-1]
-    positions = positions.flatten()
-    num_tokens = positions.shape[0]
-    cos_cache, sin_cache = cos_sin_cache.chunk(2, dim=-1)
-    cos = cos_cache[positions]
-    sin = sin_cache[positions]
-
-    query_shape = q.shape
-    query = q.view(num_tokens, -1, head_size)
-    query_rot = query[..., :rotary_dim]
-    query_pass = query[..., rotary_dim:]
-    query_rot = apply_rotary_emb(query_rot, cos, sin, is_neox)
-    query = torch.cat((query_rot, query_pass), dim=-1).reshape(query_shape)
-
-    key_shape = k.shape
-    key = k.view(num_tokens, -1, head_size)
-    key_rot = key[..., :rotary_dim]
-    key_pass = key[..., rotary_dim:]
-    key_rot = apply_rotary_emb(key_rot, cos, sin, is_neox)
-    key = torch.cat((key_rot, key_pass), dim=-1).reshape(key_shape)
-    return query, key
-
-
 def sglang_fused_qk_rope_with_cache(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -100,9 +41,49 @@ def sglang_fused_qk_rope_with_cache(
     rotary_dim: int,
     is_neox: bool,
 ):
-    return fused_qk_rope_with_cos_sin_cache(
+    fused_qk_rope_with_cos_sin_cache_inplace(
         q, k, cos_sin_cache, positions, rotary_dim, is_neox
     )
+
+
+def calculate_bandwidth(
+    num_tokens: int,
+    num_heads: int,
+    num_kv_heads: int,
+    rotary_dim: int,
+    time_ms: float,
+    dtype: torch.dtype,
+):
+    """Estimate effective memory bandwidth (GB/s) for the fused QK RoPE kernel.
+
+    This is an *effective* bandwidth model: it approximates how many bytes are
+    moved for one invocation and divides by measured kernel time.
+
+    Byte model:
+    - Q/K read + write for rotary part:
+        num_tokens * (num_heads + num_kv_heads) * rotary_dim * dtype_size * 2
+        (*2 accounts for one read and one write of Q/K rotary slices).
+    - Cos/sin cache read:
+        num_tokens * rotary_dim * dtype_size
+        (counted as one read per token; cache effects can make measured bandwidth
+        differ from peak/theoretical device bandwidth).
+
+    Effective bandwidth = total_bytes / elapsed_time.
+    """
+    dtype_size = 2 if dtype in [torch.float16, torch.bfloat16] else 4
+    qkv_read_write_bytes = (
+        num_tokens * (num_heads + num_kv_heads) * rotary_dim * dtype_size * 2
+    )
+    # cos_sin_cache is fetched once per token for the current position.
+    cache_read_bytes = num_tokens * rotary_dim * dtype_size
+    total_bytes = qkv_read_write_bytes + cache_read_bytes
+
+    time_s = time_ms / 1000.0
+    # Return effective GB/s (decimal GB).
+    return (total_bytes / 1e9) / time_s
+
+
+all_results = []
 
 
 def get_benchmark(device="xpu"):
@@ -118,8 +99,8 @@ def get_benchmark(device="xpu"):
             ],
             x_vals=configs,
             line_arg="provider",
-            line_vals=["sglang", "native"],
-            line_names=["SGLang", "native"],
+            line_vals=["sglang"],
+            line_names=["SGLang"],
             styles=[("blue", "-"), ("green", "-")],
             ylabel="Latency (us)",
             plot_name="fused-qk-rope-with-cache-performance",
@@ -138,17 +119,29 @@ def get_benchmark(device="xpu"):
         )
         cos_sin_cache = create_cos_sin_cache(rope_dim).to(dtype)
 
-        if provider == "sglang" or provider == "sglang1":
+        if provider == "sglang":
             fn = lambda: sglang_fused_qk_rope_with_cache(
-                q, k, cos_sin_cache, positions, rope_dim, is_neox
-            )
-        elif provider == "native":
-            fn = lambda: native_fused_qk_rope_with_cache(
                 q, k, cos_sin_cache, positions, rope_dim, is_neox
             )
 
         quantiles = [0.5, 0.2, 0.8]
         ms, min_ms, max_ms = triton.testing.do_bench(fn, quantiles=quantiles)
+        bandwidth = calculate_bandwidth(
+            num_tokens, num_heads, num_kv_heads, rope_dim, ms, dtype
+        )
+        all_results.append(
+            {
+                "num_tokens": num_tokens,
+                "num_heads": num_heads,
+                "num_kv_heads": num_kv_heads,
+                "rope_dim": rope_dim,
+                "is_neox": is_neox,
+                "dtype": dtype,
+                "provider": provider,
+                "bandwidth": bandwidth,
+                "ms": ms,
+            }
+        )
 
         return 1000 * ms, 1000 * max_ms, 1000 * min_ms
 
@@ -177,12 +170,6 @@ if __name__ == "__main__":
 
     keys = sweep_params.keys()
     configs = list(itertools.product(*sweep_params.values()))
-    print(f"Testing {len(configs)} configurations...")
-    for config in configs:
-        num_tokens, num_heads, num_kv_heads, rope_dim, is_neox, dtype = config
-        print(
-            f"Config: num_tokens={num_tokens}, num_heads={num_heads}, num_kv_heads={num_kv_heads}, rope_dim: {rope_dim}, is_neox: {is_neox}, dtype={dtype}"
-        )
 
     global benchmark_configs
     benchmark_configs = configs
@@ -190,4 +177,8 @@ if __name__ == "__main__":
     # Run benchmark
     print("Starting performance benchmark...")
     benchmark = get_benchmark()
-    benchmark.run(print_data=True, show_plots=False, save_path=".")
+    benchmark.run(print_data=False)
+    print("Benchmark finished!")
+
+    df = pd.DataFrame(all_results)
+    print(df.to_markdown())

--- a/benchmark/bench_fused_qk_rope_with_cache.py
+++ b/benchmark/bench_fused_qk_rope_with_cache.py
@@ -1,0 +1,193 @@
+import itertools
+
+import torch
+import triton
+from sgl_kernel import fused_qk_rope_with_cos_sin_cache
+
+DEVICE = "xpu"
+MAX_SEQ_LEN = 131072  # common seq length
+
+ROPE_BASE = 10000.0
+CACHE_SIZE = 1024 * 128
+
+
+def create_cos_sin_cache(
+    rotary_dim: int,
+    max_position: int = MAX_SEQ_LEN,
+    base: float = ROPE_BASE,
+) -> torch.Tensor:
+    """Create cos/sin cache compatible with SGLang layout: [max_pos, rotary_dim]."""
+    inv_freq = 1.0 / (
+        base
+        ** (
+            torch.arange(0, rotary_dim, 2, dtype=torch.float32, device=DEVICE)
+            / rotary_dim
+        )
+    )
+    t = torch.arange(max_position, dtype=torch.float32, device=DEVICE)
+    freqs = torch.einsum("i,j->ij", t, inv_freq)
+    cos = freqs.cos()
+    sin = freqs.sin()
+    cache = torch.cat((cos, sin), dim=-1)  # [max_pos, rotary_dim]
+    return cache
+
+
+def apply_rotary_emb(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    is_neox_style: bool,
+) -> torch.Tensor:
+    """
+    Args:
+        x: [num_tokens, num_heads, head_size]
+        cos: [num_tokens, head_size // 2]
+        sin: [num_tokens, head_size // 2]
+        is_neox_style: Whether to use the Neox-style or GPT-J-style rotary
+            positional embeddings.
+    """
+    cos = cos.unsqueeze(-2).to(x.dtype)
+    sin = sin.unsqueeze(-2).to(x.dtype)
+    if is_neox_style:
+        x1, x2 = torch.chunk(x, 2, dim=-1)
+    else:
+        x1 = x[..., ::2]
+        x2 = x[..., 1::2]
+    o1 = x1 * cos - x2 * sin
+    o2 = x2 * cos + x1 * sin
+    if is_neox_style:
+        return torch.cat((o1, o2), dim=-1)
+    else:
+        return torch.stack((o1, o2), dim=-1).flatten(-2)
+
+
+def native_fused_qk_rope_with_cache(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    rotary_dim: int,
+    is_neox: bool,
+):
+    head_size = q.shape[-1]
+    positions = positions.flatten()
+    num_tokens = positions.shape[0]
+    cos_cache, sin_cache = cos_sin_cache.chunk(2, dim=-1)
+    cos = cos_cache[positions]
+    sin = sin_cache[positions]
+
+    query_shape = q.shape
+    query = q.view(num_tokens, -1, head_size)
+    query_rot = query[..., :rotary_dim]
+    query_pass = query[..., rotary_dim:]
+    query_rot = apply_rotary_emb(query_rot, cos, sin, is_neox)
+    query = torch.cat((query_rot, query_pass), dim=-1).reshape(query_shape)
+
+    key_shape = k.shape
+    key = k.view(num_tokens, -1, head_size)
+    key_rot = key[..., :rotary_dim]
+    key_pass = key[..., rotary_dim:]
+    key_rot = apply_rotary_emb(key_rot, cos, sin, is_neox)
+    key = torch.cat((key_rot, key_pass), dim=-1).reshape(key_shape)
+    return query, key
+
+
+def sglang_fused_qk_rope_with_cache(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    rotary_dim: int,
+    is_neox: bool,
+):
+    return fused_qk_rope_with_cos_sin_cache(
+        q, k, cos_sin_cache, positions, rotary_dim, is_neox
+    )
+
+
+def get_benchmark(device="xpu"):
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=[
+                "num_tokens",
+                "num_heads",
+                "num_kv_heads",
+                "rope_dim",
+                "is_neox",
+                "dtype",
+            ],
+            x_vals=configs,
+            line_arg="provider",
+            line_vals=["sglang", "native"],
+            line_names=["SGLang", "native"],
+            styles=[("blue", "-"), ("green", "-")],
+            ylabel="Latency (us)",
+            plot_name="fused-qk-rope-with-cache-performance",
+            args={},
+        )
+    )
+    def benchmark(
+        num_tokens, num_heads, num_kv_heads, rope_dim, is_neox, dtype, provider
+    ):
+
+        q = torch.randn(num_tokens, num_heads, rope_dim, device=device, dtype=dtype)
+        k = torch.randn(num_tokens, num_kv_heads, rope_dim, device=device, dtype=dtype)
+
+        positions = torch.randint(
+            0, MAX_SEQ_LEN, (num_tokens,), device=device, dtype=torch.int64
+        )
+        cos_sin_cache = create_cos_sin_cache(rope_dim).to(dtype)
+
+        if provider == "sglang" or provider == "sglang1":
+            fn = lambda: sglang_fused_qk_rope_with_cache(
+                q, k, cos_sin_cache, positions, rope_dim, is_neox
+            )
+        elif provider == "native":
+            fn = lambda: native_fused_qk_rope_with_cache(
+                q, k, cos_sin_cache, positions, rope_dim, is_neox
+            )
+
+        quantiles = [0.5, 0.2, 0.8]
+        ms, min_ms, max_ms = triton.testing.do_bench(fn, quantiles=quantiles)
+
+        return 1000 * ms, 1000 * max_ms, 1000 * min_ms
+
+    return benchmark
+
+
+if __name__ == "__main__":
+    bs = [1, 2, 4, 8]
+    seq_len = 1024
+    num_tokens = [seq_len * b for b in bs]
+    # configs from llama3.1 8B an Qwen-235B
+    num_heads = [32, 64]
+    num_kv_heads = [4, 8]
+    rope_dim = [128]
+    is_neox = [True]
+    dtype = [torch.bfloat16]
+
+    sweep_params = {
+        "num_tokens": num_tokens,
+        "num_heads": num_heads,
+        "num_kv_heads": num_kv_heads,
+        "rope_dim": rope_dim,
+        "is_neox": is_neox,
+        "dtype": dtype,
+    }
+
+    keys = sweep_params.keys()
+    configs = list(itertools.product(*sweep_params.values()))
+    print(f"Testing {len(configs)} configurations...")
+    for config in configs:
+        num_tokens, num_heads, num_kv_heads, rope_dim, is_neox, dtype = config
+        print(
+            f"Config: num_tokens={num_tokens}, num_heads={num_heads}, num_kv_heads={num_kv_heads}, rope_dim: {rope_dim}, is_neox: {is_neox}, dtype={dtype}"
+        )
+
+    global benchmark_configs
+    benchmark_configs = configs
+
+    # Run benchmark
+    print("Starting performance benchmark...")
+    benchmark = get_benchmark()
+    benchmark.run(print_data=True, show_plots=False, save_path=".")

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -181,6 +181,13 @@ void fused_qk_rope(
     double high,
     double attention_factor,
     int64_t rotary_dim);
+void fused_qk_rope_with_cos_sin_cache(
+    at::Tensor& query,
+    at::Tensor& key,
+    at::Tensor& cos_sin_cache,
+    at::Tensor& positions,
+    int64_t rope_dim,
+    bool is_neox);
 void sgl_per_token_group_quant_fp4(
     at::Tensor input, at::Tensor output_q, at::Tensor output_s, int64_t group_size, double eps);
 }  // namespace at::native::xpu

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -181,7 +181,7 @@ void fused_qk_rope(
     double high,
     double attention_factor,
     int64_t rotary_dim);
-void fused_qk_rope_with_cos_sin_cache(
+void fused_qk_rope_with_cos_sin_cache_inplace(
     at::Tensor& query,
     at::Tensor& key,
     at::Tensor& cos_sin_cache,

--- a/python/sgl_kernel/__init__.py
+++ b/python/sgl_kernel/__init__.py
@@ -24,7 +24,7 @@ from sgl_kernel.elementwise import (
     fused_add_rmsnorm,
     fused_qk_norm_rope,
     fused_qk_rope,
-    fused_qk_rope_with_cos_sin_cache,
+    fused_qk_rope_with_cos_sin_cache_inplace,
     gelu_and_mul,
     gelu_tanh_and_mul,
     gemma_fused_add_rmsnorm,

--- a/python/sgl_kernel/__init__.py
+++ b/python/sgl_kernel/__init__.py
@@ -24,6 +24,7 @@ from sgl_kernel.elementwise import (
     fused_add_rmsnorm,
     fused_qk_norm_rope,
     fused_qk_rope,
+    fused_qk_rope_with_cos_sin_cache,
     gelu_and_mul,
     gelu_tanh_and_mul,
     gemma_fused_add_rmsnorm,

--- a/python/sgl_kernel/elementwise.py
+++ b/python/sgl_kernel/elementwise.py
@@ -425,3 +425,25 @@ def fused_qk_rope(
         attention_factor,
         rotary_dim,
     )
+
+
+def fused_qk_rope_with_cos_sin_cache(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    head_dim: int,
+    is_neox: bool,
+) -> None:
+    r"""Apply RoPE to Q/K using precomputed cos/sin cache.
+
+    This op updates ``q`` and ``k`` in-place.
+    """
+    torch.ops.sgl_kernel.fused_qk_rope_with_cos_sin_cache(
+        q,
+        k,
+        cos_sin_cache,
+        positions,
+        head_dim,
+        is_neox,
+    )

--- a/python/sgl_kernel/elementwise.py
+++ b/python/sgl_kernel/elementwise.py
@@ -427,7 +427,7 @@ def fused_qk_rope(
     )
 
 
-def fused_qk_rope_with_cos_sin_cache(
+def fused_qk_rope_with_cos_sin_cache_inplace(
     q: torch.Tensor,
     k: torch.Tensor,
     cos_sin_cache: torch.Tensor,
@@ -454,7 +454,7 @@ def fused_qk_rope_with_cos_sin_cache(
     is_neox: bool
         Whether to apply NeoX-style rotary layout.
     """
-    torch.ops.sgl_kernel.fused_qk_rope_with_cos_sin_cache(
+    torch.ops.sgl_kernel.fused_qk_rope_with_cos_sin_cache_inplace(
         q,
         k,
         cos_sin_cache,

--- a/python/sgl_kernel/elementwise.py
+++ b/python/sgl_kernel/elementwise.py
@@ -432,18 +432,33 @@ def fused_qk_rope_with_cos_sin_cache(
     k: torch.Tensor,
     cos_sin_cache: torch.Tensor,
     positions: torch.Tensor,
-    head_dim: int,
+    rope_dim: int,
     is_neox: bool,
 ) -> None:
     r"""Apply RoPE to Q/K using precomputed cos/sin cache.
 
-    This op updates ``q`` and ``k`` in-place.
+    Parameters
+    ----------
+    q: torch.Tensor
+        Query tensor updated in-place.
+    k: torch.Tensor
+        Key tensor updated in-place.
+    cos_sin_cache: torch.Tensor
+        Precomputed RoPE cos/sin cache.
+    positions: torch.Tensor
+        Position indices used to index the cache.
+    rope_dim: int
+        Rotary/RoPE dimension represented by ``cos_sin_cache`` (that is,
+        the size of the cached cos/sin concatenation), not the full attention
+        head dimension.
+    is_neox: bool
+        Whether to apply NeoX-style rotary layout.
     """
     torch.ops.sgl_kernel.fused_qk_rope_with_cos_sin_cache(
         q,
         k,
         cos_sin_cache,
         positions,
-        head_dim,
+        rope_dim,
         is_neox,
     )

--- a/src/sycl/FusedQKRope.cpp
+++ b/src/sycl/FusedQKRope.cpp
@@ -397,4 +397,154 @@ void fused_qk_rope(
 #undef FUSED_QK_ROPE_LAUNCH_ARGS
 }
 
+template <bool is_neox, typename scalar_t, typename pos_t>
+struct FusedRopeCacheKernel {
+  scalar_t* query;
+  scalar_t* key;
+  const scalar_t* cos_sin_cache;
+  const pos_t* positions;
+  int64_t q_stride;
+  int64_t k_stride;
+  int64_t q_head_stride;
+  int64_t k_head_stride;
+  int64_t num_tokens;
+  int64_t num_q_heads;
+  int64_t num_k_heads;
+  int64_t rope_dim;
+  int64_t cache_stride;
+  int64_t workers_per_work_group;
+  int64_t total_workers;
+
+  [[sycl::reqd_sub_group_size(16)]]
+  void operator()(sycl::nd_item<1> item) const {
+    const int64_t sg_size = item.get_sub_group().get_max_local_range()[0];
+    assert(sg_size == 16);
+    const int64_t local_id = item.get_local_id(0);
+    const int64_t worker_in_work_group = local_id / sg_size;
+    const int64_t lane_id = local_id % sg_size;
+    const int64_t worker_id = item.get_group(0) * workers_per_work_group + worker_in_work_group;
+
+    const int64_t num_qk_heads = num_q_heads + num_k_heads;
+    const int64_t num_works = num_tokens * num_qk_heads;
+    const int64_t half_rope = rope_dim / 2;
+
+    for (int64_t idx = worker_id; idx < num_works; idx += total_workers) {
+      const int64_t token_id = idx / num_qk_heads;
+      const int64_t head_id = idx % num_qk_heads;
+      const bool is_q_head = head_id < num_q_heads;
+
+      const int64_t pos = static_cast<int64_t>(positions[token_id]);
+      scalar_t* base_ptr = nullptr;
+      int64_t head_index = 0;
+
+      if (is_q_head) {
+        head_index = head_id;
+        base_ptr = query + token_id * q_stride + head_index * q_head_stride;
+      } else {
+        head_index = head_id - num_q_heads;
+        base_ptr = key + token_id * k_stride + head_index * k_head_stride;
+      }
+
+      const scalar_t* cos_ptr = cos_sin_cache + pos * cache_stride;
+      const scalar_t* sin_ptr = cos_ptr + half_rope;
+
+      if constexpr (is_neox) {
+        for (int64_t i = lane_id; i < half_rope; i += sg_size) {
+          const scalar_t x = base_ptr[i];
+          const scalar_t y = base_ptr[i + half_rope];
+          const scalar_t c = cos_ptr[i];
+          const scalar_t s = sin_ptr[i];
+          base_ptr[i] = x * c - y * s;
+          base_ptr[i + half_rope] = x * s + y * c;
+        }
+      } else {
+        for (int64_t i = lane_id; i < half_rope; i += sg_size) {
+          const int64_t x_idx = 2 * i;
+          const int64_t y_idx = 2 * i + 1;
+          const scalar_t x = base_ptr[x_idx];
+          const scalar_t y = base_ptr[y_idx];
+          const scalar_t c = cos_ptr[i];
+          const scalar_t s = sin_ptr[i];
+          base_ptr[x_idx] = x * c - y * s;
+          base_ptr[y_idx] = x * s + y * c;
+        }
+      }
+    }
+  }
+};
+
+template <bool is_neox, typename scalar_t, typename pos_t>
+void launch_fused_rope_cache_kernel_scalar(
+    at::Tensor& query,
+    at::Tensor& key,
+    const at::Tensor& cos_sin_cache,
+    const at::Tensor& positions,
+    int64_t rope_dim) {
+  constexpr int kWorkGroupSize = 128;
+  constexpr int sg_size = 16;
+  static_assert(kWorkGroupSize % sg_size == 0, "kWorkGroupSize must be divisible by subgroup size");
+
+  const int64_t workers_per_work_group = kWorkGroupSize / sg_size;
+  const int64_t num_tokens = query.size(0);
+  const int64_t num_q_heads = query.size(1);
+  const int64_t num_k_heads = key.size(1);
+  const int64_t num_works = num_tokens * (num_q_heads + num_k_heads);
+  const int64_t num_groups = CeilDiv(num_works, workers_per_work_group);
+  const int64_t total_workers = num_groups * workers_per_work_group;
+
+  FusedRopeCacheKernel<is_neox, scalar_t, pos_t> kernel{
+      query.data_ptr<scalar_t>(),
+      key.data_ptr<scalar_t>(),
+      cos_sin_cache.data_ptr<scalar_t>(),
+      positions.data_ptr<pos_t>(),
+      query.stride(0),
+      key.stride(0),
+      query.stride(1),
+      key.stride(1),
+      num_tokens,
+      num_q_heads,
+      num_k_heads,
+      rope_dim,
+      cos_sin_cache.stride(0),
+      workers_per_work_group,
+      total_workers};
+
+  sycl_kernel_submit(
+      sycl::range<1>(num_groups * kWorkGroupSize), sycl::range<1>(kWorkGroupSize), dpcppGetCurrentQueue(), kernel);
+}
+
+void fused_qk_rope_with_cos_sin_cache(
+    at::Tensor& query,
+    at::Tensor& key,
+    at::Tensor& cos_sin_cache,
+    at::Tensor& positions,
+    int64_t rope_dim,
+    bool is_neox) {
+  const auto input_dim = query.dim();
+  // Note that query and key were truncated to rope_dim here if head_dim is larger.
+  TORCH_CHECK(
+      input_dim == 3, "fused_qk_rope_with_cos_sin_cache only supports 3D input [num_tokens, num_heads, rope_dim]");
+
+  SYCL_DISPATCH_FLOATING_TYPES(
+      at::ScalarType::Half, at::ScalarType::BFloat16, query.scalar_type(), "fused_qk_rope_with_cos_sin_cache", [&]() {
+        if (positions.scalar_type() == at::kInt) {
+          if (is_neox) {
+            launch_fused_rope_cache_kernel_scalar<true, scalar_t, int32_t>(
+                query, key, cos_sin_cache, positions, rope_dim);
+          } else {
+            launch_fused_rope_cache_kernel_scalar<false, scalar_t, int32_t>(
+                query, key, cos_sin_cache, positions, rope_dim);
+          }
+        } else {
+          if (is_neox) {
+            launch_fused_rope_cache_kernel_scalar<true, scalar_t, int64_t>(
+                query, key, cos_sin_cache, positions, rope_dim);
+          } else {
+            launch_fused_rope_cache_kernel_scalar<false, scalar_t, int64_t>(
+                query, key, cos_sin_cache, positions, rope_dim);
+          }
+        }
+      });
+}
+
 }  // namespace at::native::xpu

--- a/src/sycl/FusedQKRope.cpp
+++ b/src/sycl/FusedQKRope.cpp
@@ -397,7 +397,7 @@ void fused_qk_rope(
 #undef FUSED_QK_ROPE_LAUNCH_ARGS
 }
 
-template <bool is_neox, typename scalar_t, typename pos_t>
+template <bool is_neox, int64_t rope_dim, typename scalar_t, typename pos_t>
 struct FusedRopeCacheKernel {
   scalar_t* query;
   scalar_t* key;
@@ -410,14 +410,13 @@ struct FusedRopeCacheKernel {
   int64_t num_tokens;
   int64_t num_q_heads;
   int64_t num_k_heads;
-  int64_t rope_dim;
   int64_t cache_stride;
   int64_t workers_per_work_group;
   int64_t total_workers;
 
   [[sycl::reqd_sub_group_size(16)]]
   void operator()(sycl::nd_item<1> item) const {
-    const int64_t sg_size = item.get_sub_group().get_max_local_range()[0];
+    constexpr int64_t sg_size = 16;
     assert(sg_size == 16);
     const int64_t local_id = item.get_local_id(0);
     const int64_t worker_in_work_group = local_id / sg_size;
@@ -426,7 +425,7 @@ struct FusedRopeCacheKernel {
 
     const int64_t num_qk_heads = num_q_heads + num_k_heads;
     const int64_t num_works = num_tokens * num_qk_heads;
-    const int64_t half_rope = rope_dim / 2;
+    constexpr int64_t half_rope = rope_dim / 2;
 
     for (int64_t idx = worker_id; idx < num_works; idx += total_workers) {
       const int64_t token_id = idx / num_qk_heads;
@@ -449,6 +448,7 @@ struct FusedRopeCacheKernel {
       const scalar_t* sin_ptr = cos_ptr + half_rope;
 
       if constexpr (is_neox) {
+#pragma unroll
         for (int64_t i = lane_id; i < half_rope; i += sg_size) {
           const scalar_t x = base_ptr[i];
           const scalar_t y = base_ptr[i + half_rope];
@@ -458,6 +458,7 @@ struct FusedRopeCacheKernel {
           base_ptr[i + half_rope] = x * s + y * c;
         }
       } else {
+#pragma unroll
         for (int64_t i = lane_id; i < half_rope; i += sg_size) {
           const int64_t x_idx = 2 * i;
           const int64_t y_idx = 2 * i + 1;
@@ -473,13 +474,9 @@ struct FusedRopeCacheKernel {
   }
 };
 
-template <bool is_neox, typename scalar_t, typename pos_t>
+template <bool is_neox, int64_t rope_dim, typename scalar_t, typename pos_t>
 void launch_fused_rope_cache_kernel_scalar(
-    at::Tensor& query,
-    at::Tensor& key,
-    const at::Tensor& cos_sin_cache,
-    const at::Tensor& positions,
-    int64_t rope_dim) {
+    at::Tensor& query, at::Tensor& key, const at::Tensor& cos_sin_cache, const at::Tensor& positions) {
   constexpr int kWorkGroupSize = 128;
   constexpr int sg_size = 16;
   static_assert(kWorkGroupSize % sg_size == 0, "kWorkGroupSize must be divisible by subgroup size");
@@ -492,7 +489,7 @@ void launch_fused_rope_cache_kernel_scalar(
   const int64_t num_groups = CeilDiv(num_works, workers_per_work_group);
   const int64_t total_workers = num_groups * workers_per_work_group;
 
-  FusedRopeCacheKernel<is_neox, scalar_t, pos_t> kernel{
+  FusedRopeCacheKernel<is_neox, rope_dim, scalar_t, pos_t> kernel{
       query.data_ptr<scalar_t>(),
       key.data_ptr<scalar_t>(),
       cos_sin_cache.data_ptr<scalar_t>(),
@@ -504,7 +501,6 @@ void launch_fused_rope_cache_kernel_scalar(
       num_tokens,
       num_q_heads,
       num_k_heads,
-      rope_dim,
       cos_sin_cache.stride(0),
       workers_per_work_group,
       total_workers};
@@ -513,7 +509,7 @@ void launch_fused_rope_cache_kernel_scalar(
       sycl::range<1>(num_groups * kWorkGroupSize), sycl::range<1>(kWorkGroupSize), dpcppGetCurrentQueue(), kernel);
 }
 
-void fused_qk_rope_with_cos_sin_cache(
+void fused_qk_rope_with_cos_sin_cache_inplace(
     at::Tensor& query,
     at::Tensor& key,
     at::Tensor& cos_sin_cache,
@@ -523,28 +519,49 @@ void fused_qk_rope_with_cos_sin_cache(
   const auto input_dim = query.dim();
   // Note that query and key were truncated to rope_dim here if head_dim is larger.
   TORCH_CHECK(
-      input_dim == 3, "fused_qk_rope_with_cos_sin_cache only supports 3D input [num_tokens, num_heads, rope_dim]");
+      input_dim == 3,
+      "fused_qk_rope_with_cos_sin_cache_inplace only supports 3D input [num_tokens, num_heads, rope_dim]");
+
+#define LAUNCH_ROPE_CACHE_KERNEL(IS_NEOX, POS_T)                                                                  \
+  switch (rope_dim) {                                                                                             \
+    case 64:                                                                                                      \
+      launch_fused_rope_cache_kernel_scalar<IS_NEOX, 64, scalar_t, POS_T>(query, key, cos_sin_cache, positions);  \
+      break;                                                                                                      \
+    case 128:                                                                                                     \
+      launch_fused_rope_cache_kernel_scalar<IS_NEOX, 128, scalar_t, POS_T>(query, key, cos_sin_cache, positions); \
+      break;                                                                                                      \
+    case 256:                                                                                                     \
+      launch_fused_rope_cache_kernel_scalar<IS_NEOX, 256, scalar_t, POS_T>(query, key, cos_sin_cache, positions); \
+      break;                                                                                                      \
+    case 512:                                                                                                     \
+      launch_fused_rope_cache_kernel_scalar<IS_NEOX, 512, scalar_t, POS_T>(query, key, cos_sin_cache, positions); \
+      break;                                                                                                      \
+    default:                                                                                                      \
+      TORCH_CHECK(false, "Unsupported rope_dim: ", rope_dim);                                                     \
+  }
+
+#define DISPATCH_ROPE_CACHE_KERNEL_BY_LAYOUT(POS_T) \
+  if (is_neox) {                                    \
+    LAUNCH_ROPE_CACHE_KERNEL(true, POS_T);          \
+  } else {                                          \
+    LAUNCH_ROPE_CACHE_KERNEL(false, POS_T);         \
+  }
 
   SYCL_DISPATCH_FLOATING_TYPES(
-      at::ScalarType::Half, at::ScalarType::BFloat16, query.scalar_type(), "fused_qk_rope_with_cos_sin_cache", [&]() {
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      query.scalar_type(),
+      "fused_qk_rope_with_cos_sin_cache_inplace",
+      [&]() {
         if (positions.scalar_type() == at::kInt) {
-          if (is_neox) {
-            launch_fused_rope_cache_kernel_scalar<true, scalar_t, int32_t>(
-                query, key, cos_sin_cache, positions, rope_dim);
-          } else {
-            launch_fused_rope_cache_kernel_scalar<false, scalar_t, int32_t>(
-                query, key, cos_sin_cache, positions, rope_dim);
-          }
+          DISPATCH_ROPE_CACHE_KERNEL_BY_LAYOUT(int32_t);
         } else {
-          if (is_neox) {
-            launch_fused_rope_cache_kernel_scalar<true, scalar_t, int64_t>(
-                query, key, cos_sin_cache, positions, rope_dim);
-          } else {
-            launch_fused_rope_cache_kernel_scalar<false, scalar_t, int64_t>(
-                query, key, cos_sin_cache, positions, rope_dim);
-          }
+          DISPATCH_ROPE_CACHE_KERNEL_BY_LAYOUT(int64_t);
         }
       });
+
+#undef DISPATCH_ROPE_CACHE_KERNEL_BY_LAYOUT
+#undef LAUNCH_ROPE_CACHE_KERNEL
 }
 
 }  // namespace at::native::xpu

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -178,9 +178,13 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("fused_qk_rope", torch::kXPU, &at::native::xpu::fused_qk_rope);
 
   m.def(
-      "fused_qk_rope_with_cos_sin_cache(Tensor! q, Tensor! k, Tensor! cos_sin_cache, Tensor! positions, int rope_dim, "
+      "fused_qk_rope_with_cos_sin_cache_inplace(Tensor! q, Tensor! k, Tensor! cos_sin_cache, Tensor! positions, int "
+      "rope_dim, "
       "bool is_neox) -> ()");
-  m.impl("fused_qk_rope_with_cos_sin_cache", torch::kXPU, &at::native::xpu::fused_qk_rope_with_cos_sin_cache);
+  m.impl(
+      "fused_qk_rope_with_cos_sin_cache_inplace",
+      torch::kXPU,
+      &at::native::xpu::fused_qk_rope_with_cos_sin_cache_inplace);
 
   /* utils */
   m.def("query_device(int device_id) -> (int, int)");

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -176,6 +176,12 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "Tensor! q_weight, Tensor! k_weight, float base, bool is_neox, Tensor! position_ids, "
       "float factor, float low, float high, float attention_factor, int rotary_dim) -> ()");
   m.impl("fused_qk_rope", torch::kXPU, &at::native::xpu::fused_qk_rope);
+
+  m.def(
+      "fused_qk_rope_with_cos_sin_cache(Tensor! q, Tensor! k, Tensor! cos_sin_cache, Tensor! positions, int rope_dim, "
+      "bool is_neox) -> ()");
+  m.impl("fused_qk_rope_with_cos_sin_cache", torch::kXPU, &at::native::xpu::fused_qk_rope_with_cos_sin_cache);
+
   /* utils */
   m.def("query_device(int device_id) -> (int, int)");
   m.impl("query_device", c10::DispatchKey::BackendSelect, &query_device);

--- a/tests/run_suite.py
+++ b/tests/run_suite.py
@@ -29,6 +29,7 @@ suites = {
         TestFile("test_moe_fused_gate.py"),
         TestFile("test_per_tensor_quant_fp8.py"),
         TestFile("test_fused_qk_norm_rope.py"),
+        TestFile("test_fused_qk_rope_with_cache.py"),
         TestFile("test_merge_state_v2.py"),
         TestFile("test_norm.py"),
         TestFile("test_per_token_group_quant_8bit_v2.py"),

--- a/tests/test_fused_qk_rope_with_cache.py
+++ b/tests/test_fused_qk_rope_with_cache.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import triton
 import utils
-from sgl_kernel import fused_qk_rope_with_cos_sin_cache
+from sgl_kernel import fused_qk_rope_with_cos_sin_cache_inplace
 
 DEVICE = utils.get_device()
 DTYPE = torch.bfloat16
@@ -106,7 +106,7 @@ def fused_qk_rope_with_cache(
     rotary_dim: int,
     is_neox: bool,
 ):
-    return fused_qk_rope_with_cos_sin_cache(
+    return fused_qk_rope_with_cos_sin_cache_inplace(
         q, k, cos_sin_cache, positions, rotary_dim, is_neox
     )
 
@@ -149,7 +149,7 @@ def test_rope(
 
     q_ker, k_ker = q.clone(), k.clone()
     q_na, k_na = torch_impl_rope(q, k, cos_sin_cache, positions, rope_dim, is_neox)
-    fused_qk_rope_with_cos_sin_cache(
+    fused_qk_rope_with_cos_sin_cache_inplace(
         q_ker, k_ker, cos_sin_cache, positions, rope_dim, is_neox
     )
 
@@ -171,7 +171,7 @@ def test_rope_position_dtypes(dtype: torch.dtype) -> None:
 
     q_ker, k_ker = q.clone(), k.clone()
     q_na, k_na = torch_impl_rope(q, k, cos_sin_cache, positions, rope_dim, is_neox)
-    fused_qk_rope_with_cos_sin_cache(
+    fused_qk_rope_with_cos_sin_cache_inplace(
         q_ker, k_ker, cos_sin_cache, positions, rope_dim, is_neox
     )
     atol = rtol = 1e-2

--- a/tests/test_fused_qk_rope_with_cache.py
+++ b/tests/test_fused_qk_rope_with_cache.py
@@ -1,0 +1,180 @@
+import sys
+
+import pytest
+import torch
+import triton
+import utils
+from sgl_kernel import fused_qk_rope_with_cos_sin_cache
+
+DEVICE = utils.get_device()
+DTYPE = torch.bfloat16
+MAX_SEQ_LEN = 131072  # common seq length
+ROPE_BASE = 10000.0
+CACHE_SIZE = 1024 * 128
+
+
+def create_cos_sin_cache(
+    rotary_dim: int,
+    max_position: int = MAX_SEQ_LEN,
+    base: float = ROPE_BASE,
+) -> torch.Tensor:
+    """Create cos/sin cache compatible with SGLang layout: [max_pos, rotary_dim]."""
+    inv_freq = 1.0 / (
+        base
+        ** (
+            torch.arange(0, rotary_dim, 2, dtype=torch.float32, device=DEVICE)
+            / rotary_dim
+        )
+    )
+    t = torch.arange(max_position, dtype=torch.float32, device=DEVICE)
+    freqs = torch.einsum("i,j->ij", t, inv_freq)
+    cos = freqs.cos()
+    sin = freqs.sin()
+    cache = torch.cat((cos, sin), dim=-1)  # [max_pos, rotary_dim]
+    return cache
+
+
+def apply_rotary_emb(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    is_neox_style: bool,
+) -> torch.Tensor:
+    """
+    Args:
+        x: [num_tokens, num_heads, head_size]
+        cos: [num_tokens, head_size // 2]
+        sin: [num_tokens, head_size // 2]
+        is_neox_style: Whether to use the Neox-style or GPT-J-style rotary
+            positional embeddings.
+    """
+    cos = cos.unsqueeze(-2).to(x.dtype)
+    sin = sin.unsqueeze(-2).to(x.dtype)
+    if is_neox_style:
+        x1, x2 = torch.chunk(x, 2, dim=-1)
+    else:
+        x1 = x[..., ::2]
+        x2 = x[..., 1::2]
+    o1 = x1 * cos - x2 * sin
+    o2 = x2 * cos + x1 * sin
+    if is_neox_style:
+        return torch.cat((o1, o2), dim=-1)
+    else:
+        return torch.stack((o1, o2), dim=-1).flatten(-2)
+
+
+def torch_impl_rope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    rotary_dim: int,
+    is_neox: bool,
+):
+    head_size = q.shape[-1]
+    positions = positions.flatten()
+    num_tokens = positions.shape[0]
+    rotary_dim = cos_sin_cache.shape[-1]
+    cos_cache, sin_cache = cos_sin_cache.chunk(2, dim=-1)
+    cos = cos_cache[positions]
+    sin = sin_cache[positions]
+
+    query_shape = q.shape
+    query = q.view(num_tokens, -1, head_size)
+    query_rot = query[..., :rotary_dim]
+    query_pass = query[..., rotary_dim:]
+    query_rot = apply_rotary_emb(query_rot, cos, sin, is_neox)
+    query = torch.cat((query_rot, query_pass), dim=-1).reshape(query_shape)
+
+    key_shape = k.shape
+    key = k.view(num_tokens, -1, head_size)
+    key_rot = key[..., :rotary_dim]
+    key_pass = key[..., rotary_dim:]
+    key_rot = apply_rotary_emb(key_rot, cos, sin, is_neox)
+    key = torch.cat((key_rot, key_pass), dim=-1).reshape(key_shape)
+    return query, key
+
+
+def fused_qk_rope_with_cache(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    rotary_dim: int,
+    is_neox: bool,
+):
+    return fused_qk_rope_with_cos_sin_cache(
+        q, k, cos_sin_cache, positions, rotary_dim, is_neox
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test parameters
+# ---------------------------------------------------------------------------
+
+BS_LIST = [1, 128, 2048]
+NUM_KV_HEADS_LIST = [1, 4]
+GQA_RATIO = [1, 8]
+ROPE_DIM_LIST = [64, 256]
+IS_NEOX_LIST = [False, True]
+DTYPE_LIST = [torch.bfloat16, torch.float16]
+PARTIAL_ROPE_DIM_LIST = [64, 96]
+HEAD_DIM_LIST = [64, 256]
+
+
+@pytest.mark.parametrize("batch_size", BS_LIST)
+@pytest.mark.parametrize("gqa_ratio", GQA_RATIO)
+@pytest.mark.parametrize("num_kv_heads", NUM_KV_HEADS_LIST)
+@pytest.mark.parametrize("rope_dim", ROPE_DIM_LIST)
+@pytest.mark.parametrize("is_neox", IS_NEOX_LIST)
+@pytest.mark.parametrize("dtype", DTYPE_LIST)
+def test_rope(
+    batch_size: int,
+    gqa_ratio: int,
+    num_kv_heads: int,
+    rope_dim: int,
+    is_neox: bool,
+    dtype: torch.dtype,
+) -> None:
+    num_qo_heads = num_kv_heads * gqa_ratio
+    q = torch.randn(batch_size, num_qo_heads, rope_dim, device=DEVICE, dtype=dtype)
+    k = torch.randn(batch_size, num_kv_heads, rope_dim, device=DEVICE, dtype=dtype)
+    positions = torch.randint(
+        0, MAX_SEQ_LEN, (batch_size,), device=DEVICE, dtype=torch.int64
+    )
+    cos_sin_cache = create_cos_sin_cache(rope_dim).to(dtype)
+
+    q_ker, k_ker = q.clone(), k.clone()
+    q_na, k_na = torch_impl_rope(q, k, cos_sin_cache, positions, rope_dim, is_neox)
+    fused_qk_rope_with_cos_sin_cache(
+        q_ker, k_ker, cos_sin_cache, positions, rope_dim, is_neox
+    )
+
+    atol = rtol = 1e-2
+    triton.testing.assert_close(q_na, q_ker, atol=atol, rtol=rtol)
+    triton.testing.assert_close(k_na, k_ker, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("dtype", [torch.int32, torch.int64])
+def test_rope_position_dtypes(dtype: torch.dtype) -> None:
+    """Ensure both int32 and int64 position tensors work correctly."""
+    batch_size, num_qo_heads, num_kv_heads, rope_dim = 16384, 16, 2, 128
+    is_neox = True
+
+    q = torch.randn(batch_size, num_qo_heads, rope_dim, device=DEVICE, dtype=DTYPE)
+    k = torch.randn(batch_size, num_kv_heads, rope_dim, device=DEVICE, dtype=DTYPE)
+    positions = torch.randint(0, MAX_SEQ_LEN, (batch_size,), device=DEVICE, dtype=dtype)
+    cos_sin_cache = create_cos_sin_cache(rope_dim).to(DTYPE)
+
+    q_ker, k_ker = q.clone(), k.clone()
+    q_na, k_na = torch_impl_rope(q, k, cos_sin_cache, positions, rope_dim, is_neox)
+    fused_qk_rope_with_cos_sin_cache(
+        q_ker, k_ker, cos_sin_cache, positions, rope_dim, is_neox
+    )
+    atol = rtol = 1e-2
+    triton.testing.assert_close(q_na, q_ker, atol=atol, rtol=rtol)
+    triton.testing.assert_close(k_na, k_ker, atol=atol, rtol=rtol)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/tests/test_fused_qk_rope_with_cache.py
+++ b/tests/test_fused_qk_rope_with_cache.py
@@ -74,7 +74,10 @@ def torch_impl_rope(
     head_size = q.shape[-1]
     positions = positions.flatten()
     num_tokens = positions.shape[0]
-    rotary_dim = cos_sin_cache.shape[-1]
+    assert rotary_dim == cos_sin_cache.size(-1), (
+        f"rotary_dim ({rotary_dim}) must match cos/sin cache rotary width "
+        f"({cos_cache.size(-1)})"
+    )
     cos_cache, sin_cache = cos_sin_cache.chunk(2, dim=-1)
     cos = cos_cache[positions]
     sin = sin_cache[positions]


### PR DESCRIPTION
The original kernel of '**fused_qk_rope**' accepts qkv fused tensor input and doesn't use pre-computed cos_sin_cache. Add this **cos_sin_cache** version to make the interface aligned to sglang calling.
Sglang enabling PR in https://github.com/sgl-project/sglang/pull/25773

The code logic the same as [cuda_rope_sglang](https://github.com/sgl-project/sglang/blob/main/python/sglang/jit_kernel/csrc/elementwise/rope.cuh).