### PR TITLE
Add mrope kernel

### DIFF
--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -67,6 +67,7 @@ jobs:
               python3 bench_moe_sum_reduce.py 2>&1 | tee moe_sum_reduce.log \
               python3 bench_moe_fused_gate.py 2>&1 | tee moe_fused_gate.py.log \
               python3 bench_merge_states_v2.py 2>&1 | tee merge_states.py.log \
+              python3 bench_mrope.py 2>&1 | tee mrope.py.log \
               python3 bench_swiglu_alpha_limit.py 2>&1 | tee swiglu_alpha_limit.py.log \
               python3 bench_fused_qk_norm_rope.py 2>&1 | tee fused_qk_norm_rope.py.log \
               python3 bench_fused_qk_rope_with_cache.py 2>&1 | tee bench_fused_qk_rope_with_cache.py.log \

--- a/benchmark/bench_mrope.py
+++ b/benchmark/bench_mrope.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 import pandas as pd
 import torch
 import triton
-from sgl_kernel import multomodal_rotary_embedding
+from sgl_kernel import multimodal_rotary_embedding
 
 
 def apply_interleaved_rope(x: torch.Tensor, mrope_section: list) -> torch.Tensor:
@@ -58,7 +58,7 @@ def mrope_sglang(
     is_neox_style: bool,
     axis_map: Optional[torch.Tensor],
 ):
-    multomodal_rotary_embedding(
+    multimodal_rotary_embedding(
         q,
         k,
         cos_sin_cache,

--- a/benchmark/bench_mrope.py
+++ b/benchmark/bench_mrope.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import itertools
+from typing import List, Optional
+
+import pandas as pd
+import torch
+import triton
+from sgl_kernel import multomodal_rotary_embedding
+
+
+def apply_interleaved_rope(x: torch.Tensor, mrope_section: list) -> torch.Tensor:
+    x_t = x[0].clone()
+    x_t[..., 1 : mrope_section[1] * 3 : 3] = x[1, ..., 1 : mrope_section[1] * 3 : 3]
+    x_t[..., 2 : mrope_section[2] * 3 : 3] = x[2, ..., 2 : mrope_section[2] * 3 : 3]
+    return x_t
+
+
+def apply_rotary_emb(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    is_neox_style: bool,
+) -> torch.Tensor:
+    """
+    Args:
+        x: [num_tokens, num_heads, head_size]
+        cos: [num_tokens, head_size // 2]
+        sin: [num_tokens, head_size // 2]
+        is_neox_style: Whether to use the Neox-style or GPT-J-style rotary
+            positional embeddings.
+    """
+    cos = cos.unsqueeze(-2).to(x.dtype)
+    sin = sin.unsqueeze(-2).to(x.dtype)
+    if is_neox_style:
+        x1, x2 = torch.chunk(x, 2, dim=-1)
+    else:
+        x1 = x[..., ::2]
+        x2 = x[..., 1::2]
+    o1 = x1 * cos - x2 * sin
+    o2 = x2 * cos + x1 * sin
+    if is_neox_style:
+        return torch.cat((o1, o2), dim=-1)
+    else:
+        return torch.stack((o1, o2), dim=-1).flatten(-2)
+
+
+def mrope_sglang(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    mrope_section: List[int],
+    head_size: int,
+    rotary_dim: int,
+    mrope_interleaved: bool,
+    mrope_interleaved_glm: bool,
+    is_neox_style: bool,
+    axis_map: Optional[torch.Tensor],
+):
+    multomodal_rotary_embedding(
+        q,
+        k,
+        cos_sin_cache,
+        positions,
+        mrope_section,
+        head_size,
+        rotary_dim,
+        mrope_interleaved,
+        mrope_interleaved_glm,
+        is_neox_style,
+        axis_map,
+    )
+
+
+def calculate_bandwidth(
+    num_tokens: int,
+    q_heads: int,
+    kv_heads: int,
+    rotary_dim: int,
+    time_ms: float,
+    dtype: torch.dtype,
+) -> float:
+    """
+    Calculate the effective memory bandwidth of the MRoPE kernel in GB/s.
+
+    Only the rotary_dim portion of each head is read and written;
+    the non-rotary tail is never touched by the kernel.
+
+    Args:
+        num_tokens: Number of tokens in the batch.
+        q_heads:    Number of query heads.
+        kv_heads:   Number of key/value heads (k and v share the same head count).
+        rotary_dim: Number of elements per head that are rotated (head_size * partial_rotary_factor).
+        time_ms:    Kernel elapsed time in milliseconds (e.g. from triton.testing.do_bench).
+        dtype:      Torch dtype of q and k tensors (used to get element size in bytes).
+
+    Returns:
+        Bandwidth in GB/s.
+    """
+    elem_bytes = (
+        torch.finfo(dtype).bits // 8
+    )  # e.g. 2 for bfloat16/float16, 4 for float32
+
+    # Q and K are read then written in-place → multiply by 2
+    bytes_q = num_tokens * q_heads * rotary_dim * elem_bytes * 2
+    bytes_k = num_tokens * kv_heads * rotary_dim * elem_bytes * 2
+
+    # cos_sin_cache: one effective row of `rotary_dim` elements read per token
+    bytes_cos_sin = 3 * num_tokens * rotary_dim * elem_bytes
+
+    # positions: 3 int64 values per token (t, h, w) — small but included for correctness
+    bytes_positions = num_tokens * 3 * torch.iinfo(torch.int64).bits // 8
+    # bytes_positions = 0
+    total_bytes = bytes_q + bytes_k + bytes_cos_sin + bytes_positions
+
+    bandwidth_gb_s = total_bytes / (time_ms * 1e-3) / 1e9
+    return bandwidth_gb_s
+
+
+all_results = []
+
+
+def get_benchmark(device="xpu"):
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=[
+                "num_tokens",
+                "num_head_pairs",
+                "head_dim",
+                "partial_rotary_factor",
+                "max_position_embeddings",
+            ],
+            x_vals=configs,
+            line_arg="provider",
+            line_vals=["sglang"],
+            line_names=["Sglang"],
+            styles=[("blue", "-"), ("green", "-")],
+            ylabel="Latency (us)",
+            plot_name="mrope-performance",
+            args={},
+        )
+    )
+    def benchmark(
+        num_tokens,
+        num_head_pairs,
+        head_dim,
+        partial_rotary_factor,
+        max_position_embeddings,
+        provider,
+    ):
+        dtype = torch.bfloat16
+        q_heads, kv_heads = num_head_pairs[0], num_head_pairs[1]
+        q = torch.randn((num_tokens, q_heads * head_dim), device=device, dtype=dtype)
+        k = torch.randn((num_tokens, kv_heads * head_dim), device=device, dtype=dtype)
+        rotary_dim = int(head_dim * partial_rotary_factor)
+        cos_sin_cache = torch.randn(
+            (max_position_embeddings, rotary_dim), dtype=dtype, device=device
+        )
+        positions = torch.randint(
+            0, max_position_embeddings, (3, num_tokens), device=device
+        )
+        mrope_section = [11, 11, 10]
+
+        if provider == "sglang":
+            fn = lambda: mrope_sglang(
+                q,
+                k,
+                cos_sin_cache,
+                positions,
+                mrope_section,
+                head_dim,
+                rotary_dim,
+                True,
+                False,
+                True,
+                None,
+            )
+
+        quantiles = [0.5, 0.2, 0.8]
+        ms, min_ms, max_ms = triton.testing.do_bench(fn, quantiles=quantiles)
+        bandwidth = calculate_bandwidth(
+            num_tokens, q_heads, kv_heads, rotary_dim, ms, dtype
+        )
+
+        all_results.append(
+            {
+                "num_tokens": num_tokens,
+                "q_heads": q_heads,
+                "kv_heads": kv_heads,
+                "rotary_dim": rotary_dim,
+                "dtype": dtype,
+                "provider": provider,
+                "bandwidth": bandwidth,
+                "ms": ms,
+            }
+        )
+
+        return 1000 * ms, 1000 * max_ms, 1000 * min_ms
+
+    return benchmark
+
+
+if __name__ == "__main__":
+    # Run correctness test on small configs if not using a real model
+
+    bs = [1, 2, 4, 8]
+    # bs = [16, 32, 64]
+    seq_len = 1024
+    num_tokens = [seq_len * b for b in bs]
+    # configs from qwen3.5-9b(16-4) and qwen3.5-35b-a3b(4-1 with tp=4)
+    num_head_pairs = [[4, 1], [16, 4]]
+    head_dim = [256]
+    is_neox = [True]
+    dtype = [torch.bfloat16]
+
+    sweep_params = {
+        "num_tokens": num_tokens,
+        "num_head_pairs": num_head_pairs,
+        "head_dim": head_dim,
+        "partial_rotary_factor": [0.25],
+        "max_position_embeddings": [262400],
+    }
+
+    keys = sweep_params.keys()
+    configs = list(itertools.product(*sweep_params.values()))
+
+    global benchmark_configs
+    benchmark_configs = configs
+
+    # Run benchmark
+    print("Starting performance benchmark...")
+    benchmark = get_benchmark()
+    benchmark.run(print_data=False)
+
+    df = pd.DataFrame(all_results)
+    print(df.to_markdown())

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -188,7 +188,7 @@ void fused_qk_rope_with_cos_sin_cache_inplace(
     at::Tensor& positions,
     int64_t rope_dim,
     bool is_neox);
-void multomodal_rotary_embedding(
+void multimodal_rotary_embedding(
     at::Tensor& query,
     at::Tensor& key,
     at::Tensor& cos_sin_cache,

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -191,8 +191,8 @@ void fused_qk_rope_with_cos_sin_cache_inplace(
 void multimodal_rotary_embedding(
     at::Tensor& query,
     at::Tensor& key,
-    at::Tensor& cos_sin_cache,
-    at::Tensor& positions,
+    const at::Tensor& cos_sin_cache,
+    const at::Tensor& positions,
     const std::vector<int64_t>& mrope_section,
     int64_t head_size,
     int64_t rotary_dim,

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -188,6 +188,18 @@ void fused_qk_rope_with_cos_sin_cache_inplace(
     at::Tensor& positions,
     int64_t rope_dim,
     bool is_neox);
+void multomodal_rotary_embedding(
+    at::Tensor& query,
+    at::Tensor& key,
+    at::Tensor& cos_sin_cache,
+    at::Tensor& positions,
+    const std::vector<int64_t>& mrope_section,
+    int64_t head_size,
+    int64_t rotary_dim,
+    bool mrope_interleaved,
+    bool mrope_interleaved_glm,
+    bool is_neox_style,
+    const std::optional<at::Tensor>& axis_map);
 void sgl_per_token_group_quant_fp4(
     at::Tensor input, at::Tensor output_q, at::Tensor output_s, int64_t group_size, double eps);
 }  // namespace at::native::xpu

--- a/python/sgl_kernel/__init__.py
+++ b/python/sgl_kernel/__init__.py
@@ -29,7 +29,7 @@ from sgl_kernel.elementwise import (
     gelu_tanh_and_mul,
     gemma_fused_add_rmsnorm,
     gemma_rmsnorm,
-    multomodal_rotary_embedding,
+    multimodal_rotary_embedding,
     rmsnorm,
     silu_and_mul,
 )

--- a/python/sgl_kernel/__init__.py
+++ b/python/sgl_kernel/__init__.py
@@ -29,6 +29,7 @@ from sgl_kernel.elementwise import (
     gelu_tanh_and_mul,
     gemma_fused_add_rmsnorm,
     gemma_rmsnorm,
+    multomodal_rotary_embedding,
     rmsnorm,
     silu_and_mul,
 )

--- a/python/sgl_kernel/elementwise.py
+++ b/python/sgl_kernel/elementwise.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 import torch
 from sgl_kernel.utils import get_xpu_stream
@@ -462,3 +462,59 @@ def fused_qk_rope_with_cos_sin_cache_inplace(
         rope_dim,
         is_neox,
     )
+
+
+def multimodal_rotary_embedding(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    mrope_section: List[int],
+    head_size: int,
+    rotary_dim: int,
+    mrope_interleaved: bool,
+    mrope_interleaved_glm: bool,
+    is_neox: bool,
+    axis_map: Optional[torch.Tensor]
+) -> None:
+    r"""Apply multimodal RoPE to Q/K using precomputed cos/sin cache.
+
+    Parameters
+    ----------
+    query: torch.Tensor
+        Query tensor updated in-place.
+    key: torch.Tensor
+        Key tensor updated in-place.
+    cos_sin_cache: torch.Tensor
+        Precomputed RoPE cos/sin cache.
+    positions: torch.Tensor
+        Position indices used to index the cache.
+    mrope_section: List[int]
+        Per-axis section sizes for multimodal RoPE.
+    head_size: int
+        Full attention head size for Q/K.
+    rotary_dim: int
+        Rotary/RoPE dimension represented by ``cos_sin_cache``.
+    mrope_interleaved: bool
+        Whether multimodal rotary dimensions are interleaved.
+    mrope_interleaved_glm: bool
+        Whether to use GLM-style interleaving behavior.
+    is_neox: bool
+        Whether to apply NeoX-style rotary layout.
+    axis_map: Optional[torch.Tensor]
+        Optional axis remapping tensor for multimodal position handling.
+    """
+    torch.ops.sgl_kernel.multimodal_rotary_embedding(
+        query,
+        key,
+        cos_sin_cache,
+        positions,
+        mrope_section,
+        head_size,
+        rotary_dim,
+        mrope_interleaved,
+        mrope_interleaved_glm,
+        is_neox,
+        axis_map,
+    )
+

--- a/python/sgl_kernel/elementwise.py
+++ b/python/sgl_kernel/elementwise.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import List, Optional
 
 import torch
 from sgl_kernel.utils import get_xpu_stream
@@ -475,7 +475,7 @@ def multimodal_rotary_embedding(
     mrope_interleaved: bool,
     mrope_interleaved_glm: bool,
     is_neox: bool,
-    axis_map: Optional[torch.Tensor]
+    axis_map: Optional[torch.Tensor],
 ) -> None:
     r"""Apply multimodal RoPE to Q/K using precomputed cos/sin cache.
 
@@ -517,4 +517,3 @@ def multimodal_rotary_embedding(
         is_neox,
         axis_map,
     )
-

--- a/src/sycl/MRope.cpp
+++ b/src/sycl/MRope.cpp
@@ -171,7 +171,7 @@ void launch_mrope(
 
 }  // namespace
 
-void multomodal_rotary_embedding(
+void multimodal_rotary_embedding(
     at::Tensor& query,
     at::Tensor& key,
     at::Tensor& cos_sin_cache,
@@ -205,7 +205,7 @@ void multomodal_rotary_embedding(
   const int64_t num_k_heads = key.size(1) / head_size;
 
 #define LAUNCH_MROPE_KERNEL(IS_NEOX, IS_INTERLEAVED)                                                                 \
-  SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, query.scalar_type(), "multomodal_rotary_embedding", [&]() { \
+  SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, query.scalar_type(), "multimodal_rotary_embedding", [&]() { \
     launch_mrope<scalar_t, IS_NEOX, IS_INTERLEAVED>(                                                                 \
         query,                                                                                                       \
         key,                                                                                                         \

--- a/src/sycl/MRope.cpp
+++ b/src/sycl/MRope.cpp
@@ -16,6 +16,9 @@ namespace {
 
 static constexpr int sg_size = 32;
 
+// Adapted from triton implementation in sglang "_triton_mrope_forward_fused":
+// https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/rotary_embedding/triton_kernels.py
+
 template <typename scalar_t, bool is_neox, bool is_interleaved>
 struct MRoPEKernel {
   // Grid  : nd_range<2>( {num_tokens, global_rotary_dim}, {1, local_rotary_dim} )

--- a/src/sycl/MRope.cpp
+++ b/src/sycl/MRope.cpp
@@ -1,0 +1,236 @@
+#include <ATen/ATen.h>
+#include <c10/xpu/XPUStream.h>
+#include <torch/all.h>
+
+#include <optional>
+#include <sycl/sycl.hpp>
+#include <vector>
+
+#include "SYCLHelpers.h"
+#include "Utils.h"
+#include "comm/Numerics.h"
+
+namespace at::native::xpu {
+
+namespace {
+
+static constexpr int sg_size = 32;
+
+template <typename scalar_t, bool is_neox, bool is_interleaved>
+struct MRoPEKernel {
+  // Grid  : nd_range<2>( {num_tokens, global_rotary_dim}, {1, local_rotary_dim} )
+  //   dim 0: token   (1 work-group row per token)
+  //   dim 1: rot lane (local_rotary_dim lanes per work-group)
+
+  [[sycl::reqd_sub_group_size(sg_size)]]
+  void operator()(sycl::nd_item<2> item) const {
+    const int32_t token_id = item.get_global_id(0);
+    const int32_t rot = item.get_global_id(1);
+
+    if (token_id >= num_tokens_ || rot >= half_rotary_dim_) return;
+
+    const int64_t t_pos = positions_[token_id];
+    const int64_t h_pos = positions_[positions_stride_ + token_id];
+    const int64_t w_pos = positions_[2 * positions_stride_ + token_id];
+
+    bool h_mask = false, w_mask = false;
+
+    if constexpr (is_interleaved) {
+      // Interleaved layout: t=0 mod3, h=1 mod3, w=2 mod3
+      h_mask = ((rot % 3) == 1) && (rot < 3 * section_h_);
+      w_mask = ((rot % 3) == 2) && (rot < 3 * section_w_);
+    } else {
+      // Standard contiguous layout: [t_section | h_section | w_section]
+      const int64_t t_end = section_t_;
+      const int64_t h_end = t_end + section_h_;
+      h_mask = (t_end <= rot) && (rot < h_end);
+      w_mask = (h_end <= rot) && (rot < half_rotary_dim_);
+    }
+
+    const int64_t chosen_pos = h_mask ? h_pos : (w_mask ? w_pos : t_pos);
+    const int64_t cache_base = chosen_pos * rotary_dim_;
+
+    const scalar_t cos_v = cos_sin_cache_[cache_base + rot];
+    const scalar_t sin_v = cos_sin_cache_[cache_base + rot + half_rotary_dim_];
+
+    const int64_t max_heads = (num_q_heads_ > num_k_heads_) ? num_q_heads_ : num_k_heads_;
+
+    for (int head_id = 0; head_id < max_heads; ++head_id) {
+      if (head_id < num_q_heads_) {
+        scalar_t* q_head = query_ + token_id * q_stride_ + head_id * head_size_;
+
+        if constexpr (is_neox) {
+          const scalar_t x = q_head[rot];
+          const scalar_t y = q_head[rot + half_rotary_dim_];
+          q_head[rot] = static_cast<scalar_t>(x * cos_v - y * sin_v);
+          q_head[rot + half_rotary_dim_] = static_cast<scalar_t>(y * cos_v + x * sin_v);
+        } else {
+          const int64_t x_idx = 2 * rot;
+          const int64_t y_idx = x_idx + 1;
+          const scalar_t x = q_head[x_idx];
+          const scalar_t y = q_head[y_idx];
+          q_head[x_idx] = static_cast<scalar_t>(x * cos_v - y * sin_v);
+          q_head[y_idx] = static_cast<scalar_t>(y * cos_v + x * sin_v);
+        }
+      }
+      if (head_id < num_k_heads_) {
+        scalar_t* k_head = key_ + token_id * k_stride_ + head_id * head_size_;
+
+        if constexpr (is_neox) {
+          const scalar_t x = k_head[rot];
+          const scalar_t y = k_head[rot + half_rotary_dim_];
+          k_head[rot] = static_cast<scalar_t>(x * cos_v - y * sin_v);
+          k_head[rot + half_rotary_dim_] = static_cast<scalar_t>(y * cos_v + x * sin_v);
+        } else {
+          const int64_t x_idx = 2 * rot;
+          const int64_t y_idx = x_idx + 1;
+          const scalar_t x = k_head[x_idx];
+          const scalar_t y = k_head[y_idx];
+          k_head[x_idx] = static_cast<scalar_t>(x * cos_v - y * sin_v);
+          k_head[y_idx] = static_cast<scalar_t>(y * cos_v + x * sin_v);
+        }
+      }
+    }
+  }
+
+  // Pointers
+  scalar_t* query_;
+  scalar_t* key_;
+  const scalar_t* cos_sin_cache_;
+  const int64_t* positions_;
+
+  // Strides
+  int64_t q_stride_;
+  int64_t k_stride_;
+  int64_t positions_stride_;
+
+  // Sizes
+  int64_t num_tokens_;
+  int64_t num_q_heads_;
+  int64_t num_k_heads_;
+  int64_t head_size_;
+  int64_t rotary_dim_;
+  int64_t half_rotary_dim_;  // rd/2
+
+  // MRoPE section boundaries (in units of rot-lane index)
+  int64_t section_t_;
+  int64_t section_h_;
+  int64_t section_w_;
+};
+
+template <typename scalar_t, bool is_neox, bool is_interleaved>
+void launch_mrope(
+    at::Tensor& query,
+    at::Tensor& key,
+    const at::Tensor& cos_sin_cache,
+    const at::Tensor& positions,
+    int64_t num_q_heads,
+    int64_t num_k_heads,
+    int64_t head_size,
+    int64_t rotary_dim,
+    int64_t section_t,
+    int64_t section_h,
+    int64_t section_w) {
+  // local_rotary_dim(wg_size): sub-group-friendly tile size for the rotary dimension.
+  // 64 fills two Intel sub-groups (2×32) and gives good occupancy on
+  // Intel Arc / Xe / PVC.
+  constexpr int64_t local_rotary_dim = 2 * sg_size;
+
+  const int64_t num_tokens = query.size(0);
+  const int64_t half_rotary_dim = rotary_dim / 2;
+  const int64_t global_rotary_dim = CeilDiv(half_rotary_dim, local_rotary_dim) * local_rotary_dim;
+
+  MRoPEKernel<scalar_t, is_neox, is_interleaved> kernel{
+      query.data_ptr<scalar_t>(),
+      key.data_ptr<scalar_t>(),
+      cos_sin_cache.data_ptr<scalar_t>(),
+      positions.data_ptr<int64_t>(),
+      static_cast<int64_t>(query.stride(0)),
+      static_cast<int64_t>(key.stride(0)),
+      static_cast<int64_t>(positions.stride(0)),
+      num_tokens,
+      num_q_heads,
+      num_k_heads,
+      head_size,
+      rotary_dim,
+      half_rotary_dim,
+      section_t,
+      section_h,
+      section_w,
+  };
+
+  sycl_kernel_submit(
+      sycl::range<2>(static_cast<size_t>(num_tokens), static_cast<size_t>(global_rotary_dim)),
+      sycl::range<2>(1, static_cast<size_t>(local_rotary_dim)),
+      dpcppGetCurrentQueue(),
+      kernel);
+}
+
+}  // namespace
+
+void multomodal_rotary_embedding(
+    at::Tensor& query,
+    at::Tensor& key,
+    at::Tensor& cos_sin_cache,
+    at::Tensor& positions,
+    const std::vector<int64_t>& mrope_section,
+    int64_t head_size,
+    int64_t rotary_dim,
+    bool mrope_interleaved,
+    bool mrope_interleaved_glm,
+    bool is_neox_style,
+    const std::optional<at::Tensor>& axis_map) {
+  TORCH_CHECK(query.dim() == 2, "query must be 2D [num_tokens, num_heads * head_size]");
+  TORCH_CHECK(key.dim() == 2, "key must be 2D [num_tokens, num_kv_heads * head_size]");
+  TORCH_CHECK(mrope_section.size() == 3, "mrope_section must have 3 elements [t, h, w]");
+
+  const int64_t section_t = mrope_section[0];
+  const int64_t section_h = mrope_section[1];
+  const int64_t section_w = mrope_section[2];
+  TORCH_CHECK(section_t >= 0 && section_h >= 0 && section_w >= 0, "mrope_section values must be non-negative");
+  if (!mrope_interleaved) {
+    TORCH_CHECK(
+        section_t + section_h + section_w == rotary_dim / 2,
+        "for non-interleaved mrope, sum(mrope_section) must equal rotary_dim/2");
+  }
+
+  const int64_t num_tokens = query.size(0);
+  TORCH_CHECK(positions.size(1) == num_tokens, "positions second dimension must equal num_tokens");
+  TORCH_CHECK(mrope_interleaved_glm == false, "glm style rope is not supported");
+
+  const int64_t num_q_heads = query.size(1) / head_size;
+  const int64_t num_k_heads = key.size(1) / head_size;
+
+#define LAUNCH_MROPE_KERNEL(IS_NEOX, IS_INTERLEAVED)                                                                 \
+  SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, query.scalar_type(), "multomodal_rotary_embedding", [&]() { \
+    launch_mrope<scalar_t, IS_NEOX, IS_INTERLEAVED>(                                                                 \
+        query,                                                                                                       \
+        key,                                                                                                         \
+        cos_sin_cache,                                                                                               \
+        positions,                                                                                                   \
+        num_q_heads,                                                                                                 \
+        num_k_heads,                                                                                                 \
+        head_size,                                                                                                   \
+        rotary_dim,                                                                                                  \
+        section_t,                                                                                                   \
+        section_h,                                                                                                   \
+        section_w);                                                                                                  \
+  });
+
+  if (is_neox_style) {
+    if (mrope_interleaved) {
+      LAUNCH_MROPE_KERNEL(true, true);
+    } else {
+      LAUNCH_MROPE_KERNEL(true, false);
+    }
+  } else {
+    if (mrope_interleaved) {
+      LAUNCH_MROPE_KERNEL(false, true);
+    } else {
+      LAUNCH_MROPE_KERNEL(false, false);
+    }
+  }
+#undef LAUNCH_MROPE_KERNEL
+}
+
+}  // namespace at::native::xpu

--- a/src/sycl/MRope.cpp
+++ b/src/sycl/MRope.cpp
@@ -1,4 +1,3 @@
-#include <ATen/ATen.h>
 #include <c10/xpu/XPUStream.h>
 #include <torch/all.h>
 
@@ -65,15 +64,15 @@ struct MRoPEKernel {
         if constexpr (is_neox) {
           const scalar_t x = q_head[rot];
           const scalar_t y = q_head[rot + half_rotary_dim_];
-          q_head[rot] = static_cast<scalar_t>(x * cos_v - y * sin_v);
-          q_head[rot + half_rotary_dim_] = static_cast<scalar_t>(y * cos_v + x * sin_v);
+          q_head[rot] = x * cos_v - y * sin_v;
+          q_head[rot + half_rotary_dim_] = y * cos_v + x * sin_v;
         } else {
           const int64_t x_idx = 2 * rot;
           const int64_t y_idx = x_idx + 1;
           const scalar_t x = q_head[x_idx];
           const scalar_t y = q_head[y_idx];
-          q_head[x_idx] = static_cast<scalar_t>(x * cos_v - y * sin_v);
-          q_head[y_idx] = static_cast<scalar_t>(y * cos_v + x * sin_v);
+          q_head[x_idx] = x * cos_v - y * sin_v;
+          q_head[y_idx] = y * cos_v + x * sin_v;
         }
       }
       if (head_id < num_k_heads_) {
@@ -82,15 +81,15 @@ struct MRoPEKernel {
         if constexpr (is_neox) {
           const scalar_t x = k_head[rot];
           const scalar_t y = k_head[rot + half_rotary_dim_];
-          k_head[rot] = static_cast<scalar_t>(x * cos_v - y * sin_v);
-          k_head[rot + half_rotary_dim_] = static_cast<scalar_t>(y * cos_v + x * sin_v);
+          k_head[rot] = x * cos_v - y * sin_v;
+          k_head[rot + half_rotary_dim_] = y * cos_v + x * sin_v;
         } else {
           const int64_t x_idx = 2 * rot;
           const int64_t y_idx = x_idx + 1;
           const scalar_t x = k_head[x_idx];
           const scalar_t y = k_head[y_idx];
-          k_head[x_idx] = static_cast<scalar_t>(x * cos_v - y * sin_v);
-          k_head[y_idx] = static_cast<scalar_t>(y * cos_v + x * sin_v);
+          k_head[x_idx] = x * cos_v - y * sin_v;
+          k_head[y_idx] = y * cos_v + x * sin_v;
         }
       }
     }
@@ -134,14 +133,12 @@ void launch_mrope(
     int64_t section_t,
     int64_t section_h,
     int64_t section_w) {
-  // local_rotary_dim(wg_size): sub-group-friendly tile size for the rotary dimension.
-  // 64 fills two Intel sub-groups (2×32) and gives good occupancy on
-  // Intel Arc / Xe / PVC.
-  constexpr int64_t local_rotary_dim = 2 * sg_size;
-
   const int64_t num_tokens = query.size(0);
   const int64_t half_rotary_dim = rotary_dim / 2;
-  const int64_t global_rotary_dim = CeilDiv(half_rotary_dim, local_rotary_dim) * local_rotary_dim;
+
+  // local_rotary_dim(wg_size): sub-group-friendly tile size for the rotary dimension.
+  const int64_t local_rotary_dim = RoundUp(half_rotary_dim, static_cast<int64_t>(sg_size));
+  const int64_t global_rotary_dim = RoundUp(half_rotary_dim, local_rotary_dim);
 
   MRoPEKernel<scalar_t, is_neox, is_interleaved> kernel{
       query.data_ptr<scalar_t>(),
@@ -163,8 +160,8 @@ void launch_mrope(
   };
 
   sycl_kernel_submit(
-      sycl::range<2>(static_cast<size_t>(num_tokens), static_cast<size_t>(global_rotary_dim)),
-      sycl::range<2>(1, static_cast<size_t>(local_rotary_dim)),
+      sycl::range<2>(num_tokens, global_rotary_dim),
+      sycl::range<2>(1, local_rotary_dim),
       dpcppGetCurrentQueue(),
       kernel);
 }

--- a/src/sycl/MRope.cpp
+++ b/src/sycl/MRope.cpp
@@ -171,8 +171,8 @@ void launch_mrope(
 void multimodal_rotary_embedding(
     at::Tensor& query,
     at::Tensor& key,
-    at::Tensor& cos_sin_cache,
-    at::Tensor& positions,
+    const at::Tensor& cos_sin_cache,
+    const at::Tensor& positions,
     const std::vector<int64_t>& mrope_section,
     int64_t head_size,
     int64_t rotary_dim,

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -186,6 +186,12 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       torch::kXPU,
       &at::native::xpu::fused_qk_rope_with_cos_sin_cache_inplace);
 
+  m.def(
+      "multomodal_rotary_embedding(Tensor! query, Tensor! key, Tensor! cos_sin_cache, Tensor! positions, "
+      "int[] mrope_section, int head_size, int rotary_dim, bool mrope_interleaved, bool mrope_interleaved_glm, "
+      "bool is_neox_style, Tensor? axis_map) -> ()");
+  m.impl("multomodal_rotary_embedding", torch::kXPU, &at::native::xpu::multomodal_rotary_embedding);
+
   /* utils */
   m.def("query_device(int device_id) -> (int, int)");
   m.impl("query_device", c10::DispatchKey::BackendSelect, &query_device);

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -187,7 +187,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       &at::native::xpu::fused_qk_rope_with_cos_sin_cache_inplace);
 
   m.def(
-      "multimodal_rotary_embedding(Tensor! query, Tensor! key, Tensor! cos_sin_cache, Tensor! positions, "
+      "multimodal_rotary_embedding(Tensor! query, Tensor! key, Tensor cos_sin_cache, Tensor positions, "
       "int[] mrope_section, int head_size, int rotary_dim, bool mrope_interleaved, bool mrope_interleaved_glm, "
       "bool is_neox_style, Tensor? axis_map) -> ()");
   m.impl("multimodal_rotary_embedding", torch::kXPU, &at::native::xpu::multimodal_rotary_embedding);

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -187,10 +187,10 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       &at::native::xpu::fused_qk_rope_with_cos_sin_cache_inplace);
 
   m.def(
-      "multomodal_rotary_embedding(Tensor! query, Tensor! key, Tensor! cos_sin_cache, Tensor! positions, "
+      "multimodal_rotary_embedding(Tensor! query, Tensor! key, Tensor! cos_sin_cache, Tensor! positions, "
       "int[] mrope_section, int head_size, int rotary_dim, bool mrope_interleaved, bool mrope_interleaved_glm, "
       "bool is_neox_style, Tensor? axis_map) -> ()");
-  m.impl("multomodal_rotary_embedding", torch::kXPU, &at::native::xpu::multomodal_rotary_embedding);
+  m.impl("multimodal_rotary_embedding", torch::kXPU, &at::native::xpu::multimodal_rotary_embedding);
 
   /* utils */
   m.def("query_device(int device_id) -> (int, int)");

--- a/tests/run_suite.py
+++ b/tests/run_suite.py
@@ -27,6 +27,7 @@ suites = {
         TestFile("test_per_token_group_quant_8bit.py"),
         TestFile("test_per_token_group_quant_mxfp4.py"),
         TestFile("test_moe_fused_gate.py"),
+        TestFile("test_mrope.py"),
         TestFile("test_per_tensor_quant_fp8.py"),
         TestFile("test_fused_qk_norm_rope.py"),
         TestFile("test_fused_qk_rope_with_cache.py"),

--- a/tests/test_fused_qk_rope_with_cache.py
+++ b/tests/test_fused_qk_rope_with_cache.py
@@ -3,10 +3,9 @@ import sys
 import pytest
 import torch
 import triton
-
 from sgl_kernel import fused_qk_rope_with_cos_sin_cache_inplace
-
 from test_rope_utils import *
+
 
 def torch_impl_rope(
     q: torch.Tensor,

--- a/tests/test_fused_qk_rope_with_cache.py
+++ b/tests/test_fused_qk_rope_with_cache.py
@@ -3,65 +3,10 @@ import sys
 import pytest
 import torch
 import triton
-import utils
+
 from sgl_kernel import fused_qk_rope_with_cos_sin_cache_inplace
 
-DEVICE = utils.get_device()
-DTYPE = torch.bfloat16
-MAX_SEQ_LEN = 131072  # common seq length
-ROPE_BASE = 10000.0
-CACHE_SIZE = 1024 * 128
-
-
-def create_cos_sin_cache(
-    rotary_dim: int,
-    max_position: int = MAX_SEQ_LEN,
-    base: float = ROPE_BASE,
-) -> torch.Tensor:
-    """Create cos/sin cache compatible with SGLang layout: [max_pos, rotary_dim]."""
-    inv_freq = 1.0 / (
-        base
-        ** (
-            torch.arange(0, rotary_dim, 2, dtype=torch.float32, device=DEVICE)
-            / rotary_dim
-        )
-    )
-    t = torch.arange(max_position, dtype=torch.float32, device=DEVICE)
-    freqs = torch.einsum("i,j->ij", t, inv_freq)
-    cos = freqs.cos()
-    sin = freqs.sin()
-    cache = torch.cat((cos, sin), dim=-1)  # [max_pos, rotary_dim]
-    return cache
-
-
-def apply_rotary_emb(
-    x: torch.Tensor,
-    cos: torch.Tensor,
-    sin: torch.Tensor,
-    is_neox_style: bool,
-) -> torch.Tensor:
-    """
-    Args:
-        x: [num_tokens, num_heads, head_size]
-        cos: [num_tokens, head_size // 2]
-        sin: [num_tokens, head_size // 2]
-        is_neox_style: Whether to use the Neox-style or GPT-J-style rotary
-            positional embeddings.
-    """
-    cos = cos.unsqueeze(-2).to(x.dtype)
-    sin = sin.unsqueeze(-2).to(x.dtype)
-    if is_neox_style:
-        x1, x2 = torch.chunk(x, 2, dim=-1)
-    else:
-        x1 = x[..., ::2]
-        x2 = x[..., 1::2]
-    o1 = x1 * cos - x2 * sin
-    o2 = x2 * cos + x1 * sin
-    if is_neox_style:
-        return torch.cat((o1, o2), dim=-1)
-    else:
-        return torch.stack((o1, o2), dim=-1).flatten(-2)
-
+from test_rope_utils import *
 
 def torch_impl_rope(
     q: torch.Tensor,

--- a/tests/test_mrope.py
+++ b/tests/test_mrope.py
@@ -3,9 +3,8 @@ from typing import List
 
 import pytest
 import triton
-from test_rope_utils import *
-
 from sgl_kernel import multomodal_rotary_embedding
+from test_rope_utils import *
 
 
 def apply_interleaved_rope(x: torch.Tensor, mrope_section: list) -> torch.Tensor:

--- a/tests/test_mrope.py
+++ b/tests/test_mrope.py
@@ -1,0 +1,208 @@
+import sys
+from typing import List
+
+import pytest
+import torch
+import triton
+import utils
+from sgl_kernel import multomodal_rotary_embedding
+
+DEVICE = utils.get_device()
+DTYPE = torch.bfloat16
+MAX_SEQ_LEN = 131072  # common seq length
+ROPE_BASE = 10000.0
+CACHE_SIZE = 1024 * 128
+
+
+def create_cos_sin_cache(
+    rotary_dim: int,
+    max_position: int = MAX_SEQ_LEN,
+    base: float = ROPE_BASE,
+) -> torch.Tensor:
+    """Create cos/sin cache compatible with SGLang layout: [max_pos, rotary_dim]."""
+    inv_freq = 1.0 / (
+        base
+        ** (
+            torch.arange(0, rotary_dim, 2, dtype=torch.float32, device=DEVICE)
+            / rotary_dim
+        )
+    )
+    t = torch.arange(max_position, dtype=torch.float32, device=DEVICE)
+    freqs = torch.einsum("i,j->ij", t, inv_freq)
+    cos = freqs.cos()
+    sin = freqs.sin()
+    cache = torch.cat((cos, sin), dim=-1)  # [max_pos, rotary_dim]
+    return cache
+
+
+def apply_rotary_emb(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    is_neox_style: bool,
+) -> torch.Tensor:
+    """
+    Args:
+        x: [num_tokens, num_heads, head_size]
+        cos: [num_tokens, head_size // 2]
+        sin: [num_tokens, head_size // 2]
+        is_neox_style: Whether to use the Neox-style or GPT-J-style rotary
+            positional embeddings.
+    """
+    # cos = cos.unsqueeze(-2).to(x.dtype)
+    # sin = sin.unsqueeze(-2).to(x.dtype)
+    cos = cos.unsqueeze(-2).to(x.dtype)
+    sin = sin.unsqueeze(-2).to(x.dtype)
+    if is_neox_style:
+        x1, x2 = torch.chunk(x, 2, dim=-1)
+    else:
+        x1 = x[..., ::2]
+        x2 = x[..., 1::2]
+    o1 = x1 * cos - x2 * sin
+    o2 = x2 * cos + x1 * sin
+    if is_neox_style:
+        return torch.cat((o1, o2), dim=-1)
+    else:
+        return torch.stack((o1, o2), dim=-1).flatten(-2)
+
+
+def apply_interleaved_rope(x: torch.Tensor, mrope_section: list) -> torch.Tensor:
+    x_t = x[0].clone()
+    x_t[..., 1 : mrope_section[1] * 3 : 3] = x[1, ..., 1 : mrope_section[1] * 3 : 3]
+    x_t[..., 2 : mrope_section[2] * 3 : 3] = x[2, ..., 2 : mrope_section[2] * 3 : 3]
+    return x_t
+
+
+def torch_impl_mrope(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    mrope_section: List[int],
+    head_size: int,
+    rotary_dim: int,
+    mrope_interleaved: bool,
+    is_neox_style: bool,
+):
+    assert positions.ndim == 1 or positions.ndim == 2
+
+    cos_sin = cos_sin_cache[positions]
+    cos, sin = cos_sin.chunk(2, dim=-1)
+    if positions.ndim == 2:
+        if mrope_interleaved:
+            cos = apply_interleaved_rope(cos, mrope_section)
+            sin = apply_interleaved_rope(sin, mrope_section)
+        else:
+            cos = torch.cat(
+                [m[i] for i, m in enumerate(cos.split(mrope_section, dim=-1))],
+                dim=-1,
+            )
+            sin = torch.cat(
+                [m[i] for i, m in enumerate(sin.split(mrope_section, dim=-1))],
+                dim=-1,
+            )
+
+    seq_len_q = query.shape[0]
+    query_shape = query.shape
+    query = query.view(seq_len_q, -1, head_size)
+    query_rot = query[..., :rotary_dim]
+    query_pass = query[..., rotary_dim:]
+    query_rot = apply_rotary_emb(query_rot, cos, sin, is_neox_style)
+    query = torch.cat((query_rot, query_pass), dim=-1).reshape(query_shape)
+
+    seq_len_k = key.shape[0]
+    key_shape = key.shape
+
+    key = key.view(seq_len_k, -1, head_size)
+    key_rot = key[..., :rotary_dim]
+    key_pass = key[..., rotary_dim:]
+    key_rot = apply_rotary_emb(key_rot, cos, sin, is_neox_style)
+    key = torch.cat((key_rot, key_pass), dim=-1).reshape(key_shape)
+    return query, key
+
+
+# ---------------------------------------------------------------------------
+# Test parameters
+# ---------------------------------------------------------------------------
+BS_LIST = [1, 128, 2048]
+NUM_KV_HEADS_LIST = [1, 4]
+GQA_RATIO = [4]
+HEAD_DIM_LIST = [256]
+PARTIAL_ROTARY_FACTOR = [0.25]
+ROTARY_DIM_LIST = [64]
+IS_NEOX_LIST = [False, True]
+MROPE_IS_INTERLEAVED = [False, True]
+MROPE_SECTION_LIST = [[11, 11, 10]]
+DTYPE_LIST = [torch.bfloat16, torch.float16]
+
+
+@pytest.mark.parametrize("batch_size", BS_LIST)
+@pytest.mark.parametrize("gqa_ratio", GQA_RATIO)
+@pytest.mark.parametrize("num_kv_heads", NUM_KV_HEADS_LIST)
+@pytest.mark.parametrize("head_size", HEAD_DIM_LIST)
+@pytest.mark.parametrize("partial_rotary_factor", PARTIAL_ROTARY_FACTOR)
+@pytest.mark.parametrize("mrope_is_interleaved", MROPE_IS_INTERLEAVED)
+@pytest.mark.parametrize("is_neox", IS_NEOX_LIST)
+@pytest.mark.parametrize("mrope_section", MROPE_SECTION_LIST)
+@pytest.mark.parametrize("dtype", DTYPE_LIST)
+def test_multomodal_rotary_embedding(
+    batch_size: int,
+    gqa_ratio: int,
+    num_kv_heads: int,
+    head_size: int,
+    partial_rotary_factor: float,
+    mrope_is_interleaved: bool,
+    is_neox: bool,
+    mrope_section: List[int],
+    dtype: torch.dtype,
+):
+
+    torch.manual_seed(1234)
+
+    num_qo_heads = num_kv_heads * gqa_ratio
+    rotary_dim = int(head_size * partial_rotary_factor)
+    q = torch.randn(batch_size, (num_qo_heads * head_size), device=DEVICE, dtype=dtype)
+    k = torch.randn(batch_size, (num_kv_heads * head_size), device=DEVICE, dtype=dtype)
+    positions = torch.randint(
+        0, MAX_SEQ_LEN, (3, batch_size), device=DEVICE, dtype=torch.int64
+    )
+
+    cos_sin_cache = create_cos_sin_cache(rotary_dim).to(dtype)
+
+    q_ker, k_ker = q.clone(), k.clone()
+    q_na, k_na = torch_impl_mrope(
+        q,
+        k,
+        cos_sin_cache,
+        positions,
+        mrope_section,
+        head_size,
+        rotary_dim,
+        mrope_is_interleaved,
+        is_neox,
+    )
+
+    multomodal_rotary_embedding(
+        q_ker,
+        k_ker,
+        cos_sin_cache,
+        positions,
+        mrope_section,
+        head_size,
+        rotary_dim,
+        mrope_is_interleaved,
+        False,
+        is_neox,
+        None,
+    )
+
+    # mrope_triton(q_ker, k_ker,
+    #    cos_sin_cache, positions, mrope_section,  head_size, rotary_dim, mrope_is_interleaved, False, is_neox, None)
+
+    atol = rtol = 1e-2
+    triton.testing.assert_close(q_na, q_ker, atol=atol, rtol=rtol)
+    triton.testing.assert_close(k_na, k_ker, atol=atol, rtol=rtol)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/tests/test_mrope.py
+++ b/tests/test_mrope.py
@@ -3,7 +3,7 @@ from typing import List
 
 import pytest
 import triton
-from sgl_kernel import multomodal_rotary_embedding
+from sgl_kernel import multimodal_rotary_embedding
 from test_rope_utils import *
 
 
@@ -86,7 +86,7 @@ DTYPE_LIST = [torch.bfloat16, torch.float16]
 @pytest.mark.parametrize("is_neox", IS_NEOX_LIST)
 @pytest.mark.parametrize("mrope_section", MROPE_SECTION_LIST)
 @pytest.mark.parametrize("dtype", DTYPE_LIST)
-def test_multomodal_rotary_embedding(
+def test_multimodal_rotary_embedding(
     batch_size: int,
     gqa_ratio: int,
     num_kv_heads: int,
@@ -123,7 +123,7 @@ def test_multomodal_rotary_embedding(
         is_neox,
     )
 
-    multomodal_rotary_embedding(
+    multimodal_rotary_embedding(
         q_ker,
         k_ker,
         cos_sin_cache,

--- a/tests/test_mrope.py
+++ b/tests/test_mrope.py
@@ -2,68 +2,10 @@ import sys
 from typing import List
 
 import pytest
-import torch
 import triton
-import utils
+from test_rope_utils import *
+
 from sgl_kernel import multomodal_rotary_embedding
-
-DEVICE = utils.get_device()
-DTYPE = torch.bfloat16
-MAX_SEQ_LEN = 131072  # common seq length
-ROPE_BASE = 10000.0
-CACHE_SIZE = 1024 * 128
-
-
-def create_cos_sin_cache(
-    rotary_dim: int,
-    max_position: int = MAX_SEQ_LEN,
-    base: float = ROPE_BASE,
-) -> torch.Tensor:
-    """Create cos/sin cache compatible with SGLang layout: [max_pos, rotary_dim]."""
-    inv_freq = 1.0 / (
-        base
-        ** (
-            torch.arange(0, rotary_dim, 2, dtype=torch.float32, device=DEVICE)
-            / rotary_dim
-        )
-    )
-    t = torch.arange(max_position, dtype=torch.float32, device=DEVICE)
-    freqs = torch.einsum("i,j->ij", t, inv_freq)
-    cos = freqs.cos()
-    sin = freqs.sin()
-    cache = torch.cat((cos, sin), dim=-1)  # [max_pos, rotary_dim]
-    return cache
-
-
-def apply_rotary_emb(
-    x: torch.Tensor,
-    cos: torch.Tensor,
-    sin: torch.Tensor,
-    is_neox_style: bool,
-) -> torch.Tensor:
-    """
-    Args:
-        x: [num_tokens, num_heads, head_size]
-        cos: [num_tokens, head_size // 2]
-        sin: [num_tokens, head_size // 2]
-        is_neox_style: Whether to use the Neox-style or GPT-J-style rotary
-            positional embeddings.
-    """
-    # cos = cos.unsqueeze(-2).to(x.dtype)
-    # sin = sin.unsqueeze(-2).to(x.dtype)
-    cos = cos.unsqueeze(-2).to(x.dtype)
-    sin = sin.unsqueeze(-2).to(x.dtype)
-    if is_neox_style:
-        x1, x2 = torch.chunk(x, 2, dim=-1)
-    else:
-        x1 = x[..., ::2]
-        x2 = x[..., 1::2]
-    o1 = x1 * cos - x2 * sin
-    o2 = x2 * cos + x1 * sin
-    if is_neox_style:
-        return torch.cat((o1, o2), dim=-1)
-    else:
-        return torch.stack((o1, o2), dim=-1).flatten(-2)
 
 
 def apply_interleaved_rope(x: torch.Tensor, mrope_section: list) -> torch.Tensor:

--- a/tests/test_mrope.py
+++ b/tests/test_mrope.py
@@ -137,9 +137,6 @@ def test_multimodal_rotary_embedding(
         None,
     )
 
-    # mrope_triton(q_ker, k_ker,
-    #    cos_sin_cache, positions, mrope_section,  head_size, rotary_dim, mrope_is_interleaved, False, is_neox, None)
-
     atol = rtol = 1e-2
     triton.testing.assert_close(q_na, q_ker, atol=atol, rtol=rtol)
     triton.testing.assert_close(k_na, k_ker, atol=atol, rtol=rtol)

--- a/tests/test_rope_utils.py
+++ b/tests/test_rope_utils.py
@@ -1,0 +1,65 @@
+import torch
+import utils
+
+DEVICE = utils.get_device()
+DTYPE = torch.bfloat16
+MAX_SEQ_LEN = 131072  # common seq length
+ROPE_BASE = 10000.0
+CACHE_SIZE = 1024 * 128
+
+"""Common utilities for calculating rope reference"""
+DEVICE = utils.get_device()
+DTYPE = torch.bfloat16
+MAX_SEQ_LEN = 131072  # common seq length
+ROPE_BASE = 10000.0
+CACHE_SIZE = 1024 * 128
+
+
+def create_cos_sin_cache(
+    rotary_dim: int,
+    max_position: int = MAX_SEQ_LEN,
+    base: float = ROPE_BASE,
+) -> torch.Tensor:
+    """Create cos/sin cache compatible with SGLang layout: [max_pos, rotary_dim]."""
+    inv_freq = 1.0 / (
+        base
+        ** (
+            torch.arange(0, rotary_dim, 2, dtype=torch.float32, device=DEVICE)
+            / rotary_dim
+        )
+    )
+    t = torch.arange(max_position, dtype=torch.float32, device=DEVICE)
+    freqs = torch.einsum("i,j->ij", t, inv_freq)
+    cos = freqs.cos()
+    sin = freqs.sin()
+    cache = torch.cat((cos, sin), dim=-1)  # [max_pos, rotary_dim]
+    return cache
+
+
+def apply_rotary_emb(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    is_neox_style: bool,
+) -> torch.Tensor:
+    """
+    Args:
+        x: [num_tokens, num_heads, head_size]
+        cos: [num_tokens, head_size // 2]
+        sin: [num_tokens, head_size // 2]
+        is_neox_style: Whether to use the Neox-style or GPT-J-style rotary
+            positional embeddings.
+    """
+    cos = cos.unsqueeze(-2).to(x.dtype)
+    sin = sin.unsqueeze(-2).to(x.dtype)
+    if is_neox_style:
+        x1, x2 = torch.chunk(x, 2, dim=-1)
+    else:
+        x1 = x[..., ::2]
+        x2 = x[..., 1::2]
+    o1 = x1 * cos - x2 * sin
+    o2 = x2 * cos + x1 * sin
+    if is_neox_style:
+        return torch.cat((o1, o2), dim=-1)
+    else:
+        return torch.stack((o1, o2), dim=-1).flatten(-2)

--- a/tests/test_rope_utils.py
+++ b/tests/test_rope_utils.py
@@ -1,12 +1,6 @@
 import torch
 import utils
 
-DEVICE = utils.get_device()
-DTYPE = torch.bfloat16
-MAX_SEQ_LEN = 131072  # common seq length
-ROPE_BASE = 10000.0
-CACHE_SIZE = 1024 * 128
-
 """Common utilities for calculating rope reference"""
 DEVICE = utils.get_device()
 DTYPE = torch.bfloat16


### PR DESCRIPTION
## Motivation
Triton's implementation's perf in sglang [triton_mrope](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/rotary_embedding/triton_kernels.py) is not good enough. Optimize this kernel mainly in 2 aspects:
1. 2D grid exposes more parallelism — the rotary dimension is parallelized across work-items instead of serialized inside one program.
2. cos/sin loaded once, reused across all heads — 2 scalar register reads vs. Triton's 6 masked vector loads that get summed. 

## Modifications
1.  Added mrope kernel for xpu, which is adapted from sglang's triton implementation.
2. Added unit test and benchmark for this kernel.
3. Refined test script to reuse common codes of calculating cos_sin_cache. Rope related test could use common methods in **tests/test_rope_utils.py**.


## Performance
The configs are from qwen3.5-9B and qwen3.5-35B-A3B(tp=4). 
head_size = 256
rotary_dim = 64
datatype = bfloat16

Compared with triton.
|    |   num_tokens |   q_heads |   kv_heads | triton time(ms) | sglang time(ms)  | ratio |
|---:|-------------:|----------|---------------|:-----------|------------:|---------:|
|  0 |         1024 |         4 |          1| 0.025194 | 0.015184 | 165.9% |
|  1 |         1024 |        16 |          4| 0.036608 | 0.021892 | 167.2% |
|  2 |         2048 |         4 |          1|0.026832 |  0.018044 | 148.7% |
|  3 |         2048 |        16 |          4|0.056784 |  0.036712 | 154.5% | 
|  4 |         4096 |         4 |          1| 0.04524|   0.03016  | 150.0% |
|  5 |         4096 |        16 |          4|0.108888 |  0.083304 | 130.7% |
|  6 |         8192 |         4 |          1|0.082784 |  0.051636 | 160.3% |
|  7 |         8192 |        16 |          4|0.231504|  0.200928 | 115.2% |