### PR TITLE
Improve small k perf for group gemm

### DIFF
--- a/src/sycl/kernels/moe/xe20/bf16/moe_kernel.hpp
+++ b/src/sycl/kernels/moe/xe20/bf16/moe_kernel.hpp
@@ -31,6 +31,7 @@
  **************************************************************************************************/
 #pragma once
 
+#include "cute/atom/copy_traits_xe_2d.hpp"
 #include "cute/tensor.hpp"
 #include "cutlass/cutlass.h"
 #include "cutlass/gemm/gemm.h"
@@ -66,7 +67,7 @@ class MoEGEMM {
  public:
   using TiledCopyA = decltype(make_block_2d_copy_A(TiledMMA{}, TensorA{}));
   using TiledCopyB = decltype(make_block_2d_copy_B(TiledMMA{}, TensorB{}));
-  using TiledCopyD = decltype(make_block_2d_copy_D(TiledMMA{}, TensorD{}));
+  using TiledCopyD = decltype(make_block_2d_copy_CD(cute::XE_STORE_2D<16, 8, 32>{}, TiledMMA{}, TensorD{}));
   using SGPerWG = decltype(product(take<1, 4>(shape(typename TiledMMA::ThrLayoutVMNK{}))));
 
   constexpr static int Stages = 3;

--- a/src/sycl/kernels/moe/xe20/bf16/moe_mainloop.hpp
+++ b/src/sycl/kernels/moe/xe20/bf16/moe_mainloop.hpp
@@ -179,11 +179,8 @@ struct MoEMainloop<
     SubgroupTensor tCrC = thr_mma.partition_sg_fragment_C(gD);
 
     /* Partition D */
-    using TD = typename DTensor::element_type;
-    TD tCrD_final_frag[tCrC.size()];
-    Tensor tCrD_final_tensor = make_tensor(make_rmem_ptr(tCrD_final_frag), tCrC.layout());
-    SubgroupTensor tCrD_final_sg_tensor = make_subgroup_tensor(tCrD_final_tensor, tCrC.tv_layout());
-    Tensor tCgD = thr_mma.partition_C(gD);
+    auto tCrD_out = thr_copy_d.partition_sg_fragment_S(gD);
+    Tensor tCgD = thr_copy_d.partition_D(gD);
 
     /* Create TiledCopy objects for prefetches */
     auto prefetch_a = make_block_2d_prefetch(tiled_copy_a);
@@ -244,8 +241,8 @@ struct MoEMainloop<
       }
     }
 
-    reorder(tCrC, tCrD_final_sg_tensor);
-    copy(tiled_copy_d, tCrD_final_sg_tensor, tCgD);
+    reorder(tCrC, tCrD_out);
+    copy(tiled_copy_d, tCrD_out, tCgD);
   }
 
   template <typename Coord>
@@ -316,15 +313,8 @@ struct MoEMainloop<
     SubgroupTensor tCrC1 = thr_mma.partition_sg_fragment_C(gC1);
 
     /* Partition D */
-    using TD = typename DTensor::element_type;
-    TD tCrD_final_frag0[tCrC0.size()];
-    Tensor tCrD_final_tensor0 = make_tensor(make_rmem_ptr(tCrD_final_frag0), tCrC0.layout());
-    SubgroupTensor tCrD_final_sg_tensor0 = make_subgroup_tensor(tCrD_final_tensor0, tCrC0.tv_layout());
-    TD tCrD_final_frag1[tCrC1.size()];
-    Tensor tCrD_final_tensor1 = make_tensor(make_rmem_ptr(tCrD_final_frag1), tCrC1.layout());
-    SubgroupTensor tCrD_final_sg_tensor1 = make_subgroup_tensor(tCrD_final_tensor1, tCrC1.tv_layout());
-
-    Tensor tCgD = thr_mma.partition_C(gC0);
+    auto tCrD_out = thr_copy_d.partition_sg_fragment_S(gC0);
+    Tensor tCgD = thr_copy_d.partition_D(gC0);
 
     /* Create TiledCopy objects for prefetches */
     auto prefetch_a = make_block_2d_prefetch(tiled_copy_a);
@@ -387,8 +377,8 @@ struct MoEMainloop<
           moe_xe20::apply_fused_activation<static_cast<int>(ActType)>(tCrC0(i), tCrC1(i), gemm1_alpha, gemm1_limit);
     }
 
-    reorder(tCrC0, tCrD_final_sg_tensor0);
-    copy(tiled_copy_d, tCrD_final_sg_tensor0, tCgD);
+    reorder(tCrC0, tCrD_out);
+    copy(tiled_copy_d, tCrD_out, tCgD);
   }
 
   template <


### PR DESCRIPTION
This is from https://github.com/vllm-project/vllm-xpu-kernels/pull/340 and it looks like a cutlass issue.
For now, **XE_STORE_2D<16, 8, 32>** has better performance than **make_block_2d_copy_D** when k of gemm is small.
For qwen-3-30b-a3b with tp=4 and K=192, while setting bs=12 and input length to 4096, the M,N,K would be(49152, 2048, 192). The perf improved from 9.2ms to 6.1ms, which affects TTFT.

We can remove this if sycl-tla fix the bug of make_block_2d_copy_D.