### PR TITLE
[XPU] Enable MXFP4 GroupGemm ActType=2 (swiglu_gpt_oss) + WithBias for gpt-oss

### DIFF
--- a/src/GroupGemmMxfp4W4A16Xe20.cmake
+++ b/src/GroupGemmMxfp4W4A16Xe20.cmake
@@ -21,24 +21,28 @@ endfunction()
 #   <_256, _64,  _32> / SG_8_2_1   — avg_m > 128,  fuse_act=true
 #   <_256, _256, _32> / SG_8_4_1   — avg_m > 128,  fuse_act=false
 
-# TEMPORARY L0-module-pressure workaround: generate only the variants DSV4
-# actually dispatches (activation_type=0 silu and activation_type=4
-# swiglu_deepseek_v4, with_bias=false), skipping the full act × bias cartesian
-# product. This keeps the AOT-compiled MXFP4 .so count small, which is
-# necessary to keep the Level Zero driver below its per-context module cap
-# under TP>1. Matching dispatch-side prune lives in
-# src/sycl/GroupGemmMxfp4W4A16Xe20.cpp.
-#   act_type 0 = silu, 4 = swiglu_deepseek_v4 (clamp gate/up then silu*up)
-set(with_bias false)
-foreach(act_type 0 4)
-    foreach(fuse_act true false)
-        add_group_gemm_mxfp4_w4a16_xe20_inst("_8" "_64" "_32" "_1, _4, _1" "_4, _1, _0" ${act_type} ${fuse_act} ${with_bias})
-    endforeach()
+# Instantiation matrix: act_type ∈ {0 silu, 2 swiglu_gpt_oss, 4 swiglu_deepseek_v4}
+# × with_bias ∈ {false, true} × the fuse_act tile menu above.
+#
+# act_type 2 (swiglu_gpt_oss) and with_bias=true were re-enabled here to serve
+# gpt-oss-20b (GptOssForCausalLM), whose MoE uses the gpt-oss gated activation
+# and per-channel mlp1/mlp2 biases. The original prune kept only DSV4's
+# {0,4}+no-bias variants to bound Level Zero per-context module count under
+# TP>1; at TP=1 the larger matrix fits. The dispatch-side TORCH_CHECKs in
+# src/sycl/GroupGemmMxfp4W4A16Xe20.cpp are relaxed to match. If you reintroduce
+# TP>1 and hit L0 module-pool exhaustion, narrow this matrix back down.
+#   act_type 0 = silu, 2 = swiglu_gpt_oss (clamp + (up+1) gate), 4 = swiglu_deepseek_v4
+foreach(act_type 0 2 4)
+    foreach(with_bias false true)
+        foreach(fuse_act true false)
+            add_group_gemm_mxfp4_w4a16_xe20_inst("_8" "_64" "_32" "_1, _4, _1" "_4, _1, _0" ${act_type} ${fuse_act} ${with_bias})
+        endforeach()
 
-    add_group_gemm_mxfp4_w4a16_xe20_inst("_128" "_64" "_32" "_4, _2, _1" "_2, _1, _0" ${act_type} true ${with_bias})
-    add_group_gemm_mxfp4_w4a16_xe20_inst("_128" "_128" "_32" "_4, _2, _1" "_2, _1, _0" ${act_type} false ${with_bias})
-    add_group_gemm_mxfp4_w4a16_xe20_inst("_256" "_64" "_32" "_8, _2, _1" "_2, _1, _0" ${act_type} true ${with_bias})
-    add_group_gemm_mxfp4_w4a16_xe20_inst("_256" "_256" "_32" "_8, _4, _1" "_4, _1, _0" ${act_type} false ${with_bias})
+        add_group_gemm_mxfp4_w4a16_xe20_inst("_128" "_64" "_32" "_4, _2, _1" "_2, _1, _0" ${act_type} true ${with_bias})
+        add_group_gemm_mxfp4_w4a16_xe20_inst("_128" "_128" "_32" "_4, _2, _1" "_2, _1, _0" ${act_type} false ${with_bias})
+        add_group_gemm_mxfp4_w4a16_xe20_inst("_256" "_64" "_32" "_8, _2, _1" "_2, _1, _0" ${act_type} true ${with_bias})
+        add_group_gemm_mxfp4_w4a16_xe20_inst("_256" "_256" "_32" "_8, _4, _1" "_4, _1, _0" ${act_type} false ${with_bias})
+    endforeach()
 endforeach()
 
 list(APPEND ATen_XPU_SYCL_XE20 ${GROUP_GEMM_MXFP4_W4A16_XE20_INST_SRCS})

--- a/src/sycl/GroupGemmMxfp4W4A16Xe20.cpp
+++ b/src/sycl/GroupGemmMxfp4W4A16Xe20.cpp
@@ -75,7 +75,7 @@ using SG_8_4_1 = Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>;
   DECLARE_XE20_MOE_MXFP4_EXTERN(Tile_256_64_32, SG_8_2_1, ActType, true, WithBias)   \
   DECLARE_XE20_MOE_MXFP4_EXTERN(Tile_256_256_32, SG_8_4_1, ActType, false, WithBias)
 
-#define DECLARE_XE20_MOE_MXFP4_TILES(ActType) \
+#define DECLARE_XE20_MOE_MXFP4_TILES(ActType)    \
   DECLARE_XE20_MOE_MXFP4_TILES_B(ActType, false) \
   DECLARE_XE20_MOE_MXFP4_TILES_B(ActType, true)
 
@@ -108,38 +108,38 @@ DECLARE_XE20_MOE_MXFP4_TILES(4)
 // concrete template specialization for the runtime (ActType, FuseAct,
 // WithBias) triple. Combos outside this set hit the TORCH_CHECK below; restore
 // them in both this file and the cmake matrix before rebuilding.
-#define LAUNCH_MOE_MXFP4_ACT(ActTypeLit, FuseAct, WithBias, ...)  \
-  do {                                                            \
-    if (FuseAct) {                                                \
-      if (WithBias) {                                             \
-        LAUNCH_MOE_MXFP4(__VA_ARGS__, ActTypeLit, true, true);    \
-      } else {                                                    \
-        LAUNCH_MOE_MXFP4(__VA_ARGS__, ActTypeLit, true, false);   \
-      }                                                           \
-    } else {                                                      \
-      if (WithBias) {                                             \
-        LAUNCH_MOE_MXFP4(__VA_ARGS__, ActTypeLit, false, true);   \
-      } else {                                                    \
-        LAUNCH_MOE_MXFP4(__VA_ARGS__, ActTypeLit, false, false);  \
-      }                                                           \
-    }                                                             \
+#define LAUNCH_MOE_MXFP4_ACT(ActTypeLit, FuseAct, WithBias, ...) \
+  do {                                                           \
+    if (FuseAct) {                                               \
+      if (WithBias) {                                            \
+        LAUNCH_MOE_MXFP4(__VA_ARGS__, ActTypeLit, true, true);   \
+      } else {                                                   \
+        LAUNCH_MOE_MXFP4(__VA_ARGS__, ActTypeLit, true, false);  \
+      }                                                          \
+    } else {                                                     \
+      if (WithBias) {                                            \
+        LAUNCH_MOE_MXFP4(__VA_ARGS__, ActTypeLit, false, true);  \
+      } else {                                                   \
+        LAUNCH_MOE_MXFP4(__VA_ARGS__, ActTypeLit, false, false); \
+      }                                                          \
+    }                                                            \
   } while (0)
 
-#define DISPATCH_MOE_MXFP4(ActType, FuseAct, WithBias, ...)                                                       \
-  do {                                                                                                            \
-    TORCH_CHECK(                                                                                                  \
-        (ActType) == 0 || (ActType) == 2 || (ActType) == 4,                                                       \
-        "mxfp4 fused kernel built with ActType=0 (silu), 2 (swiglu_gpt_oss) and 4 (swiglu_deepseek_v4) only; "   \
-        "got ActType=",                                                                                           \
-        (ActType),                                                                                                \
-        ". See src/GroupGemmMxfp4W4A16Xe20.cmake to re-enable additional ActType/WithBias combos.");              \
-    if ((ActType) == 4) {                                                                                         \
-      LAUNCH_MOE_MXFP4_ACT(4, FuseAct, WithBias, __VA_ARGS__);                                                    \
-    } else if ((ActType) == 2) {                                                                                  \
-      LAUNCH_MOE_MXFP4_ACT(2, FuseAct, WithBias, __VA_ARGS__);                                                    \
-    } else {                                                                                                      \
-      LAUNCH_MOE_MXFP4_ACT(0, FuseAct, WithBias, __VA_ARGS__);                                                    \
-    }                                                                                                             \
+#define DISPATCH_MOE_MXFP4(ActType, FuseAct, WithBias, ...)                                                    \
+  do {                                                                                                         \
+    TORCH_CHECK(                                                                                               \
+        (ActType) == 0 || (ActType) == 2 || (ActType) == 4,                                                    \
+        "mxfp4 fused kernel built with ActType=0 (silu), 2 (swiglu_gpt_oss) and 4 (swiglu_deepseek_v4) only; " \
+        "got ActType=",                                                                                        \
+        (ActType),                                                                                             \
+        ". See src/GroupGemmMxfp4W4A16Xe20.cmake to re-enable additional ActType/WithBias combos.");           \
+    if ((ActType) == 4) {                                                                                      \
+      LAUNCH_MOE_MXFP4_ACT(4, FuseAct, WithBias, __VA_ARGS__);                                                 \
+    } else if ((ActType) == 2) {                                                                               \
+      LAUNCH_MOE_MXFP4_ACT(2, FuseAct, WithBias, __VA_ARGS__);                                                 \
+    } else {                                                                                                   \
+      LAUNCH_MOE_MXFP4_ACT(0, FuseAct, WithBias, __VA_ARGS__);                                                 \
+    }                                                                                                          \
   } while (0)
 
 void moe_grouped_mm_nt_xe20_mxfp4_w4a16(

--- a/src/sycl/GroupGemmMxfp4W4A16Xe20.cpp
+++ b/src/sycl/GroupGemmMxfp4W4A16Xe20.cpp
@@ -62,22 +62,29 @@ using SG_8_4_1 = Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>;
       float,                                                                                           \
       float);
 
-// TEMPORARY L0-module-pressure workaround: declare only the instantiations
-// that GroupGemmMxfp4W4A16Xe20.cmake actually emits (ActType=0 silu and
-// ActType=4 swiglu_deepseek_v4, WithBias=false). The dispatcher below enforces
-// the same constraint at runtime. Keep the two sides in sync.
-#define DECLARE_XE20_MOE_MXFP4_TILES(ActType)                                     \
-  DECLARE_XE20_MOE_MXFP4_EXTERN(Tile_8_64_32, SG_1_4_1, ActType, true, false)     \
-  DECLARE_XE20_MOE_MXFP4_EXTERN(Tile_8_64_32, SG_1_4_1, ActType, false, false)    \
-  DECLARE_XE20_MOE_MXFP4_EXTERN(Tile_128_64_32, SG_4_2_1, ActType, true, false)   \
-  DECLARE_XE20_MOE_MXFP4_EXTERN(Tile_128_128_32, SG_4_2_1, ActType, false, false) \
-  DECLARE_XE20_MOE_MXFP4_EXTERN(Tile_256_64_32, SG_8_2_1, ActType, true, false)   \
-  DECLARE_XE20_MOE_MXFP4_EXTERN(Tile_256_256_32, SG_8_4_1, ActType, false, false)
+// Declare the instantiations GroupGemmMxfp4W4A16Xe20.cmake emits:
+// ActType ∈ {0 silu, 2 swiglu_gpt_oss, 4 swiglu_deepseek_v4} × WithBias ∈
+// {false, true} × the fuse_act tile menu. The dispatcher below allows the same
+// set at runtime. Keep the two sides in sync (see the cmake header comment for
+// the TP>1 module-pressure caveat).
+#define DECLARE_XE20_MOE_MXFP4_TILES_B(ActType, WithBias)                            \
+  DECLARE_XE20_MOE_MXFP4_EXTERN(Tile_8_64_32, SG_1_4_1, ActType, true, WithBias)     \
+  DECLARE_XE20_MOE_MXFP4_EXTERN(Tile_8_64_32, SG_1_4_1, ActType, false, WithBias)    \
+  DECLARE_XE20_MOE_MXFP4_EXTERN(Tile_128_64_32, SG_4_2_1, ActType, true, WithBias)   \
+  DECLARE_XE20_MOE_MXFP4_EXTERN(Tile_128_128_32, SG_4_2_1, ActType, false, WithBias) \
+  DECLARE_XE20_MOE_MXFP4_EXTERN(Tile_256_64_32, SG_8_2_1, ActType, true, WithBias)   \
+  DECLARE_XE20_MOE_MXFP4_EXTERN(Tile_256_256_32, SG_8_4_1, ActType, false, WithBias)
+
+#define DECLARE_XE20_MOE_MXFP4_TILES(ActType) \
+  DECLARE_XE20_MOE_MXFP4_TILES_B(ActType, false) \
+  DECLARE_XE20_MOE_MXFP4_TILES_B(ActType, true)
 
 DECLARE_XE20_MOE_MXFP4_TILES(0)
+DECLARE_XE20_MOE_MXFP4_TILES(2)
 DECLARE_XE20_MOE_MXFP4_TILES(4)
 
 #undef DECLARE_XE20_MOE_MXFP4_TILES
+#undef DECLARE_XE20_MOE_MXFP4_TILES_B
 #undef DECLARE_XE20_MOE_MXFP4_EXTERN
 
 #define LAUNCH_MOE_MXFP4(...)                      \
@@ -96,38 +103,43 @@ DECLARE_XE20_MOE_MXFP4_TILES(4)
       static_cast<float>(gemm1_alpha),             \
       static_cast<float>(gemm1_limit))
 
-// TEMPORARY: matching prune for the cmake-side instantiation matrix above.
-// Only ActType ∈ {0 silu, 4 swiglu_deepseek_v4} and WithBias=false are
-// instantiated, so the dispatch branches over just those values rather than
-// the full activation set. Callers that need the other combos will hit the
-// TORCH_CHECK below and must restore the full matrix before rebuilding.
-#define LAUNCH_MOE_MXFP4_ACT(ActTypeLit, FuseAct, ...)         \
-  do {                                                         \
-    if (FuseAct) {                                             \
-      LAUNCH_MOE_MXFP4(__VA_ARGS__, ActTypeLit, true, false);  \
-    } else {                                                   \
-      LAUNCH_MOE_MXFP4(__VA_ARGS__, ActTypeLit, false, false); \
-    }                                                          \
+// Dispatch over the instantiated matrix: ActType ∈ {0 silu, 2 swiglu_gpt_oss,
+// 4 swiglu_deepseek_v4} × WithBias ∈ {false, true} × FuseAct. Selects the
+// concrete template specialization for the runtime (ActType, FuseAct,
+// WithBias) triple. Combos outside this set hit the TORCH_CHECK below; restore
+// them in both this file and the cmake matrix before rebuilding.
+#define LAUNCH_MOE_MXFP4_ACT(ActTypeLit, FuseAct, WithBias, ...)  \
+  do {                                                            \
+    if (FuseAct) {                                                \
+      if (WithBias) {                                             \
+        LAUNCH_MOE_MXFP4(__VA_ARGS__, ActTypeLit, true, true);    \
+      } else {                                                    \
+        LAUNCH_MOE_MXFP4(__VA_ARGS__, ActTypeLit, true, false);   \
+      }                                                           \
+    } else {                                                      \
+      if (WithBias) {                                             \
+        LAUNCH_MOE_MXFP4(__VA_ARGS__, ActTypeLit, false, true);   \
+      } else {                                                    \
+        LAUNCH_MOE_MXFP4(__VA_ARGS__, ActTypeLit, false, false);  \
+      }                                                           \
+    }                                                             \
   } while (0)
 
-#define DISPATCH_MOE_MXFP4(ActType, FuseAct, WithBias, ...)                                                     \
-  do {                                                                                                          \
-    TORCH_CHECK(                                                                                                \
-        (ActType) == 0 || (ActType) == 4,                                                                       \
-        "mxfp4 fused kernel built with ActType=0 (silu) and ActType=4 (swiglu_deepseek_v4) only; got ActType=", \
-        (ActType),                                                                                              \
-        ". The AOT instantiation matrix is pruned to keep Level Zero module pressure in budget under TP>1 — " \
-        "see src/GroupGemmMxfp4W4A16Xe20.cmake to re-enable additional ActType/WithBias combos.");              \
-    TORCH_CHECK(                                                                                                \
-        !(WithBias),                                                                                            \
-        "mxfp4 fused kernel built with WithBias=false only; bias path unsupported in this build. "              \
-        "The AOT instantiation matrix is pruned to keep Level Zero module pressure in budget under TP>1 — "   \
-        "see src/GroupGemmMxfp4W4A16Xe20.cmake to re-enable additional ActType/WithBias combos.");              \
-    if ((ActType) == 4) {                                                                                       \
-      LAUNCH_MOE_MXFP4_ACT(4, FuseAct, __VA_ARGS__);                                                            \
-    } else {                                                                                                    \
-      LAUNCH_MOE_MXFP4_ACT(0, FuseAct, __VA_ARGS__);                                                            \
-    }                                                                                                           \
+#define DISPATCH_MOE_MXFP4(ActType, FuseAct, WithBias, ...)                                                       \
+  do {                                                                                                            \
+    TORCH_CHECK(                                                                                                  \
+        (ActType) == 0 || (ActType) == 2 || (ActType) == 4,                                                       \
+        "mxfp4 fused kernel built with ActType=0 (silu), 2 (swiglu_gpt_oss) and 4 (swiglu_deepseek_v4) only; "   \
+        "got ActType=",                                                                                           \
+        (ActType),                                                                                                \
+        ". See src/GroupGemmMxfp4W4A16Xe20.cmake to re-enable additional ActType/WithBias combos.");              \
+    if ((ActType) == 4) {                                                                                         \
+      LAUNCH_MOE_MXFP4_ACT(4, FuseAct, WithBias, __VA_ARGS__);                                                    \
+    } else if ((ActType) == 2) {                                                                                  \
+      LAUNCH_MOE_MXFP4_ACT(2, FuseAct, WithBias, __VA_ARGS__);                                                    \
+    } else {                                                                                                      \
+      LAUNCH_MOE_MXFP4_ACT(0, FuseAct, WithBias, __VA_ARGS__);                                                    \
+    }                                                                                                             \
   } while (0)
 
 void moe_grouped_mm_nt_xe20_mxfp4_w4a16(

--- a/tests/test_moe_gemm.py
+++ b/tests/test_moe_gemm.py
@@ -396,6 +396,122 @@ def test_moe_gemm_mxfp4_weights(
 
 
 # ---------------------------------------------------------------------------
+# MXFP4 expert-weight test — gpt-oss swiglu (ActType=2) + per-expert bias
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "num_tokens,topk,num_experts,hidden_size,intermediate_size,with_bias",
+    list(
+        itertools.product(
+            [1, 33, 222],  # num_tokens
+            [1, 2, 6],  # topk
+            [8, 64],  # num_experts
+            [128, 1024],  # hidden_size       – multiple of MXFP4_BLOCK_SIZE
+            [128, 512],  # intermediate_size  – multiple of MXFP4_BLOCK_SIZE
+            [False, True],  # with_bias
+        )
+    ),
+)
+def test_moe_gemm_mxfp4_weights_gpt_oss(
+    num_tokens,
+    topk,
+    num_experts,
+    hidden_size,
+    intermediate_size,
+    with_bias,
+):
+    """MXFP4-packed expert weights (W4A16) with the gpt-oss gated activation
+    (swiglu_gpt_oss, ActType=2) and optional per-channel mlp1/mlp2 biases.
+
+    This is the combination gpt-oss-20b (GptOssForCausalLM) needs: the tile-
+    fused MXFP4 grouped-GEMM must dispatch activation_type=2 + with_bias=true.
+    The instantiation matrix in src/GroupGemmMxfp4W4A16Xe20.cmake was originally
+    pruned to {silu, deepseek_v4} x {no-bias}; this test guards the re-enabled
+    ActType=2 / WithBias path so a future re-prune that drops it fails loudly
+    here instead of aborting at the first gpt-oss MoE forward with:
+        RuntimeError: mxfp4 fused kernel built with ActType=0 (silu) and
+        ActType=4 (swiglu_deepseek_v4) only; got ActType=2.
+
+    Weights are quantised to MXFP4 then dequantised for the reference, so both
+    paths see identical MXFP4-rounded weights and any diff is bf16 GEMM noise.
+    """
+    torch.manual_seed(0)
+    torch.xpu.manual_seed_all(0)
+
+    rtol, atol = 1e-1, 1e-2
+
+    a = create_random_cpu_tensor((num_tokens, hidden_size), torch.bfloat16)
+    # w1: gate+up projection [E, 2*I, H] (interleaved g0,u0,g1,u1,... for gpt-oss);
+    # w2: down projection [E, H, I].
+    w1_bf16 = create_random_cpu_tensor(
+        (num_experts, 2 * intermediate_size, hidden_size), torch.bfloat16
+    )
+    w2_bf16 = create_random_cpu_tensor(
+        (num_experts, hidden_size, intermediate_size), torch.bfloat16
+    )
+
+    # Per-channel biases (float32, matching the kernel's fp32 bias accumulate).
+    b1, b2 = None, None
+    if with_bias:
+        b1 = create_random_cpu_tensor(
+            (num_experts, 2 * intermediate_size), torch.float32, std=0.005
+        )
+        b2 = create_random_cpu_tensor(
+            (num_experts, hidden_size), torch.float32, std=0.005
+        )
+
+    score = torch.randn([num_tokens, num_experts], dtype=torch.bfloat16)
+    score = torch.softmax(score, dim=-1, dtype=torch.float32)
+    topk_weight, topk_ids = torch.topk(score, topk)
+
+    # ---- quantise → dequantise so kernel + reference see the same weights ----
+    w1_packed, w1_scale = _quantize_weights_mxfp4(w1_bf16)
+    w2_packed, w2_scale = _quantize_weights_mxfp4(w2_bf16)
+    w1_dq = _dequantize_weights_mxfp4(w1_packed, w1_scale)
+    w2_dq = _dequantize_weights_mxfp4(w2_packed, w2_scale)
+
+    torch_output = torch_naive_moe(
+        a,
+        w1_dq,
+        w2_dq,
+        topk_ids,
+        topk_weight,
+        topk,
+        b1,
+        b2,
+        activations="silu",
+        gemm1_alpha=SWIGLU_ALPHA,
+        gemm1_limit=SWIGLU_LIMIT,
+    )
+
+    device = "xpu"
+    sglang_output = fused_experts(
+        a.to(device),
+        w1_packed.view(torch.int8).to(device),
+        w2_packed.view(torch.int8).to(device),
+        topk_weight.to(device),
+        topk_ids.to(device),
+        b1.to(device) if b1 is not None else None,
+        b2.to(device) if b2 is not None else None,
+        activation="silu",
+        use_mxfp4_w4a16=True,
+        w1_scale=torch.exp2((w1_scale.to(torch.int32) - 127).to(torch.float32)).to(
+            device
+        ),
+        w2_scale=torch.exp2((w2_scale.to(torch.int32) - 127).to(torch.float32)).to(
+            device
+        ),
+        gemm1_alpha=SWIGLU_ALPHA,
+        gemm1_limit=SWIGLU_LIMIT,
+    )
+
+    torch.testing.assert_close(
+        torch_output, sglang_output.to("cpu"), rtol=rtol, atol=atol
+    )
+
+
+# ---------------------------------------------------------------------------
 # Op-level test: moe_grouped_mm_nt_xe20_mxfp4_w4a16 vs. moe_grouped_mm_nt_xe20(dequant)
 # ---------------------------------------------------------------------------
 #


### PR DESCRIPTION
The MXFP4 W4A16 grouped-GEMM AOT instantiation matrix was pruned to {ActType 0 (silu), 4 (swiglu_deepseek_v4)} x {WithBias false} to keep Level Zero per-context module count in budget under TP>1.

gpt-oss-20b (GptOssForCausalLM) cannot run on this pruned kernel: its MoE uses the gpt-oss gated activation (swiglu_gpt_oss, ActType=2) with per-channel mlp1/mlp2 biases. sglang's mxfp4 path forwards the model's gemm1_alpha/gemm1_limit to sgl_kernel.fused_experts, which resolves to activation_type=2 + with_bias=true and dispatches
moe_grouped_mm_nt_xe20_mxfp4_w4a16. Against the pruned build this aborts at the first MoE forward:

  RuntimeError: mxfp4 fused kernel built with ActType=0 (silu) and
  ActType=4 (swiglu_deepseek_v4) only; got ActType=2.

(verified empirically: built pruned HEAD, launched gpt-oss-20b on Intel BMG/Xe2, observed the abort; re-enabling act=2+bias makes it serve.)

This re-adds ActType=2 and WithBias={false,true} to the cmake instantiation matrix and relaxes the matching dispatch-side TORCH_CHECKs. At TP=1 the larger module set fits; if TP>1 hits L0 module-pool exhaustion, narrow the matrix back down (see the cmake header comment).