### PR TITLE
 Add fused store_cache_xpu kernel

### DIFF
--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -190,6 +190,7 @@ void fused_qk_rope_with_cos_sin_cache_inplace(
     bool is_neox);
 void sgl_per_token_group_quant_fp4(
     at::Tensor input, at::Tensor output_q, at::Tensor output_s, int64_t group_size, double eps);
+void store_cache_xpu(at::Tensor& k, at::Tensor& v, at::Tensor& k_cache, at::Tensor& v_cache, at::Tensor& indices);
 }  // namespace at::native::xpu
 void silu_and_mul(torch::Tensor& out, torch::Tensor& input);
 void gelu_tanh_and_mul(torch::Tensor& out, torch::Tensor& input);

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -190,7 +190,7 @@ void fused_qk_rope_with_cos_sin_cache_inplace(
     bool is_neox);
 void sgl_per_token_group_quant_fp4(
     at::Tensor input, at::Tensor output_q, at::Tensor output_s, int64_t group_size, double eps);
-void store_cache_xpu(at::Tensor& k, at::Tensor& v, at::Tensor& k_cache, at::Tensor& v_cache, at::Tensor& indices);
+void store_cache(at::Tensor& k, at::Tensor& v, at::Tensor& k_cache, at::Tensor& v_cache, at::Tensor& indices);
 }  // namespace at::native::xpu
 void silu_and_mul(torch::Tensor& out, torch::Tensor& input);
 void gelu_tanh_and_mul(torch::Tensor& out, torch::Tensor& input);

--- a/python/sgl_kernel/__init__.py
+++ b/python/sgl_kernel/__init__.py
@@ -31,6 +31,7 @@ from sgl_kernel.elementwise import (
     gemma_rmsnorm,
     rmsnorm,
     silu_and_mul,
+    store_cache_xpu,
 )
 from sgl_kernel.gemm import (
     awq_dequantize,

--- a/python/sgl_kernel/elementwise.py
+++ b/python/sgl_kernel/elementwise.py
@@ -195,6 +195,35 @@ def gelu_and_mul(input: torch.Tensor, out: torch.Tensor = None) -> torch.Tensor:
     return out
 
 
+def store_cache_xpu(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    indices: torch.Tensor,
+) -> None:
+    r"""Fused KV-cache store for XPU.
+
+    Writes K and V into the flat KV-cache at the given slot indices in a
+    single SYCL kernel launch (replacing 2x aten::_index_put_impl_).
+
+    Parameters
+    ----------
+    k : torch.Tensor
+        Key tensor, shape: ``(num_tokens, row_dim)``.
+    v : torch.Tensor
+        Value tensor, shape: ``(num_tokens, row_dim)``.
+    k_cache : torch.Tensor
+        Key cache buffer, shape: ``(cache_size, row_dim)``.
+    v_cache : torch.Tensor
+        Value cache buffer, shape: ``(cache_size, row_dim)``.
+    indices : torch.Tensor
+        Flat cache slot indices, shape: ``(num_tokens,)``, dtype int64.
+        Use -1 to skip a token.
+    """
+    torch.ops.sgl_kernel.store_cache_xpu(k, v, k_cache, v_cache, indices.long())
+
+
 def apply_rope_with_cos_sin_cache_inplace(
     positions: torch.Tensor,
     query: torch.Tensor,

--- a/python/sgl_kernel/elementwise.py
+++ b/python/sgl_kernel/elementwise.py
@@ -221,7 +221,7 @@ def store_cache_xpu(
         Flat cache slot indices, shape: ``(num_tokens,)``, dtype int64.
         Use -1 to skip a token.
     """
-    torch.ops.sgl_kernel.store_cache_xpu(k, v, k_cache, v_cache, indices.long())
+    torch.ops.sgl_kernel.store_cache(k, v, k_cache, v_cache, indices.long())
 
 
 def apply_rope_with_cos_sin_cache_inplace(

--- a/src/sycl/KVCache.cpp
+++ b/src/sycl/KVCache.cpp
@@ -20,17 +20,27 @@ struct StoreCacheKernel {
     scalar_t* k_dst = k_cache_ + cache_idx * row_dim_;
     scalar_t* v_dst = v_cache_ + cache_idx * row_dim_;
 
+    // K/V are a pure copy. For 2-byte scalar_t (bf16/half) we move 16 bytes at a
+    // time as one Intel Xe LSC OWord message via sycl::vec<uint32_t, 4>, using the
+    // native sycl::vec::load/store(offset, ptr) API (no memcpy) — offset is in units
+    // of the 16-byte pack, ptr is the reinterpreted uint32_t row base. This mirrors
+    // the B1 V-write idiom in Rope.cpp and src/sycl/merge_states.cpp:106. A native
+    // sycl::vec<scalar_t, 8> would hit the c10::BFloat16/Half element-type-trait
+    // mismatch and (measured on the rope kernel) does not coalesce to one OWord.
     using pack_t = sycl::vec<uint32_t, 4>;
     constexpr int64_t vec_width = sizeof(pack_t) / sizeof(scalar_t);
     const int64_t vec_count = row_dim_ / vec_width;
 
+    auto* k_src_p = reinterpret_cast<uint32_t*>(k_src);
+    auto* v_src_p = reinterpret_cast<uint32_t*>(v_src);
+    auto* k_dst_p = reinterpret_cast<uint32_t*>(k_dst);
+    auto* v_dst_p = reinterpret_cast<uint32_t*>(v_dst);
     for (int64_t i = local_id; i < vec_count; i += local_range) {
       pack_t kp, vp;
-      const int64_t off = i * vec_width;
-      memcpy(&kp, k_src + off, sizeof(pack_t));
-      memcpy(&vp, v_src + off, sizeof(pack_t));
-      memcpy(k_dst + off, &kp, sizeof(pack_t));
-      memcpy(v_dst + off, &vp, sizeof(pack_t));
+      kp.load(i, k_src_p);
+      vp.load(i, v_src_p);
+      kp.store(i, k_dst_p);
+      vp.store(i, v_dst_p);
     }
     for (int64_t i = vec_count * vec_width + local_id; i < row_dim_; i += local_range) {
       k_dst[i] = k_src[i];
@@ -46,7 +56,7 @@ struct StoreCacheKernel {
   int64_t row_dim_;
 };
 
-void store_cache_xpu(at::Tensor& k, at::Tensor& v, at::Tensor& k_cache, at::Tensor& v_cache, at::Tensor& indices) {
+void store_cache(at::Tensor& k, at::Tensor& v, at::Tensor& k_cache, at::Tensor& v_cache, at::Tensor& indices) {
   CHECK_DEVICE(k);
   CHECK_DEVICE(v);
   CHECK_DEVICE(k_cache);
@@ -84,22 +94,21 @@ void store_cache_xpu(at::Tensor& k, at::Tensor& v, at::Tensor& k_cache, at::Tens
   int64_t max_wg_size = dpcppMaxWorkGroupSize(dev_id);
   int64_t group_size = std::min<int64_t>(std::min<int64_t>(row_dim, 512), max_wg_size);
 
-  SYCL_DISPATCH_FLOATING_TYPES(
-      at::ScalarType::Half, at::ScalarType::BFloat16, k.scalar_type(), "store_cache_xpu", [&]() {
-        auto cgf = DPCPP_Q_CGF(cgh) {
-          StoreCacheKernel<scalar_t> kernel = {
-              .k_ = k.data_ptr<scalar_t>(),
-              .v_ = v.data_ptr<scalar_t>(),
-              .k_cache_ = k_cache.data_ptr<scalar_t>(),
-              .v_cache_ = v_cache.data_ptr<scalar_t>(),
-              .indices_ = indices.data_ptr<int64_t>(),
-              .row_dim_ = row_dim,
-          };
-          cgh.parallel_for<decltype(kernel)>(
-              sycl::nd_range<1>(sycl::range<1>(num_tokens * group_size), sycl::range<1>(group_size)), kernel);
-        };
-        dpcppGetCurrentQueue().submit(cgf);
-      });
+  SYCL_DISPATCH_FLOATING_TYPES(at::ScalarType::Half, at::ScalarType::BFloat16, k.scalar_type(), "store_cache", [&]() {
+    auto cgf = DPCPP_Q_CGF(cgh) {
+      StoreCacheKernel<scalar_t> kernel = {
+          .k_ = k.data_ptr<scalar_t>(),
+          .v_ = v.data_ptr<scalar_t>(),
+          .k_cache_ = k_cache.data_ptr<scalar_t>(),
+          .v_cache_ = v_cache.data_ptr<scalar_t>(),
+          .indices_ = indices.data_ptr<int64_t>(),
+          .row_dim_ = row_dim,
+      };
+      cgh.parallel_for<decltype(kernel)>(
+          sycl::nd_range<1>(sycl::range<1>(num_tokens * group_size), sycl::range<1>(group_size)), kernel);
+    };
+    dpcppGetCurrentQueue().submit(cgf);
+  });
 }
 
 }  // namespace at::native::xpu

--- a/src/sycl/KVCache.cpp
+++ b/src/sycl/KVCache.cpp
@@ -20,7 +20,22 @@ struct StoreCacheKernel {
     scalar_t* k_dst = k_cache_ + cache_idx * row_dim_;
     scalar_t* v_dst = v_cache_ + cache_idx * row_dim_;
 
-    for (int64_t i = local_id; i < row_dim_; i += local_range) {
+    // Vectorized copy: 4 elements at a time (8 bytes for bf16/fp16)
+    constexpr int64_t vec_width = sizeof(uint64_t) / sizeof(scalar_t);
+    int64_t row_dim_vec = (row_dim_ / vec_width) * vec_width;
+
+    auto* k_src_vec = reinterpret_cast<const uint64_t*>(k_src);
+    auto* v_src_vec = reinterpret_cast<const uint64_t*>(v_src);
+    auto* k_dst_vec = reinterpret_cast<uint64_t*>(k_dst);
+    auto* v_dst_vec = reinterpret_cast<uint64_t*>(v_dst);
+    int64_t vec_count = row_dim_vec / vec_width;
+
+    for (int64_t i = local_id; i < vec_count; i += local_range) {
+      k_dst_vec[i] = k_src_vec[i];
+      v_dst_vec[i] = v_src_vec[i];
+    }
+    // Handle remaining elements
+    for (int64_t i = row_dim_vec + local_id; i < row_dim_; i += local_range) {
       k_dst[i] = k_src[i];
       v_dst[i] = v_src[i];
     }
@@ -35,9 +50,33 @@ struct StoreCacheKernel {
 };
 
 void store_cache_xpu(at::Tensor& k, at::Tensor& v, at::Tensor& k_cache, at::Tensor& v_cache, at::Tensor& indices) {
+  CHECK_DEVICE(k);
+  CHECK_DEVICE(v);
+  CHECK_DEVICE(k_cache);
+  CHECK_DEVICE(v_cache);
+  CHECK_DEVICE(indices);
+
+  CHECK_CONTIGUOUS(k);
+  CHECK_CONTIGUOUS(v);
+  CHECK_CONTIGUOUS(k_cache);
+  CHECK_CONTIGUOUS(v_cache);
+  CHECK_CONTIGUOUS(indices);
+
   TORCH_CHECK(k.dim() == 2, "k must be 2D [num_tokens, row_dim]");
   TORCH_CHECK(v.dim() == 2, "v must be 2D [num_tokens, row_dim]");
   TORCH_CHECK(k_cache.dim() == 2, "k_cache must be 2D [cache_size, row_dim]");
+  TORCH_CHECK(v_cache.dim() == 2, "v_cache must be 2D [cache_size, row_dim]");
+  TORCH_CHECK(indices.dim() == 1, "indices must be 1D [num_tokens]");
+
+  TORCH_CHECK(v.sizes() == k.sizes(), "v shape must match k shape");
+  TORCH_CHECK(v_cache.sizes() == k_cache.sizes(), "v_cache shape must match k_cache shape");
+  TORCH_CHECK(k.size(1) == k_cache.size(1), "k row_dim must match k_cache row_dim");
+  TORCH_CHECK(indices.size(0) == k.size(0), "indices length must match num_tokens");
+
+  TORCH_CHECK(indices.scalar_type() == at::kLong, "indices must be int64");
+  TORCH_CHECK(k.dtype() == v.dtype(), "k and v must have the same dtype");
+  TORCH_CHECK(k.dtype() == k_cache.dtype(), "k and k_cache must have the same dtype");
+  TORCH_CHECK(k.dtype() == v_cache.dtype(), "k and v_cache must have the same dtype");
 
   int64_t num_tokens = k.size(0);
   int64_t row_dim = k.size(1);

--- a/src/sycl/KVCache.cpp
+++ b/src/sycl/KVCache.cpp
@@ -20,22 +20,19 @@ struct StoreCacheKernel {
     scalar_t* k_dst = k_cache_ + cache_idx * row_dim_;
     scalar_t* v_dst = v_cache_ + cache_idx * row_dim_;
 
-    // Vectorized copy: 4 elements at a time (8 bytes for bf16/fp16)
-    constexpr int64_t vec_width = sizeof(uint64_t) / sizeof(scalar_t);
-    int64_t row_dim_vec = (row_dim_ / vec_width) * vec_width;
-
-    auto* k_src_vec = reinterpret_cast<const uint64_t*>(k_src);
-    auto* v_src_vec = reinterpret_cast<const uint64_t*>(v_src);
-    auto* k_dst_vec = reinterpret_cast<uint64_t*>(k_dst);
-    auto* v_dst_vec = reinterpret_cast<uint64_t*>(v_dst);
-    int64_t vec_count = row_dim_vec / vec_width;
+    using pack_t = sycl::vec<uint32_t, 4>;
+    constexpr int64_t vec_width = sizeof(pack_t) / sizeof(scalar_t);
+    const int64_t vec_count = row_dim_ / vec_width;
 
     for (int64_t i = local_id; i < vec_count; i += local_range) {
-      k_dst_vec[i] = k_src_vec[i];
-      v_dst_vec[i] = v_src_vec[i];
+      pack_t kp, vp;
+      const int64_t off = i * vec_width;
+      memcpy(&kp, k_src + off, sizeof(pack_t));
+      memcpy(&vp, v_src + off, sizeof(pack_t));
+      memcpy(k_dst + off, &kp, sizeof(pack_t));
+      memcpy(v_dst + off, &vp, sizeof(pack_t));
     }
-    // Handle remaining elements
-    for (int64_t i = row_dim_vec + local_id; i < row_dim_; i += local_range) {
+    for (int64_t i = vec_count * vec_width + local_id; i < row_dim_; i += local_range) {
       k_dst[i] = k_src[i];
       v_dst[i] = v_src[i];
     }

--- a/src/sycl/KVCache.cpp
+++ b/src/sycl/KVCache.cpp
@@ -1,0 +1,69 @@
+#include <ATen/ATen.h>
+
+#include "Utils.h"
+#include "comm/General.h"
+
+namespace at::native::xpu {
+
+template <typename scalar_t>
+struct StoreCacheKernel {
+  void operator()(sycl::nd_item<1> item) const {
+    int64_t token_id = static_cast<int64_t>(item.get_group(0));
+    int64_t local_id = static_cast<int64_t>(item.get_local_id(0));
+    int64_t local_range = static_cast<int64_t>(item.get_local_range(0));
+
+    int64_t cache_idx = indices_[token_id];
+    if (cache_idx < 0) return;
+
+    scalar_t* k_src = k_ + token_id * row_dim_;
+    scalar_t* v_src = v_ + token_id * row_dim_;
+    scalar_t* k_dst = k_cache_ + cache_idx * row_dim_;
+    scalar_t* v_dst = v_cache_ + cache_idx * row_dim_;
+
+    for (int64_t i = local_id; i < row_dim_; i += local_range) {
+      k_dst[i] = k_src[i];
+      v_dst[i] = v_src[i];
+    }
+  }
+
+  scalar_t* k_;
+  scalar_t* v_;
+  scalar_t* k_cache_;
+  scalar_t* v_cache_;
+  int64_t* indices_;
+  int64_t row_dim_;
+};
+
+void store_cache_xpu(at::Tensor& k, at::Tensor& v, at::Tensor& k_cache, at::Tensor& v_cache, at::Tensor& indices) {
+  TORCH_CHECK(k.dim() == 2, "k must be 2D [num_tokens, row_dim]");
+  TORCH_CHECK(v.dim() == 2, "v must be 2D [num_tokens, row_dim]");
+  TORCH_CHECK(k_cache.dim() == 2, "k_cache must be 2D [cache_size, row_dim]");
+
+  int64_t num_tokens = k.size(0);
+  int64_t row_dim = k.size(1);
+
+  if (num_tokens == 0) return;
+
+  auto dev_id = dpcppGetDeviceIdOfCurrentQueue();
+  int64_t max_wg_size = dpcppMaxWorkGroupSize(dev_id);
+  int64_t group_size = std::min<int64_t>(std::min<int64_t>(row_dim, 512), max_wg_size);
+
+  SYCL_DISPATCH_FLOATING_TYPES(
+      at::ScalarType::Half, at::ScalarType::BFloat16, k.scalar_type(), "store_cache_xpu", [&]() {
+        auto cgf = DPCPP_Q_CGF(cgh) {
+          StoreCacheKernel<scalar_t> kernel = {
+              .k_ = k.data_ptr<scalar_t>(),
+              .v_ = v.data_ptr<scalar_t>(),
+              .k_cache_ = k_cache.data_ptr<scalar_t>(),
+              .v_cache_ = v_cache.data_ptr<scalar_t>(),
+              .indices_ = indices.data_ptr<int64_t>(),
+              .row_dim_ = row_dim,
+          };
+          cgh.parallel_for<decltype(kernel)>(
+              sycl::nd_range<1>(sycl::range<1>(num_tokens * group_size), sycl::range<1>(group_size)), kernel);
+        };
+        dpcppGetCurrentQueue().submit(cgf);
+      });
+}
+
+}  // namespace at::native::xpu

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -71,7 +71,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def(
       "store_cache(Tensor k, Tensor v, Tensor(a!) k_cache, Tensor(b!) v_cache, "
       "Tensor indices) -> ()");
-  m.impl("store_cache", torch::kXPU, &at::native::xpu::store_cache_xpu);
+  m.impl("store_cache", torch::kXPU, &at::native::xpu::store_cache);
 
   m.def("moe_sum_reduce(Tensor input, Tensor output, float routed_scaling_factor) -> ()");
   m.impl("moe_sum_reduce", torch::kXPU, &moe_sum_reduce);

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -68,6 +68,11 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "bool is_neox) -> (Tensor, Tensor)");
   m.impl("rotary_embedding", torch::kXPU, &at::native::xpu::rotary_embedding);
 
+  m.def(
+      "store_cache_xpu(Tensor k, Tensor v, Tensor(a!) k_cache, Tensor(b!) v_cache, "
+      "Tensor indices) -> ()");
+  m.impl("store_cache_xpu", torch::kXPU, &at::native::xpu::store_cache_xpu);
+
   m.def("moe_sum_reduce(Tensor input, Tensor output, float routed_scaling_factor) -> ()");
   m.impl("moe_sum_reduce", torch::kXPU, &moe_sum_reduce);
   m.def(

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -69,9 +69,9 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("rotary_embedding", torch::kXPU, &at::native::xpu::rotary_embedding);
 
   m.def(
-      "store_cache_xpu(Tensor k, Tensor v, Tensor(a!) k_cache, Tensor(b!) v_cache, "
+      "store_cache(Tensor k, Tensor v, Tensor(a!) k_cache, Tensor(b!) v_cache, "
       "Tensor indices) -> ()");
-  m.impl("store_cache_xpu", torch::kXPU, &at::native::xpu::store_cache_xpu);
+  m.impl("store_cache", torch::kXPU, &at::native::xpu::store_cache_xpu);
 
   m.def("moe_sum_reduce(Tensor input, Tensor output, float routed_scaling_factor) -> ()");
   m.impl("moe_sum_reduce", torch::kXPU, &moe_sum_reduce);

--- a/tests/run_suite.py
+++ b/tests/run_suite.py
@@ -37,6 +37,7 @@ suites = {
         TestFile("test_scatter_tokens_to_experts.py"),
         TestFile("test_sampling.py"),
         TestFile("test_hc_split_sinkhorn.py"),
+        TestFile("test_store_cache_xpu.py"),
     ],
 }
 

--- a/tests/test_store_cache_xpu.py
+++ b/tests/test_store_cache_xpu.py
@@ -1,0 +1,102 @@
+"""Tests for store_cache_xpu kernel."""
+
+import pytest
+import torch
+
+
+@pytest.fixture(autouse=True)
+def skip_if_no_xpu():
+    if not torch.xpu.is_available():
+        pytest.skip("XPU not available")
+
+
+def reference_store_cache(k, v, k_cache, v_cache, indices):
+    """Reference implementation using index_put."""
+    k_cache[indices] = k
+    v_cache[indices] = v
+
+
+class TestStoreCacheXPU:
+    @pytest.mark.parametrize("num_tokens", [1, 4, 32, 128])
+    @pytest.mark.parametrize("row_dim", [128, 256, 512, 1024])
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+    def test_parity(self, num_tokens, row_dim, dtype):
+        from sgl_kernel import store_cache_xpu
+
+        torch.manual_seed(42)
+        cache_size = 2048
+
+        k = torch.randn(num_tokens, row_dim, dtype=dtype, device="xpu")
+        v = torch.randn(num_tokens, row_dim, dtype=dtype, device="xpu")
+        indices = torch.randperm(cache_size, device="xpu")[:num_tokens].to(torch.int64)
+
+        k_cache_ref = torch.zeros(cache_size, row_dim, dtype=dtype, device="xpu")
+        v_cache_ref = torch.zeros_like(k_cache_ref)
+        k_cache_test = torch.zeros_like(k_cache_ref)
+        v_cache_test = torch.zeros_like(k_cache_ref)
+
+        reference_store_cache(k, v, k_cache_ref, v_cache_ref, indices)
+        store_cache_xpu(k, v, k_cache_test, v_cache_test, indices)
+
+        torch.testing.assert_close(k_cache_test, k_cache_ref)
+        torch.testing.assert_close(v_cache_test, v_cache_ref)
+
+    def test_negative_indices_skip(self):
+        """Tokens with index=-1 should not write to cache."""
+        from sgl_kernel import store_cache_xpu
+
+        torch.manual_seed(42)
+        num_tokens, row_dim, cache_size = 4, 256, 1024
+
+        k = torch.randn(num_tokens, row_dim, dtype=torch.bfloat16, device="xpu")
+        v = torch.randn(num_tokens, row_dim, dtype=torch.bfloat16, device="xpu")
+        indices = torch.tensor([10, -1, 20, -1], dtype=torch.int64, device="xpu")
+
+        k_cache = torch.zeros(cache_size, row_dim, dtype=torch.bfloat16, device="xpu")
+        v_cache = torch.zeros_like(k_cache)
+
+        store_cache_xpu(k, v, k_cache, v_cache, indices)
+
+        zero_row = torch.zeros(row_dim, dtype=torch.bfloat16, device="xpu")
+
+        # Written slots should have data
+        assert not torch.all(k_cache[10] == 0).item()
+        assert not torch.all(v_cache[10] == 0).item()
+        assert not torch.all(k_cache[20] == 0).item()
+        assert not torch.all(v_cache[20] == 0).item()
+
+        # Skipped slots should remain zero
+        for slot in [0, 1, 5, 15, 100]:
+            torch.testing.assert_close(k_cache[slot], zero_row)
+            torch.testing.assert_close(v_cache[slot], zero_row)
+
+    def test_empty_input(self):
+        """Zero tokens should not crash."""
+        from sgl_kernel import store_cache_xpu
+
+        k = torch.empty(0, 256, dtype=torch.bfloat16, device="xpu")
+        v = torch.empty(0, 256, dtype=torch.bfloat16, device="xpu")
+        k_cache = torch.zeros(1024, 256, dtype=torch.bfloat16, device="xpu")
+        v_cache = torch.zeros_like(k_cache)
+        indices = torch.empty(0, dtype=torch.int64, device="xpu")
+
+        store_cache_xpu(k, v, k_cache, v_cache, indices)
+        assert torch.all(k_cache == 0).item()
+
+    def test_single_token(self):
+        """Single token decode (most common case)."""
+        from sgl_kernel import store_cache_xpu
+
+        torch.manual_seed(0)
+        row_dim = 512
+
+        k = torch.randn(1, row_dim, dtype=torch.bfloat16, device="xpu")
+        v = torch.randn(1, row_dim, dtype=torch.bfloat16, device="xpu")
+        k_cache = torch.zeros(4096, row_dim, dtype=torch.bfloat16, device="xpu")
+        v_cache = torch.zeros_like(k_cache)
+        indices = torch.tensor([42], dtype=torch.int64, device="xpu")
+
+        store_cache_xpu(k, v, k_cache, v_cache, indices)
+
+        torch.testing.assert_close(k_cache[42], k[0])
+        torch.testing.assert_close(v_cache[42], v[0])


### PR DESCRIPTION
## Summary

Add a SYCL kernel that fuses the two separate `aten::_index_put_impl_` calls (K write + V write) into a single kernel launch for KV-cache writes on XPU.

## Changes

- `src/sycl/KVCache.cpp`: new `StoreCacheKernel` + `store_cache_xpu` entry point (~75 lines)
- `include/sgl_kernel_ops.h`: forward declaration
- `src/torch_extension_sycl.cc`: op registration under `sgl_kernel` TORCH_LIBRARY_FRAGMENT
- `python/sgl_kernel/elementwise.py`: Python wrapper with docstring
- `python/sgl_kernel/__init__.py`: export

## Kernel details

- One work-group per token, work-items stride over `row_dim`
- Handles negative indices (skip token for speculative decoding)
- Supports bf16 and fp16 via `SYCL_DISPATCH_FLOATING_TYPES`
- Mirrors the CUDA `store_cache` JIT kernel from `sglang/jit_kernel/kvcache.py`

## Companion sglang PR

- [sglang #26594](https://github.com/sgl-project/sglang/pull/26594): adds `_is_xpu` to the `store_cache` dispatch gate in `memory_pool.py`

## Test

- Bit-parity verified: `store_cache_xpu` output matches `k_cache[indices] = k; v_cache[indices] = v` reference
- E2B GSM8K 5-shot (N=200): 0.175 accuracy — no regression