### PR TITLE
[XPU] Updates for XPU Graph + torch.compile compatibility

### DIFF
--- a/include/sgl_flash_kernel_ops.h
+++ b/include/sgl_flash_kernel_ops.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <torch/library.h>
 #include <torch/torch.h>
 
+#include <tuple>
 #include <vector>
 
 #include "sgl_kernel_torch_shim.h"

--- a/include/sgl_flash_kernel_ops.h
+++ b/include/sgl_flash_kernel_ops.h
@@ -42,7 +42,7 @@ limitations under the License.
 /*
  * From flash-attention
  */
-std::vector<at::Tensor> mha_fwd(
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
     const at::Tensor& q,  // (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_q
     const at::Tensor& k,  // (b_k, s_k, h_k, d) or (total_k, h_k, d) if there is cu_seqlens_k or (num_pages, page_size,
                           // h_k, d) if there is page_table.
@@ -72,7 +72,8 @@ std::vector<at::Tensor> mha_fwd(
     std::optional<at::Tensor>& scheduler_metadata_,  // (b + 1)
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
-    int const sm_margin);
+    int const sm_margin,
+    std::optional<at::Tensor>& out_);
 
 void flash_mla_decode(
     torch::Tensor& out,

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -105,6 +105,8 @@ void merge_state(
 void merge_state_v2(
     at::Tensor v_a, at::Tensor s_a, at::Tensor v_b, at::Tensor s_b, at::Tensor v_merged, at::Tensor s_merged);
 
+at::Tensor weak_ref_tensor(const at::Tensor& tensor);
+
 /*
  * From csrc/elementwise
  */

--- a/python/sgl_kernel/__init__.py
+++ b/python/sgl_kernel/__init__.py
@@ -54,6 +54,7 @@ from sgl_kernel.gemm import (
 )
 from sgl_kernel.grammar import apply_token_bitmask_inplace_cuda
 from sgl_kernel.lora import embedding_lora_a_fwd
+from sgl_kernel.memory import weak_ref_tensor
 from sgl_kernel.mhc import hc_pre_big_fuse, hc_split_sinkhorn
 from sgl_kernel.moe import (
     apply_shuffle_mul_sum,

--- a/python/sgl_kernel/flash_attn.py
+++ b/python/sgl_kernel/flash_attn.py
@@ -212,10 +212,17 @@ def flash_attn_with_kvcache(
            to automatically determine the number of splits.
            Don't change this unless you know what you are doing.
         return_softmax_lse: bool. Whether to return the logsumexp of the attention scores.
+        out [optional]: preallocated output buffer of shape (total_q, nheads, headdim_v),
+            dtype matching q, on the same XPU device as q, with a contiguous last dimension
+            (stride(-1) == 1). When provided, the kernel writes results directly into this
+            buffer and the returned tensor aliases it. Useful for XPU graph / torch.compile
+            capture to avoid allocating a new output tensor each step.
 
     Return:
-        out: (batch_size, seqlen, nheads, headdim).
-        softmax_lse [optional, if return_softmax_lse=True]: (batch_size, nheads, seqlen). The
+        out: (total_q, nheads, headdim_v), where total_q = batch_size * seqlen (non-varlen)
+            or the sum of actual sequence lengths (varlen). The tensor aliases the provided
+            ``out`` buffer when one is supplied.
+        softmax_lse [optional, if return_softmax_lse=True]: (total_q, nheads). The
             logsumexp of each row of the matrix QK^T * scaling (e.g., log of the softmax
             normalization factor).
     """

--- a/python/sgl_kernel/flash_attn.py
+++ b/python/sgl_kernel/flash_attn.py
@@ -216,13 +216,15 @@ def flash_attn_with_kvcache(
             dtype matching q, on the same XPU device as q, with a contiguous last dimension
             (stride(-1) == 1). When provided, the kernel writes results directly into this
             buffer and the returned tensor aliases it. Useful for XPU graph / torch.compile
-            capture to avoid allocating a new output tensor each step.
+            capture to avoid allocating a new output tensor each step. Requires
+            ``page_table`` to be provided (paged KV cache); passing ``out`` without a
+            page table raises a ``RuntimeError``.
 
     Return:
         out: (total_q, nheads, headdim_v), where total_q = batch_size * seqlen (non-varlen)
             or the sum of actual sequence lengths (varlen). The tensor aliases the provided
             ``out`` buffer when one is supplied.
-        softmax_lse [optional, if return_softmax_lse=True]: (total_q, nheads). The
+        softmax_lse [optional, if return_softmax_lse=True]: (nheads, total_q). The
             logsumexp of each row of the matrix QK^T * scaling (e.g., log of the softmax
             normalization factor).
     """

--- a/python/sgl_kernel/flash_attn.py
+++ b/python/sgl_kernel/flash_attn.py
@@ -132,6 +132,7 @@ def flash_attn_with_kvcache(
     pack_gqa=None,  # Can be tuned for speed
     sm_margin=0,  # Can be tuned if some SMs are used for communication
     return_softmax_lse=False,
+    out=None,
 ):
     """
     If k and v are not None, k_cache and v_cache will be updated *inplace* with the new values from
@@ -245,7 +246,7 @@ def flash_attn_with_kvcache(
     rotary_cos, rotary_sin = [maybe_contiguous(x) for x in (rotary_cos, rotary_sin)]
     rotary_seqlens = maybe_contiguous(rotary_seqlens)
 
-    if cu_seqlens_q == None:  # !is_varlen_q
+    if cu_seqlens_q is None:  # !is_varlen_q
         cu_seqlens_q = torch.arange(
             0, q.size(0) + 1, dtype=torch.int, device=q.device
         ) * q.size(1)
@@ -283,6 +284,7 @@ def flash_attn_with_kvcache(
         num_splits,
         pack_gqa,
         sm_margin,
+        out,
     )
     return (out, softmax_lse, *rest) if return_softmax_lse else out
 
@@ -320,7 +322,7 @@ def flash_attn_varlen_func(
         softmax_scale = (q.shape[-1] + (qv.shape[-1] if qv is not None else 0)) ** (
             -0.5
         )
-    if cu_seqlens_q == None:  # !is_varlen_q
+    if cu_seqlens_q is None:  # !is_varlen_q
         cu_seqlens_q = torch.arange(
             0, q.size(0) + 1, dtype=torch.int, device=q.device
         ) * q.size(1)

--- a/python/sgl_kernel/memory.py
+++ b/python/sgl_kernel/memory.py
@@ -4,7 +4,7 @@ import torch
 def weak_ref_tensor(tensor):
     if not isinstance(tensor, torch.Tensor):
         return tensor
-    if not tensor.is_xpu():
+    if not tensor.is_xpu:
         return tensor
 
     return torch.ops.sgl_kernel.weak_ref_tensor(tensor)

--- a/python/sgl_kernel/memory.py
+++ b/python/sgl_kernel/memory.py
@@ -4,5 +4,7 @@ import torch
 def weak_ref_tensor(tensor):
     if not isinstance(tensor, torch.Tensor):
         return tensor
+    if not tensor.is_xpu():
+        return tensor
 
     return torch.ops.sgl_kernel.weak_ref_tensor(tensor)

--- a/python/sgl_kernel/memory.py
+++ b/python/sgl_kernel/memory.py
@@ -1,0 +1,8 @@
+import torch
+
+
+def weak_ref_tensor(tensor):
+    if not isinstance(tensor, torch.Tensor):
+        return tensor
+
+    return torch.ops.sgl_kernel.weak_ref_tensor(tensor)

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -1255,8 +1255,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
     const at::Tensor& out_val = out_.value();
     TORCH_CHECK(out_val.scalar_type() == q.scalar_type(), "out dtype must match q dtype");
     TORCH_CHECK(
-        out_val.dim() == 3 && out_val.size(0) == q.size(0) && out_val.size(1) == q.size(1) &&
-            out_val.size(2) == v.size(2),
+        out_val.dim() == 3 && out_val.size(0) == q.size(0) && out_val.size(1) == q.size(-2) &&
+            out_val.size(2) == v.size(-1),
         "out shape must be [total_q, num_heads, head_size_v]");
     TORCH_CHECK(out_val.device() == q.device(), "out must be on the same device as q");
     TORCH_CHECK(out_val.stride(-1) == 1, "out must have a contiguous last dimension");

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -1255,8 +1255,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
     const at::Tensor& out_val = out_.value();
     TORCH_CHECK(out_val.scalar_type() == q.scalar_type(), "out dtype must match q dtype");
     TORCH_CHECK(
-        out_val.dim() == 3 && out_val.size(0) == q.size(0) && out_val.size(1) == q.size(-2) &&
-            out_val.size(2) == v.size(-1),
+        out_val.dim() == 3 && out_val.size(0) == q.size(0) && out_val.size(1) == q.size(1) &&
+            out_val.size(2) == v.size(2),
         "out shape must be [total_q, num_heads, head_size_v]");
     TORCH_CHECK(out_val.device() == q.device(), "out must be on the same device as q");
     TORCH_CHECK(out_val.stride(-1) == 1, "out must have a contiguous last dimension");

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -1219,12 +1219,10 @@ std::vector<at::Tensor> mha_fwd(
 }  // namespace chunkprefill
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
-    const at::Tensor& q,  // (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_q
-    const at::Tensor& k,  // (b_k, s_k, h_k, d) or (total_k, h_k, d) if there is cu_seqlens_k or (num_pages, page_size,
-                          // h_k, d) if there is page_table.
-    const at::Tensor& v,  // (b_k, s_k, h_k, dv) or (total_k, h_k, dv) if there is cu_seqlens_k or (num_pages,
-                          // page_size, h_k, dv) if there is page_table.
-    std::optional<const at::Tensor>& q_v_,  // (b, s_q, h, dv) or (total_q_new, h, dv) if there is cu_seqlens_q
+    const at::Tensor& q,  // (total_q, h, d) — ragged 3D
+    const at::Tensor& k,  // (total_k, h_k, d) if non-paged, or (num_pages, page_size, h_k, d) if paged
+    const at::Tensor& v,  // (total_k, h_k, dv) if non-paged, or (num_pages, page_size, h_k, dv) if paged
+    std::optional<const at::Tensor>& q_v_,  // (total_q, h, dv) — not yet supported
     const at::Tensor& cu_seqlens_q,         // b+1
     const at::Tensor& cu_seqlens_k,         // b+1
     int max_seqlen_q,
@@ -1250,12 +1248,14 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
     std::optional<bool> pack_gqa_,
     int const sm_margin,
     std::optional<at::Tensor>& out_) {
-  TORCH_CHECK(cu_seqlens_k.data_ptr<int>() != nullptr, "cu_seqlens_k is not valid.");
+  TORCH_CHECK(q.dim() == 3, "query must be in ragged format (total_q, h, d)");
+  // k and v may be 3D (total_k, h_k, d) for non-paged or 4D (num_pages, page_size, h_k, d)
+  // for paged KV cache; sub-functions validate their own shapes.
   if (out_.has_value()) {
     const at::Tensor& out_val = out_.value();
     TORCH_CHECK(out_val.scalar_type() == q.scalar_type(), "out dtype must match q dtype");
     TORCH_CHECK(
-        out_val.dim() == 3 && out_val.size(0) == q.size(0) && out_val.size(1) == q.size(-2) &&
+        out_val.dim() == 3 && out_val.size(0) == q.size(0) && out_val.size(1) == q.size(1) &&
             out_val.size(2) == v.size(-1),
         "out shape must be [total_q, num_heads, head_size_v]");
     TORCH_CHECK(out_val.device() == q.device(), "out must be on the same device as q");

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -1141,7 +1141,8 @@ std::vector<at::Tensor> mha_fwd(
     std::optional<at::Tensor>& scheduler_metadata_,
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
-    int const sm_margin) {
+    int const sm_margin,
+    std::optional<at::Tensor> out_ = std::nullopt) {
   // Supports both paged (page_table != None) and non-paged (contiguous ragged
   // KV, page_table == None) layouts. In the non-paged case both sub-launches run
   // the non-paged prefill kernel (decode is paged-only), which is mathematically
@@ -1197,8 +1198,9 @@ std::vector<at::Tensor> mha_fwd(
         std::move(skip_mask));
   };
 
-  // Launch 1: decode allocates the shared output and skips prefill batches.
-  auto out = launch(decode::mha_fwd, std::nullopt, is_prefill)[0];
+  // Launch 1: decode allocates the shared output (or reuses the caller-provided
+  // out_ buffer) and skips prefill batches.
+  auto out = launch(decode::mha_fwd, std::move(out_), is_prefill)[0];
   // Launch 2: prefill writes into the same output and skips decode batches.
   launch(prefill::mha_fwd, out, is_prefill.logical_not());
 
@@ -1210,7 +1212,7 @@ std::vector<at::Tensor> mha_fwd(
 
 }  // namespace chunkprefill
 
-std::vector<at::Tensor> mha_fwd(
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
     const at::Tensor& q,  // (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_q
     const at::Tensor& k,  // (b_k, s_k, h_k, d) or (total_k, h_k, d) if there is cu_seqlens_k or (num_pages, page_size,
                           // h_k, d) if there is page_table.
@@ -1240,12 +1242,22 @@ std::vector<at::Tensor> mha_fwd(
     std::optional<at::Tensor>& scheduler_metadata_,  // (b + 1)
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
-    int const sm_margin) {
+    int const sm_margin,
+    std::optional<at::Tensor>& out_) {
   TORCH_CHECK(cu_seqlens_k.data_ptr<int>() != nullptr, "cu_seqlens_k is not valid.");
+  if (out_.has_value()) {
+    const at::Tensor& out_val = out_.value();
+    TORCH_CHECK(out_val.scalar_type() == q.scalar_type(), "out dtype must match q dtype");
+    TORCH_CHECK(
+        out_val.dim() == 3 && out_val.size(0) == q.size(0) && out_val.size(1) == q.size(-2) &&
+            out_val.size(2) == v.size(-1),
+        "out shape must be [total_q, num_heads, head_size_v]");
+  }
+  auto to_tuple = [](std::vector<at::Tensor> v) { return std::make_tuple(v[0], v[1], v[2], v[3]); };
   int const num_heads = q.size(-2);
   int const num_heads_k = k.size(-2);
   if (max_seqlen_q == 1 && page_table.has_value()) {
-    return decode::mha_fwd(
+    return to_tuple(decode::mha_fwd(
         q,
         k,
         v,
@@ -1273,9 +1285,10 @@ std::vector<at::Tensor> mha_fwd(
         scheduler_metadata_,
         num_kv_splits,
         pack_gqa_,
-        sm_margin);
+        sm_margin,
+        out_));
   } else {
-    return chunkprefill::mha_fwd(
+    return to_tuple(chunkprefill::mha_fwd(
         q,
         k,
         v,
@@ -1303,7 +1316,8 @@ std::vector<at::Tensor> mha_fwd(
         scheduler_metadata_,
         num_kv_splits,
         pack_gqa_,
-        sm_margin);
+        sm_margin,
+        out_));
   }
 }
 #undef SYCL_INTEL_TARGET

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -1155,6 +1155,12 @@ std::vector<at::Tensor> mha_fwd(
           !k_descale_.has_value() && !v_descale_.has_value() && !scheduler_metadata_.has_value(),
       "chunkprefill two-launch path does not yet support q_v / rotary / descale / scheduler_metadata.");
   TORCH_CHECK(cu_seqlens_q.scalar_type() == at::kInt, "cu_seqlens_q must be int32.");
+  // Pre-allocated out requires paged KV: on the non-paged path zero-KV-length
+  // rows are never written by the kernel, so a caller buffer would retain stale
+  // values on graph replay. SGLang always provides page_table (paged KV cache),
+  // so this check should never fire in practice.
+  TORCH_CHECK(
+      !out_.has_value() || page_table.has_value(), "chunkprefill: out buffer requires page_table (paged KV cache).");
 
   int64_t batch_size = cu_seqlens_q.size(0) - 1;
   TORCH_CHECK(batch_size >= 0, "cu_seqlens_q must have at least 1 element.");

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -1252,6 +1252,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
         out_val.dim() == 3 && out_val.size(0) == q.size(0) && out_val.size(1) == q.size(-2) &&
             out_val.size(2) == v.size(-1),
         "out shape must be [total_q, num_heads, head_size_v]");
+    TORCH_CHECK(out_val.device() == q.device(), "out must be on the same device as q");
+    TORCH_CHECK(out_val.stride(-1) == 1, "out must have a contiguous last dimension");
   }
   auto to_tuple = [](std::vector<at::Tensor> v) { return std::make_tuple(v[0], v[1], v[2], v[3]); };
   int const num_heads = q.size(-2);

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -20,6 +20,9 @@ limitations under the License.
 #include "sgl_kernel_ops.h"
 #include "sgl_kernel_torch_shim.h"
 TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
+  m.def("weak_ref_tensor(Tensor tensor) -> Tensor");
+  m.impl("weak_ref_tensor", torch::kXPU, &weak_ref_tensor);
+
   m.def("awq_dequantize(Tensor qweight, Tensor scales, Tensor qzeros) -> Tensor");
   m.impl("awq_dequantize", torch::kXPU, &awq_dequantize);
 
@@ -143,7 +146,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "    Tensor?  scheduler_metadata,"
       "    int      num_kv_splits,"
       "    bool?    pack_gqa,"
-      "    int      sm_margin) -> Tensor[]");
+      "    int      sm_margin,"
+      "    Tensor(a!)?  out=None) -> (Tensor(a!), Tensor, Tensor, Tensor)");
   m.impl("fwd", torch::kXPU, make_pytorch_shim(&mha_fwd));
 
   m.def("flash_mla_get_workspace_size", &flash_mla_get_workspace_size);

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -20,7 +20,7 @@ limitations under the License.
 #include "sgl_kernel_ops.h"
 #include "sgl_kernel_torch_shim.h"
 TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
-  m.def("weak_ref_tensor(Tensor tensor) -> Tensor");
+  m.def("weak_ref_tensor(Tensor(a) tensor) -> Tensor(a)");
   m.impl("weak_ref_tensor", torch::kXPU, &weak_ref_tensor);
 
   m.def("awq_dequantize(Tensor qweight, Tensor scales, Tensor qzeros) -> Tensor");

--- a/src/weak_ref_tensor.cpp
+++ b/src/weak_ref_tensor.cpp
@@ -18,10 +18,13 @@ limitations under the License.
 
 #include <vector>
 
+// [NOTE] weak_ref_tensor returns a no-ownership alias over the XPU tensor via `at::from_blob`.
+// Use weak references for XPU Graph outputs to decouple object lifetime from XPU graph.
+// This allows the memory to be efficiently reused.
 at::Tensor weak_ref_tensor(const at::Tensor& tensor) {
   TORCH_CHECK(tensor.is_xpu(), "weak_ref_tensor expects an XPU tensor");
   TORCH_CHECK(!tensor.requires_grad(), "weak_ref_tensor does not support autograd tensors");
-  // NOTE: The returned tensor does not own the underlying storage; ensure the backing allocation outlives it.
+  // The returned tensor does not own the underlying storage; ensure the backing allocation outlives it.
   void* data_ptr = tensor.data_ptr();
   std::vector<int64_t> sizes = tensor.sizes().vec();
   std::vector<int64_t> strides = tensor.strides().vec();

--- a/src/weak_ref_tensor.cpp
+++ b/src/weak_ref_tensor.cpp
@@ -1,0 +1,33 @@
+/* Copyright 2025 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <ATen/ATen.h>
+#include <ATen/Tensor.h>
+
+#include <vector>
+
+at::Tensor weak_ref_tensor(const at::Tensor& tensor) {
+  TORCH_CHECK(tensor.is_xpu(), "weak_ref_tensor expects an XPU tensor");
+
+  void* data_ptr = tensor.data_ptr();
+  std::vector<int64_t> sizes = tensor.sizes().vec();
+  std::vector<int64_t> strides = tensor.strides().vec();
+
+  auto options = tensor.options();
+
+  auto new_tensor = at::from_blob(data_ptr, sizes, strides, options);
+
+  return new_tensor;
+}

--- a/src/weak_ref_tensor.cpp
+++ b/src/weak_ref_tensor.cpp
@@ -20,7 +20,8 @@ limitations under the License.
 
 at::Tensor weak_ref_tensor(const at::Tensor& tensor) {
   TORCH_CHECK(tensor.is_xpu(), "weak_ref_tensor expects an XPU tensor");
-
+  TORCH_CHECK(!tensor.requires_grad(), "weak_ref_tensor does not support autograd tensors");
+  // NOTE: The returned tensor does not own the underlying storage; ensure the backing allocation outlives it.
   void* data_ptr = tensor.data_ptr();
   std::vector<int64_t> sizes = tensor.sizes().vec();
   std::vector<int64_t> strides = tensor.strides().vec();

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -1807,26 +1807,39 @@ def test_flash_attn_with_kvcache_out_buffer():
     torch.random.manual_seed(42)
     batch_size, seqlen_q, seqlen_k, nheads, nheads_kv, d = 2, 1, 64, 8, 2, 64
     dtype = torch.bfloat16
+    page_size = 64
+    num_blocks_per_seq = (seqlen_k + page_size - 1) // page_size
+    num_blocks = num_blocks_per_seq * batch_size
 
     q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype)
     k_cache = torch.randn(
-        batch_size, seqlen_k, nheads_kv, d, device=device, dtype=dtype
+        num_blocks, page_size, nheads_kv, d, device=device, dtype=dtype
     )
     v_cache = torch.randn(
-        batch_size, seqlen_k, nheads_kv, d, device=device, dtype=dtype
+        num_blocks, page_size, nheads_kv, d, device=device, dtype=dtype
+    )
+    page_table = torch.arange(num_blocks, dtype=torch.int32, device=device).view(
+        batch_size, num_blocks_per_seq
     )
     cache_seqlens = torch.full(
         (batch_size,), seqlen_k, dtype=torch.int32, device=device
     )
 
     # Run without out buffer to get reference output
-    ref_out = flash_attn_with_kvcache(q, k_cache, v_cache, cache_seqlens=cache_seqlens)
+    ref_out = flash_attn_with_kvcache(
+        q, k_cache, v_cache, cache_seqlens=cache_seqlens, page_table=page_table
+    )
 
     # Preallocate out buffer: shape [total_q, nheads, d] = [batch*seqlen_q, nheads, d]
     total_q = batch_size * seqlen_q
     out_buf = torch.empty(total_q, nheads, d, device=device, dtype=dtype)
     result = flash_attn_with_kvcache(
-        q, k_cache, v_cache, cache_seqlens=cache_seqlens, out=out_buf
+        q,
+        k_cache,
+        v_cache,
+        cache_seqlens=cache_seqlens,
+        page_table=page_table,
+        out=out_buf,
     )
 
     # The returned tensor must alias the provided buffer (same storage)

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -1799,5 +1799,47 @@ def test_flash_attn_varlen_output(
         ).abs().max().item() + dv_atol
 
 
+@pytest.mark.skipif(device.type != "xpu", reason="XPU not available")
+def test_flash_attn_with_kvcache_out_buffer():
+    """Test that a preallocated out buffer is reused and the result is correct."""
+    from sgl_kernel.flash_attn import flash_attn_with_kvcache
+
+    torch.random.manual_seed(42)
+    batch_size, seqlen_q, seqlen_k, nheads, nheads_kv, d = 2, 1, 64, 8, 2, 64
+    dtype = torch.bfloat16
+
+    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype)
+    k_cache = torch.randn(
+        batch_size, seqlen_k, nheads_kv, d, device=device, dtype=dtype
+    )
+    v_cache = torch.randn(
+        batch_size, seqlen_k, nheads_kv, d, device=device, dtype=dtype
+    )
+    cache_seqlens = torch.full(
+        (batch_size,), seqlen_k, dtype=torch.int32, device=device
+    )
+
+    # Run without out buffer to get reference output
+    ref_out = flash_attn_with_kvcache(q, k_cache, v_cache, cache_seqlens=cache_seqlens)
+
+    # Preallocate out buffer: shape [total_q, nheads, d] = [batch*seqlen_q, nheads, d]
+    total_q = batch_size * seqlen_q
+    out_buf = torch.empty(total_q, nheads, d, device=device, dtype=dtype)
+    result = flash_attn_with_kvcache(
+        q, k_cache, v_cache, cache_seqlens=cache_seqlens, out=out_buf
+    )
+
+    # The returned tensor must alias the provided buffer (same storage)
+    assert (
+        result.data_ptr() == out_buf.data_ptr()
+    ), "result should alias the provided out buffer"
+
+    # Numerical correctness: values must match the reference
+    torch.xpu.synchronize()
+    assert torch.allclose(
+        result.reshape(ref_out.shape), ref_out, atol=1e-2
+    ), "out-buffer result differs from reference"
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))

--- a/tests/test_weak_ref_tensor.py
+++ b/tests/test_weak_ref_tensor.py
@@ -5,7 +5,7 @@ import utils
 device = utils.get_device()
 
 
-@pytest.mark.skipif(not torch.xpu.is_available(), reason="XPU not available")
+@pytest.mark.skipif(device.type != "xpu", reason="XPU not available")
 def test_weak_ref_tensor_aliasing():
     """Test that weak_ref_tensor output shares storage with the input."""
     from sgl_kernel.memory import weak_ref_tensor

--- a/tests/test_weak_ref_tensor.py
+++ b/tests/test_weak_ref_tensor.py
@@ -1,0 +1,38 @@
+import pytest
+import torch
+import utils
+
+device = utils.get_device()
+
+
+@pytest.mark.skipif(not torch.xpu.is_available(), reason="XPU not available")
+def test_weak_ref_tensor_aliasing():
+    """Test that weak_ref_tensor output shares storage with the input."""
+    from sgl_kernel.memory import weak_ref_tensor
+
+    x = torch.randn(4, 8, device=device, dtype=torch.bfloat16)
+    y = weak_ref_tensor(x)
+
+    # Same data pointer: output aliases input storage
+    assert (
+        y.data_ptr() == x.data_ptr()
+    ), "weak_ref_tensor output should share storage with input"
+
+    # Sizes and strides are preserved
+    assert list(y.shape) == list(
+        x.shape
+    ), "weak_ref_tensor output shape must match input"
+    assert list(y.stride()) == list(
+        x.stride()
+    ), "weak_ref_tensor output strides must match input"
+
+    # Non-XPU tensors are returned as-is (no op)
+    cpu_x = torch.randn(4, 8)
+    cpu_y = weak_ref_tensor(cpu_x)
+    assert cpu_y is cpu_x, "weak_ref_tensor should return CPU tensor unchanged"
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Motivation

This change updates for XPU Graph + torch.compile support compatibility.


## Changes
* `mha_fwd` optional out argument — callers can now pass a pre-allocated output tensor. Under graph capture, SGLang binds a stable output buffer once and reuses it across replays.
* `fwd` return type and schema — the top-level op now returns a fixed 4-tuple `(out, softmax_lse, out_accum, softmax_lse_accum)` instead of `Tensor[]`. The Torch schema is annotated as `Tensor(a!)? out=None) -> (Tensor(a!), Tensor, Tensor, Tensor)`, so functionalization correctly models the in-place output aliasing required for Dynamo tracing.
* `weak_ref_tensor` op for XPU — registers a no-ownership view over an XPU tensor (`at::from_blob`). SGLang uses it to release captured-output ownership earlier on the XPU graph path.
* Minor change— `cu_seqlens_q == None` → `cu_seqlens_q is None` for torch.compile compatibility.