### PR TITLE
Support fp32 gating logits in topk_sigmoid

### DIFF
--- a/src/sycl/TopKSigMoid.cpp
+++ b/src/sycl/TopKSigMoid.cpp
@@ -244,17 +244,16 @@ void topk_sigmoid(
   // models (e.g. Nemotron-3-Nano MoE) emit fp32 router gating logits. The kernel
   // already upcasts each element to float internally, so the fp32 path is a
   // no-op cast and adds no numerical change.
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      at::ScalarType::Half, at::ScalarType::BFloat16, gating_output.scalar_type(), "fused_topk_sigmoid_kernel", [&]() {
-        TopKSigmoidImpl::fused_topk_sigmoid<scalar_t>(
-            gating_output.data_ptr<scalar_t>(),
-            topk_weights.data_ptr<float>(),
-            topk_indices.data_ptr<int>(),
-            bias_ptr,
-            renormalize,
-            n_tokens,
-            n_experts,
-            n_topk);
-      });
+  DISPATCH_FLOAT_TYPES(gating_output.scalar_type(), "fused_topk_sigmoid_kernel", [&] {
+    TopKSigmoidImpl::fused_topk_sigmoid<scalar_t>(
+        gating_output.data_ptr<scalar_t>(),
+        topk_weights.data_ptr<float>(),
+        topk_indices.data_ptr<int>(),
+        bias_ptr,
+        renormalize,
+        n_tokens,
+        n_experts,
+        n_topk);
+  });
 }
 }  // namespace at::native::xpu

--- a/src/sycl/TopKSigMoid.cpp
+++ b/src/sycl/TopKSigMoid.cpp
@@ -240,16 +240,21 @@ void topk_sigmoid(
     bias_ptr = bias.data_ptr<float>();
   }
 
-  AT_DISPATCH_REDUCED_FLOATING_TYPES(gating_output.scalar_type(), "fused_topk_sigmoid_kernel", [&]() {
-    TopKSigmoidImpl::fused_topk_sigmoid<scalar_t>(
-        gating_output.data_ptr<scalar_t>(),
-        topk_weights.data_ptr<float>(),
-        topk_indices.data_ptr<int>(),
-        bias_ptr,
-        renormalize,
-        n_tokens,
-        n_experts,
-        n_topk);
-  });
+  // Cover Float in addition to the reduced float types (Half, BFloat16): some
+  // models (e.g. Nemotron-3-Nano MoE) emit fp32 router gating logits. The kernel
+  // already upcasts each element to float internally, so the fp32 path is a
+  // no-op cast and adds no numerical change.
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, gating_output.scalar_type(), "fused_topk_sigmoid_kernel", [&]() {
+        TopKSigmoidImpl::fused_topk_sigmoid<scalar_t>(
+            gating_output.data_ptr<scalar_t>(),
+            topk_weights.data_ptr<float>(),
+            topk_indices.data_ptr<int>(),
+            bias_ptr,
+            renormalize,
+            n_tokens,
+            n_experts,
+            n_topk);
+      });
 }
 }  // namespace at::native::xpu

--- a/tests/test_topk_sigmoid.py
+++ b/tests/test_topk_sigmoid.py
@@ -41,7 +41,13 @@ def fused_topk_sigmoid_torch_native(
     return topk_weights, topk_ids
 
 
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+# float32 covers the fp32 gating-logits path: some models (e.g.
+# Nemotron-3-Nano MoE) emit float32 router logits. Before the kernel dispatch
+# was widened from AT_DISPATCH_REDUCED_FLOATING_TYPES to also cover Float, this
+# call raised "not implemented for 'Float'". The kernel upcasts to float
+# internally, so fp32 in must match the float reference within the same
+# tolerance as the reduced-float path.
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
 @pytest.mark.parametrize("n_token", [2, 32, 4096])
 @pytest.mark.parametrize("n_expert", [8, 32, 256])
 @pytest.mark.parametrize("n_topk", [1, 2, 4])
@@ -93,63 +99,6 @@ def test_topk_sigmoid(
     ref.scatter_(1, ref_topk_indices.long(), ref_token_weights)
 
     # Increase the tolerance for this kernel for bf16 and fp16 inputs
-    atol = 3e-3
-    rtol = 1e-3
-    torch.testing.assert_close(res, ref, atol=atol, rtol=rtol)
-
-
-@pytest.mark.parametrize("n_token", [2, 32, 4096])
-@pytest.mark.parametrize("n_expert", [8, 32, 256])
-@pytest.mark.parametrize("n_topk", [1, 2, 4])
-@pytest.mark.parametrize("renormalize", [False, True])
-@pytest.mark.parametrize("with_correction_bias", [False, True])
-def test_topk_sigmoid_fp32(
-    n_token, n_topk, n_expert, renormalize, with_correction_bias
-):
-    # Regression test for the fp32 gating-logits path: some models (e.g.
-    # Nemotron-3-Nano MoE) emit float32 router logits. Before the dispatch was
-    # widened from AT_DISPATCH_REDUCED_FLOATING_TYPES to also cover Float, this
-    # call raised "not implemented for 'Float'". The kernel already upcasts to
-    # float internally, so fp32 in must match the float reference exactly (up to
-    # the same tolerance used for the reduced-float path).
-    torch.manual_seed(1024)
-    dtype = torch.float32
-
-    hidden_states = torch.randn(n_token, 100, device=device, dtype=dtype)
-    gating_output = torch.randn(n_token, n_expert, device=device, dtype=dtype)
-    correction_bias = None
-    if with_correction_bias:
-        correction_bias = torch.randn((n_expert), dtype=torch.float32, device=device)
-
-    ref_token_weights, ref_topk_indices = fused_topk_sigmoid_torch_native(
-        hidden_states.float(),
-        gating_output.float(),
-        n_topk,
-        renormalize,
-        correction_bias,
-    )
-
-    M, _ = hidden_states.shape
-    topk_weights = torch.empty(
-        M, n_topk, dtype=torch.float32, device=hidden_states.device
-    )
-    topk_indices = torch.empty(
-        M, n_topk, dtype=torch.int32, device=hidden_states.device
-    )
-
-    sgl_kernel.topk_sigmoid(
-        topk_weights,
-        topk_indices,
-        gating_output,
-        renormalize,
-        correction_bias,
-    )
-
-    res = torch.zeros(n_token, n_expert, dtype=torch.float, device=hidden_states.device)
-    ref = torch.zeros(n_token, n_expert, dtype=torch.float, device=hidden_states.device)
-    res.scatter_(1, topk_indices.long(), topk_weights)
-    ref.scatter_(1, ref_topk_indices.long(), ref_token_weights)
-
     atol = 3e-3
     rtol = 1e-3
     torch.testing.assert_close(res, ref, atol=atol, rtol=rtol)

--- a/tests/test_topk_sigmoid.py
+++ b/tests/test_topk_sigmoid.py
@@ -98,5 +98,62 @@ def test_topk_sigmoid(
     torch.testing.assert_close(res, ref, atol=atol, rtol=rtol)
 
 
+@pytest.mark.parametrize("n_token", [2, 32, 4096])
+@pytest.mark.parametrize("n_expert", [8, 32, 256])
+@pytest.mark.parametrize("n_topk", [1, 2, 4])
+@pytest.mark.parametrize("renormalize", [False, True])
+@pytest.mark.parametrize("with_correction_bias", [False, True])
+def test_topk_sigmoid_fp32(
+    n_token, n_topk, n_expert, renormalize, with_correction_bias
+):
+    # Regression test for the fp32 gating-logits path: some models (e.g.
+    # Nemotron-3-Nano MoE) emit float32 router logits. Before the dispatch was
+    # widened from AT_DISPATCH_REDUCED_FLOATING_TYPES to also cover Float, this
+    # call raised "not implemented for 'Float'". The kernel already upcasts to
+    # float internally, so fp32 in must match the float reference exactly (up to
+    # the same tolerance used for the reduced-float path).
+    torch.manual_seed(1024)
+    dtype = torch.float32
+
+    hidden_states = torch.randn(n_token, 100, device=device, dtype=dtype)
+    gating_output = torch.randn(n_token, n_expert, device=device, dtype=dtype)
+    correction_bias = None
+    if with_correction_bias:
+        correction_bias = torch.randn((n_expert), dtype=torch.float32, device=device)
+
+    ref_token_weights, ref_topk_indices = fused_topk_sigmoid_torch_native(
+        hidden_states.float(),
+        gating_output.float(),
+        n_topk,
+        renormalize,
+        correction_bias,
+    )
+
+    M, _ = hidden_states.shape
+    topk_weights = torch.empty(
+        M, n_topk, dtype=torch.float32, device=hidden_states.device
+    )
+    topk_indices = torch.empty(
+        M, n_topk, dtype=torch.int32, device=hidden_states.device
+    )
+
+    sgl_kernel.topk_sigmoid(
+        topk_weights,
+        topk_indices,
+        gating_output,
+        renormalize,
+        correction_bias,
+    )
+
+    res = torch.zeros(n_token, n_expert, dtype=torch.float, device=hidden_states.device)
+    ref = torch.zeros(n_token, n_expert, dtype=torch.float, device=hidden_states.device)
+    res.scatter_(1, topk_indices.long(), topk_weights)
+    ref.scatter_(1, ref_topk_indices.long(), ref_token_weights)
+
+    atol = 3e-3
+    rtol = 1e-3
+    torch.testing.assert_close(res, ref, atol=atol, rtol=rtol)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
Widen the topk_sigmoid dispatch from AT_DISPATCH_REDUCED_FLOATING_TYPES (Half, BFloat16 only) to AT_DISPATCH_FLOATING_TYPES_AND2 so float32 router gating logits (e.g. Nemotron-3-Nano MoE) are accepted. The kernel already upcasts each element to float internally, so the fp32 path is numerically a no-op cast.

Add test_topk_sigmoid_fp32 exercising the new fp32 path against the float reference across the same token/expert/topk/renormalize/bias grid.