### PR TITLE
Add qk_norm_rope support for Flux

### DIFF
--- a/benchmark/bench_fused_qk_norm_rope.py
+++ b/benchmark/bench_fused_qk_norm_rope.py
@@ -2,9 +2,10 @@ import itertools
 import os
 
 import pandas as pd
+import sgl_kernel
 import torch
 import triton
-from sgl_kernel import fused_qk_norm_rope
+from bench_fused_qk_rope_with_cache import create_cos_sin_cache
 
 # Supported dtypes and their properties
 DTYPE_MAP = {
@@ -300,6 +301,216 @@ def calculate_effective_bandwidth(
     }
 
 
+def apply_rotary_emb_from_cache(
+    x: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    rope_dim: int,
+    is_neox_style: bool,
+) -> torch.Tensor:
+    half_rope_dim = rope_dim // 2
+    pos = positions.to(device=x.device, dtype=torch.long).view(-1)
+    cos = cos_sin_cache[pos, :half_rope_dim].to(dtype=x.dtype)
+    sin = cos_sin_cache[pos, half_rope_dim:].to(dtype=x.dtype)
+    cos = cos.view(-1, half_rope_dim).unsqueeze(-2)
+    sin = sin.view(-1, half_rope_dim).unsqueeze(-2)
+
+    x_rot = x[..., :rope_dim]
+    if is_neox_style:
+        x1, x2 = torch.chunk(x_rot, 2, dim=-1)
+        out_rot = torch.empty_like(x_rot)
+        out_rot[..., :half_rope_dim] = x1 * cos - x2 * sin
+        out_rot[..., half_rope_dim:] = x2 * cos + x1 * sin
+    else:
+        out_rot = torch.empty_like(x_rot)
+        x1 = x_rot[..., ::2]
+        x2 = x_rot[..., 1::2]
+        out_rot[..., ::2] = x1 * cos - x2 * sin
+        out_rot[..., 1::2] = x2 * cos + x1 * sin
+
+    if rope_dim == x.shape[-1]:
+        return out_rot
+
+    out = x.clone()
+    out[..., :rope_dim] = out_rot
+    return out
+
+
+def native_qk_norm_rope_with_cache(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    rope_dim: int,
+    is_neox_style: bool,
+    eps: float,
+) -> None:
+    q_view = q.reshape(-1, q.shape[-2], q.shape[-1])
+    k_view = k.reshape(-1, k.shape[-2], k.shape[-1])
+
+    q_view.copy_(llama_rms_norm(q_view, q_weight, eps))
+    k_view.copy_(llama_rms_norm(k_view, k_weight, eps))
+
+    q_view.copy_(
+        apply_rotary_emb_from_cache(
+            q_view, cos_sin_cache, positions, rope_dim, is_neox_style
+        )
+    )
+    k_view.copy_(
+        apply_rotary_emb_from_cache(
+            k_view, cos_sin_cache, positions, rope_dim, is_neox_style
+        )
+    )
+
+
+def logical_cache_bytes_per_call(
+    flat_tokens: int,
+    num_heads_q: int,
+    num_heads_k: int,
+    head_dim: int,
+    rope_dim: int,
+    dtype_name: str,
+    position_dtype_name: str,
+) -> int:
+    dtype_bytes = DTYPE_BYTES[dtype_name]
+    position_dtype_bytes = 4 if position_dtype_name == "int32" else 8
+
+    qk_bytes = flat_tokens * (num_heads_q + num_heads_k) * head_dim * dtype_bytes * 2
+    weight_bytes = 2 * head_dim * dtype_bytes
+    cache_bytes = flat_tokens * rope_dim * 4
+    position_bytes = flat_tokens * position_dtype_bytes
+    return qk_bytes + weight_bytes + cache_bytes + position_bytes
+
+
+CACHE_CONFIGS = [
+    (False, 3, 1, 4, 2, 64, 32, False, "bf16", "int32"),
+    (False, 5, 1, 8, 4, 128, 64, True, "fp16", "int64"),
+    (True, 2, 4, 16, 4, 128, 128, False, "bf16", "int32"),
+    (True, 1, 8, 32, 8, 256, 128, True, "fp16", "int64"),
+]
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=[
+            "use_4d",
+            "batch_size",
+            "seq_len",
+            "num_q_heads",
+            "num_k_heads",
+            "head_dim",
+            "rope_dim",
+            "is_neox",
+            "dtype_name",
+            "position_dtype_name",
+        ],
+        x_vals=[list(config) for config in CACHE_CONFIGS],
+        line_arg="provider",
+        line_vals=["native_split", "cache_fused"],
+        line_names=["Native split", "SGL Kernel cache fused"],
+        styles=[("blue", "-"), ("green", "-")],
+        ylabel="Latency (us)",
+        plot_name="fused-qk-norm-rope-with-cache-performance",
+        args={},
+    )
+)
+def benchmark_cache(
+    use_4d,
+    batch_size,
+    seq_len,
+    num_q_heads,
+    num_k_heads,
+    head_dim,
+    rope_dim,
+    is_neox,
+    dtype_name,
+    position_dtype_name,
+    provider,
+):
+    q, k, q_weight, k_weight, cos_sin_cache, positions = make_cache_inputs(
+        use_4d,
+        batch_size,
+        seq_len,
+        num_q_heads,
+        num_k_heads,
+        head_dim,
+        rope_dim,
+        dtype_name,
+        position_dtype_name,
+    )
+
+    if provider == "native_split":
+
+        def fn() -> None:
+            native_qk_norm_rope_with_cache(
+                q,
+                k,
+                q_weight,
+                k_weight,
+                cos_sin_cache,
+                positions,
+                rope_dim,
+                is_neox,
+                1e-6,
+            )
+
+    elif provider == "cache_fused":
+
+        def fn() -> None:
+            sgl_kernel.fused_qk_norm_rope_with_cos_sin_cache_inplace(
+                q,
+                k,
+                q_weight,
+                k_weight,
+                cos_sin_cache,
+                positions,
+                is_neox,
+                1e-6,
+            )
+
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    quantiles = [0.5, 0.2, 0.8]
+    ms, min_ms, max_ms = triton.testing.do_bench(fn, quantiles=quantiles)
+
+    flat_tokens = batch_size * seq_len if use_4d else batch_size
+    logical_bytes = logical_cache_bytes_per_call(
+        flat_tokens,
+        num_q_heads,
+        num_k_heads,
+        head_dim,
+        rope_dim,
+        dtype_name,
+        position_dtype_name,
+    )
+    bandwidth_gbs = (logical_bytes / 1e9) / (ms / 1000.0)
+
+    cache_results.append(
+        {
+            "layout": "4d" if use_4d else "3d",
+            "batch_size": batch_size,
+            "seq_len": seq_len,
+            "num_tokens": flat_tokens,
+            "num_q_heads": num_q_heads,
+            "num_k_heads": num_k_heads,
+            "head_dim": head_dim,
+            "rope_dim": rope_dim,
+            "is_neox": is_neox,
+            "dtype": dtype_name,
+            "position_dtype": position_dtype_name,
+            "provider": provider,
+            "time_us": 1000 * ms,
+            "bandwidth_gbs": bandwidth_gbs,
+            "logical_bytes_mb": logical_bytes / 1e6,
+        }
+    )
+
+    return 1000 * ms, 1000 * max_ms, 1000 * min_ms
+
+
 @triton.testing.perf_report(
     triton.testing.Benchmark(
         x_names=[
@@ -417,7 +628,7 @@ def benchmark(
                 rotary_dim=rotary_dim,
             )
     elif provider == "sglang":
-        fn = lambda: fused_qk_norm_rope(
+        fn = lambda: sgl_kernel.fused_qk_norm_rope(
             qkv.clone(),
             num_heads_q,
             num_heads_k,
@@ -474,9 +685,67 @@ def benchmark(
     return 1000 * ms, 1000 * max_ms, 1000 * min_ms
 
 
+CACHE_DTYPE_MAP = {
+    "bf16": torch.bfloat16,
+    "fp16": torch.float16,
+}
+
+
+def build_cache_configs() -> (
+    list[tuple[bool, int, int, int, int, int, int, bool, str, str]]
+):
+    return list(CACHE_CONFIGS)
+
+
+cache_configs = CACHE_CONFIGS
+cache_results = []
+
+
+def make_cache_inputs(
+    use_4d: bool,
+    batch_size: int,
+    seq_len: int,
+    num_q_heads: int,
+    num_k_heads: int,
+    head_dim: int,
+    rope_dim: int,
+    dtype_name: str,
+    position_dtype_name: str,
+) -> tuple[
+    torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
+]:
+    dtype = CACHE_DTYPE_MAP[dtype_name]
+    position_dtype = torch.int32 if position_dtype_name == "int32" else torch.int64
+    device = torch.device("xpu")
+
+    if use_4d:
+        q = torch.randn(
+            batch_size, seq_len, num_q_heads, head_dim, device=device, dtype=dtype
+        ).contiguous()
+        k = torch.randn(
+            batch_size, seq_len, num_k_heads, head_dim, device=device, dtype=dtype
+        ).contiguous()
+        flat_tokens = batch_size * seq_len
+    else:
+        q = torch.randn(
+            batch_size, num_q_heads, head_dim, device=device, dtype=dtype
+        ).contiguous()
+        k = torch.randn(
+            batch_size, num_k_heads, head_dim, device=device, dtype=dtype
+        ).contiguous()
+        flat_tokens = batch_size
+
+    q_weight = torch.randn(head_dim, device=device, dtype=dtype).contiguous()
+    k_weight = torch.randn(head_dim, device=device, dtype=dtype).contiguous()
+    cos_sin_cache = create_cos_sin_cache(rope_dim, flat_tokens + 1, 10000.0)
+    positions = torch.arange(flat_tokens, device=device, dtype=position_dtype)
+    return q, k, q_weight, k_weight, cos_sin_cache, positions
+
+
 if __name__ == "__main__":
     print("Running benchmarks...")
     benchmark.run(print_data=True)
+    benchmark_cache.run(print_data=True)
 
     # Ensure results dir exists and write per-chunk CSV
     os.makedirs("benchmark/results", exist_ok=True)
@@ -487,6 +756,11 @@ if __name__ == "__main__":
     out_csv = os.path.join("benchmark/results", f"results_{chunk_label}.csv")
     df.to_csv(out_csv, index=False)
     print(f"Wrote results CSV: {out_csv}")
+
+    cache_df = pd.DataFrame(cache_results)
+    cache_out_csv = os.path.join("benchmark/results", f"cache_{chunk_label}.csv")
+    cache_df.to_csv(cache_out_csv, index=False)
+    print(f"Wrote cache results CSV: {cache_out_csv}")
 
     # Print bandwidth results
     print("\n" + "=" * 80)
@@ -512,6 +786,15 @@ if __name__ == "__main__":
         }
     )
     print(summary.to_markdown())
+
+    print("\n" + "=" * 80)
+    print("Cache Benchmark Results")
+    print("=" * 80)
+    if not cache_df.empty:
+        cache_df["bandwidth_gbs"] = cache_df["bandwidth_gbs"].round(2)
+        cache_df["logical_bytes_mb"] = cache_df["logical_bytes_mb"].round(2)
+        cache_df["time_us"] = cache_df["time_us"].round(2)
+        print(cache_df.to_markdown(index=False))
 
     # Print best speedup
     print("\n" + "=" * 80)

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -115,6 +115,15 @@ void rmsnorm(torch::Tensor& output, torch::Tensor& input, torch::Tensor& weight,
 void fused_add_rmsnorm(torch::Tensor input, torch::Tensor residual, torch::Tensor weight, double eps);
 void gemma_rmsnorm(torch::Tensor& output, torch::Tensor& input, torch::Tensor& weight, double eps);
 void gemma_fused_add_rmsnorm(torch::Tensor& input, torch::Tensor& residual, torch::Tensor& weight, double eps);
+void fused_qk_norm_rope_with_cos_sin_cache_inplace(
+    torch::Tensor& q,
+    torch::Tensor& k,
+    torch::Tensor& q_weight,
+    torch::Tensor& k_weight,
+    torch::Tensor& cos_sin_cache,
+    torch::Tensor& positions,
+    bool is_neox,
+    double eps);
 void topk_softmax(at::Tensor& topk_weights, at::Tensor& topk_indices, at::Tensor& gating_output, bool renormalize);
 void topk_sigmoid(
     at::Tensor& topk_weights,

--- a/python/sgl_kernel/__init__.py
+++ b/python/sgl_kernel/__init__.py
@@ -37,6 +37,7 @@ from sgl_kernel.elementwise import (
     apply_rope_with_cos_sin_cache_inplace,
     fused_add_rmsnorm,
     fused_qk_norm_rope,
+    fused_qk_norm_rope_with_cos_sin_cache_inplace,
     fused_qk_rope,
     fused_qk_rope_with_cos_sin_cache_inplace,
     gelu_and_mul,

--- a/python/sgl_kernel/elementwise.py
+++ b/python/sgl_kernel/elementwise.py
@@ -140,6 +140,53 @@ def gemma_fused_add_rmsnorm(
     torch.ops.sgl_kernel.gemma_fused_add_rmsnorm(input, residual, weight, eps)
 
 
+def fused_qk_norm_rope_with_cos_sin_cache_inplace(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    is_neox: bool,
+    eps: float = 1e-6,
+) -> None:
+    r"""Apply fused RMSNorm + RoPE to Q/K using a precomputed cos/sin cache.
+
+    Step 1:
+    ``q = RMSNorm(q, q_weight)`` and ``k = RMSNorm(k, k_weight)``
+
+    Step 2:
+    ``q`` and ``k`` are rotated in-place using the cached cosine/sine values
+    indexed by ``positions``.
+
+    Parameters
+    ----------
+    q: torch.Tensor
+        Query tensor updated in-place.
+    k: torch.Tensor
+        Key tensor updated in-place.
+    q_weight: torch.Tensor
+        RMSNorm weights for query, shape ``(head_dim,)``.
+    k_weight: torch.Tensor
+        RMSNorm weights for key, shape ``(head_dim,)``.
+    cos_sin_cache: torch.Tensor
+        Precomputed RoPE cosine/sine cache, shape ``(max_pos, rope_dim)``.
+    positions: torch.Tensor
+        Position indices used to select rows from ``cos_sin_cache``.
+    is_neox: bool
+        Whether to apply NeoX-style rotary layout.
+    eps: float
+        Epsilon for RMS normalization.
+
+    Note
+    ----
+    This is an in-place operation that modifies ``q`` and ``k`` directly.
+    """
+    torch.ops.sgl_kernel.fused_qk_norm_rope_with_cos_sin_cache_inplace(
+        q, k, q_weight, k_weight, cos_sin_cache, positions, is_neox, eps
+    )
+
+
 def _check_shape(input: torch.Tensor, output: torch.Tensor) -> None:
     assert input.ndim == output.ndim, f"{input.ndim} != {output.ndim}"
     assert (

--- a/src/sycl/FusedQKNormRope.cpp
+++ b/src/sycl/FusedQKNormRope.cpp
@@ -863,6 +863,8 @@ void fused_qk_norm_rope_with_cos_sin_cache_inplace(
   const int64_t num_kv_heads = k_view.size(1);
   const int64_t head_dim = q_view.size(2);
 
+  TORCH_CHECK(q_weight.dim() == 1, "q_weight must be 1D [head_dim]");
+  TORCH_CHECK(k_weight.dim() == 1, "k_weight must be 1D [head_dim]");
   TORCH_CHECK(q_weight.size(0) == head_dim, "q_weight size must match head_dim");
   TORCH_CHECK(k_weight.size(0) == head_dim, "k_weight size must match head_dim");
   TORCH_CHECK(cos_sin_cache.dim() == 2, "cos_sin_cache must be 2D [max_position, rope_dim]");

--- a/src/sycl/FusedQKNormRope.cpp
+++ b/src/sycl/FusedQKNormRope.cpp
@@ -126,8 +126,7 @@ inline void dispatchFusedQKNormRopeHeadDim(int64_t head_dim, const char* kernel_
 // only widths that both fit within the per-lane element count and divide it
 // evenly, then unconditionally falling back to scalar (VecSize=1) -- always
 // valid regardless of alignment -- if none matched, guaranteeing the kernel
-// is always launched. Shared by both the packed-QKV and cos/sin-cache launch
-// paths.
+// is always launched.
 template <int64_t kElemsPerThread, typename Fn>
 inline void dispatchFusedQKNormRopeVecSize(int64_t vec_size, Fn&& fn) {
   bool dispatched = false;

--- a/src/sycl/FusedQKNormRope.cpp
+++ b/src/sycl/FusedQKNormRope.cpp
@@ -174,10 +174,17 @@ inline void dispatchFusedQKNormRopeVecSize(int64_t vec_size, Fn&& fn) {
 }
 
 // Picks the largest power-of-two width (<= max_vec_size) for which every
-// pointer in `ptrs` is aligned to `elem_size * vec_size` bytes, shrinking to
-// 1 (always safe) if needed. Only the physical load/store chunk width
-// shrinks; the per-lane algorithmic element count is unaffected.
-inline int64_t pick_aligned_vec_size(int64_t max_vec_size, int64_t elem_size, std::initializer_list<const void*> ptrs) {
+// pointer in `ptrs` is aligned to `elem_size * vec_size` bytes and every
+// stride in `elem_strides` (elements; row strides for non-contiguous q/k)
+// is a multiple of vec_size, shrinking to 1 (always safe) if needed.
+// `elem_strides` defaults to empty for fully contiguous callers. Only the
+// physical load/store chunk width shrinks; the per-lane algorithmic
+// element count is unaffected.
+inline int64_t pick_aligned_vec_size(
+    int64_t max_vec_size,
+    int64_t elem_size,
+    std::initializer_list<const void*> ptrs,
+    std::initializer_list<int64_t> elem_strides = {}) {
   int64_t vec_size = max_vec_size;
   while (vec_size > 1) {
     const int64_t align_bytes = elem_size * vec_size;
@@ -186,6 +193,14 @@ inline int64_t pick_aligned_vec_size(int64_t max_vec_size, int64_t elem_size, st
       if (reinterpret_cast<uintptr_t>(p) % align_bytes != 0) {
         all_aligned = false;
         break;
+      }
+    }
+    if (all_aligned) {
+      for (int64_t stride : elem_strides) {
+        if (stride % vec_size != 0) {
+          all_aligned = false;
+          break;
+        }
       }
     }
     if (all_aligned) break;
@@ -585,8 +600,12 @@ void fused_qk_norm_rope(
 }
 
 // SYCL Kernel for Fused QK Norm + RoPE using a precomputed cos/sin cache
-// (mirrors CUDA's qknorm_rope.cuh). q/k must be 3D contiguous tensors:
-// [num_tokens, num_heads, head_dim].
+// (mirrors CUDA's qknorm_rope.cuh). q/k must be 3D tensors (after flattening
+// any leading batch/seq dims): [num_tokens, num_heads, head_dim]. Only the
+// last dimension (head_dim) is required to be contiguous; the token and head
+// strides may be arbitrary (e.g. q/k sliced out of a larger packed buffer),
+// so they are passed in explicitly rather than assumed to equal
+// num_heads * head_dim / head_dim.
 template <int64_t kHeadDim, bool kIsNeox, typename scalar_t, typename IdType, int64_t kVecSize>
 struct FusedQKNormRopeCacheKernel {
   static_assert(kHeadDim <= 256, "Only head_dim <= 256 is supported");
@@ -606,8 +625,10 @@ struct FusedQKNormRopeCacheKernel {
   int64_t rope_dim;
   int64_t rotary_lanes;
   int64_t half_rotary_lanes;
-  int64_t q_token_stride;  // elements between consecutive tokens in q (== num_qo_heads * kHeadDim)
-  int64_t k_token_stride;  // elements between consecutive tokens in k (== num_kv_heads * kHeadDim)
+  int64_t q_token_stride;  // elements between consecutive tokens in q
+  int64_t k_token_stride;  // elements between consecutive tokens in k
+  int64_t q_head_stride;   // elements between consecutive heads in q (may differ from kHeadDim)
+  int64_t k_head_stride;   // elements between consecutive heads in k (may differ from kHeadDim)
   uint32_t num_qo_heads;
   uint32_t num_kv_heads;
   uint32_t num_tokens;
@@ -632,11 +653,13 @@ struct FusedQKNormRopeCacheKernel {
       scalar_t* row_ptr;
       const scalar_t* weight_ptr;
       if (load_q) {
-        row_ptr = q_ptr + static_cast<int64_t>(token_id) * q_token_stride + static_cast<int64_t>(head_id) * kHeadDim;
+        row_ptr =
+            q_ptr + static_cast<int64_t>(token_id) * q_token_stride + static_cast<int64_t>(head_id) * q_head_stride;
         weight_ptr = q_weight_ptr;
       } else {
         const uint32_t k_head_id = head_id - num_qo_heads;
-        row_ptr = k_ptr + static_cast<int64_t>(token_id) * k_token_stride + static_cast<int64_t>(k_head_id) * kHeadDim;
+        row_ptr =
+            k_ptr + static_cast<int64_t>(token_id) * k_token_stride + static_cast<int64_t>(k_head_id) * k_head_stride;
         weight_ptr = k_weight_ptr;
       }
 
@@ -734,6 +757,8 @@ void launchFusedQKNormRopeCacheVecImpl(
     const IdType* positions_ptr,
     int64_t q_token_stride,
     int64_t k_token_stride,
+    int64_t q_head_stride,
+    int64_t k_head_stride,
     int64_t num_tokens,
     int64_t num_qo_heads,
     int64_t num_kv_heads,
@@ -757,6 +782,8 @@ void launchFusedQKNormRopeCacheVecImpl(
       half_rotary_lanes,
       q_token_stride,
       k_token_stride,
+      q_head_stride,
+      k_head_stride,
       static_cast<uint32_t>(num_qo_heads),
       static_cast<uint32_t>(num_kv_heads),
       static_cast<uint32_t>(num_tokens),
@@ -775,6 +802,8 @@ void launchFusedQKNormRopeCacheImpl(
     const IdType* positions_ptr,
     int64_t q_token_stride,
     int64_t k_token_stride,
+    int64_t q_head_stride,
+    int64_t k_head_stride,
     int64_t num_tokens,
     int64_t num_qo_heads,
     int64_t num_kv_heads,
@@ -796,8 +825,14 @@ void launchFusedQKNormRopeCacheImpl(
         rotary_lanes);
   }
   const int64_t maxVecSize = std::min<int64_t>(kElemsPerThread, maxHwVecSize(sizeof(scalar_t)));
-  const int64_t vec_size =
-      pick_aligned_vec_size(maxVecSize, sizeof(scalar_t), {q_ptr, k_ptr, q_weight_ptr, k_weight_ptr});
+  // q/k rows may be non-contiguous beyond the last dimension (e.g. sliced
+  // out of a larger packed buffer), so the chosen vector width must also
+  // divide the token/head strides, not just satisfy base-pointer alignment.
+  const int64_t vec_size = pick_aligned_vec_size(
+      maxVecSize,
+      sizeof(scalar_t),
+      {q_ptr, k_ptr, q_weight_ptr, k_weight_ptr},
+      {q_token_stride, k_token_stride, q_head_stride, k_head_stride});
 
   dispatchFusedQKNormRopeVecSize<kElemsPerThread>(vec_size, [&](auto vec_size_tag) {
     constexpr int64_t kVecSize = decltype(vec_size_tag)::value;
@@ -810,6 +845,8 @@ void launchFusedQKNormRopeCacheImpl(
         positions_ptr,
         q_token_stride,
         k_token_stride,
+        q_head_stride,
+        k_head_stride,
         num_tokens,
         num_qo_heads,
         num_kv_heads,
@@ -840,9 +877,13 @@ void fused_qk_norm_rope_with_cos_sin_cache_inplace(
   TORCH_CHECK(cos_sin_cache.scalar_type() == at::ScalarType::Float, "cos_sin_cache must be float32");
 
   CHECK_DEVICE(q);
-  CHECK_CONTIGUOUS(q);
+  // Only the last dimension (head_dim) needs to be contiguous; q/k may be
+  // views sliced out of a larger packed buffer (e.g. per-head strides that
+  // don't equal head_dim), so full tensor contiguity is not required. Token
+  // and head strides are read directly below instead of being assumed.
+  TORCH_CHECK(q.stride(-1) == 1, "q must be contiguous in its last dimension (head_dim)");
   CHECK_DEVICE(k);
-  CHECK_CONTIGUOUS(k);
+  TORCH_CHECK(k.stride(-1) == 1, "k must be contiguous in its last dimension (head_dim)");
   CHECK_DEVICE(q_weight);
   CHECK_CONTIGUOUS(q_weight);
   CHECK_DEVICE(k_weight);
@@ -851,6 +892,17 @@ void fused_qk_norm_rope_with_cos_sin_cache_inplace(
   CHECK_CONTIGUOUS(cos_sin_cache);
   CHECK_DEVICE(positions);
   CHECK_CONTIGUOUS(positions);
+
+  if (q.dim() == 4) {
+    TORCH_CHECK(
+        q.stride(0) == q.size(1) * q.stride(1),
+        "q batch and sequence dimensions must be mergeable (i.e. contiguous with each other) for 4D input");
+  }
+  if (k.dim() == 4) {
+    TORCH_CHECK(
+        k.stride(0) == k.size(1) * k.stride(1),
+        "k batch and sequence dimensions must be mergeable (i.e. contiguous with each other) for 4D input");
+  }
 
   auto q_view = q.dim() == 4 ? q.view({-1, q.size(2), q.size(3)}) : q;
   auto k_view = k.dim() == 4 ? k.view({-1, k.size(2), k.size(3)}) : k;
@@ -862,6 +914,8 @@ void fused_qk_norm_rope_with_cos_sin_cache_inplace(
   const int64_t num_qo_heads = q_view.size(1);
   const int64_t num_kv_heads = k_view.size(1);
   const int64_t head_dim = q_view.size(2);
+  const int64_t q_head_stride = q_view.stride(1);
+  const int64_t k_head_stride = k_view.stride(1);
 
   TORCH_CHECK(q_weight.dim() == 1, "q_weight must be 1D [head_dim]");
   TORCH_CHECK(k_weight.dim() == 1, "k_weight must be 1D [head_dim]");
@@ -897,6 +951,8 @@ void fused_qk_norm_rope_with_cos_sin_cache_inplace(
                           static_cast<const IdType*>(positions.data_ptr()),
                           q_view.stride(0),
                           k_view.stride(0),
+                          q_head_stride,
+                          k_head_stride,
                           num_tokens,
                           num_qo_heads,
                           num_kv_heads,
@@ -913,6 +969,8 @@ void fused_qk_norm_rope_with_cos_sin_cache_inplace(
                           static_cast<const IdType*>(positions.data_ptr()),
                           q_view.stride(0),
                           k_view.stride(0),
+                          q_head_stride,
+                          k_head_stride,
                           num_tokens,
                           num_qo_heads,
                           num_kv_heads,

--- a/src/sycl/FusedQKNormRope.cpp
+++ b/src/sycl/FusedQKNormRope.cpp
@@ -30,7 +30,7 @@ inline T divUp(T m, T n) {
   return (m + n - 1) / n;
 }
 
-// Sub-group reduction for sum; result is broadcast to every lane.
+// Sub-group reduction for sum
 template <typename T>
 inline T subGroupReduceSum(T val, const sycl::sub_group& sg) {
   return sycl::reduce_over_group(sg, val, sycl::plus<T>());

--- a/src/sycl/FusedQKNormRope.cpp
+++ b/src/sycl/FusedQKNormRope.cpp
@@ -5,10 +5,13 @@
 #include <c10/xpu/XPUStream.h>
 #include <torch/all.h>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <initializer_list>
 #include <iostream>
 #include <sycl/sycl.hpp>
+#include <type_traits>
 #include <vector>
 
 #include "MemoryAccess.h"
@@ -27,13 +30,10 @@ inline T divUp(T m, T n) {
   return (m + n - 1) / n;
 }
 
-// Sub-group reduction for sum
+// Sub-group reduction for sum; result is broadcast to every lane.
 template <typename T>
 inline T subGroupReduceSum(T val, const sycl::sub_group& sg) {
-  for (int offset = sg.get_max_local_range()[0] / 2; offset > 0; offset /= 2) {
-    val += sycl::shift_group_left(sg, val, offset);
-  }
-  return val;
+  return sycl::reduce_over_group(sg, val, sycl::plus<T>());
 }
 
 inline float compute_freq_yarn(float base, int rotary_dim, int half_dim, float factor, float low, float high) {
@@ -61,8 +61,189 @@ inline float compute_freq_yarn(float base, int rotary_dim, int half_dim, float f
   return freq;
 }
 
-// SYCL Kernel for Fused QK Norm and RoPE
-template <int head_dim, bool interleave, typename scalar_t>
+// ---------------------------------------------------------------------------
+// Sub-group width portability and occupancy-aware (persistent) launch sizing.
+//
+// Unlike CUDA's fixed 32-wide warp, Intel GPUs support a device-dependent set
+// of sub-group widths (commonly a subset of {8, 16, 32}). The kernels below
+// pin the width to NUM_REDUCE_STAGES via [[sycl::reqd_sub_group_size(...)]]
+// so compile-time lane arithmetic matches the runtime sub-group size, and
+// validate at launch time that the device actually supports that width.
+inline void check_subgroup_size_supported(int64_t required_size) {
+  auto* dev_prop = at::xpu::getDeviceProperties(dpcppGetDeviceIdOfCurrentQueue());
+  bool supported = false;
+  for (auto sz : dev_prop->sub_group_sizes) {
+    if (static_cast<int64_t>(sz) == required_size) {
+      supported = true;
+      break;
+    }
+  }
+  TORCH_CHECK(
+      supported,
+      "fused_qk_norm_rope kernels require sub-group size ",
+      required_size,
+      ", which is not supported by this device");
+}
+
+struct PersistentLaunchConfig {
+  int64_t blockSize;
+  int64_t gridSize;
+};
+
+template <typename T>
+struct TypeTag {
+  using type = T;
+};
+
+template <bool kAllowFloat8, typename Fn>
+inline void dispatchFusedQKNormRopeScalarType(at::ScalarType scalar_type, const char* kernel_name, Fn&& fn) {
+  switch (scalar_type) {
+    case at::ScalarType::Half:
+      fn(TypeTag<sycl::half>{});
+      break;
+    case at::ScalarType::BFloat16:
+      fn(TypeTag<sycl::ext::oneapi::bfloat16>{});
+      break;
+    case at::ScalarType::Float8_e4m3fn:
+      if constexpr (kAllowFloat8) {
+        fn(TypeTag<float_e4m3_t>{});
+        break;
+      }
+      [[fallthrough]];
+    default:
+      TORCH_CHECK(false, "Unsupported dtype for ", kernel_name, ": ", scalar_type);
+  }
+}
+
+template <typename Fn>
+inline void dispatchFusedQKNormRopePositionsType(at::ScalarType scalar_type, const char* kernel_name, Fn&& fn) {
+  switch (scalar_type) {
+    case at::ScalarType::Int:
+      fn(TypeTag<int32_t>{});
+      break;
+    case at::ScalarType::Long:
+      fn(TypeTag<int64_t>{});
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported dtype for ", kernel_name, " positions: ", scalar_type);
+  }
+}
+
+template <typename Fn>
+inline void dispatchFusedQKNormRopeHeadDim(int64_t head_dim, const char* kernel_name, Fn&& fn) {
+  switch (head_dim) {
+    case 64:
+      fn(std::integral_constant<int64_t, 64>{});
+      break;
+    case 128:
+      fn(std::integral_constant<int64_t, 128>{});
+      break;
+    case 256:
+      fn(std::integral_constant<int64_t, 256>{});
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported head dimension for ", kernel_name, ": ", head_dim);
+  }
+}
+
+// Dispatches over vectorized VecSize instantiations (16/8/4/2), gated by
+// `kCandidate <= kElemsPerThread` so only widths that evenly divide the
+// per-lane element count are tried, then unconditionally falls back to
+// scalar (VecSize=1) -- always valid regardless of alignment -- if none
+// matched, guaranteeing the kernel is always launched. Shared by both the
+// packed-QKV and cos/sin-cache launch paths.
+template <int64_t kElemsPerThread, typename Fn>
+inline void dispatchFusedQKNormRopeVecSize(int64_t vec_size, Fn&& fn) {
+  bool dispatched = false;
+  auto try_vec_size = [&](auto vec_size_tag) {
+    constexpr int64_t kCandidate = decltype(vec_size_tag)::value;
+    if constexpr (kCandidate <= kElemsPerThread) {
+      if (!dispatched && vec_size == kCandidate) {
+        fn(vec_size_tag);
+        dispatched = true;
+      }
+    }
+  };
+  try_vec_size(std::integral_constant<int64_t, 16>{});
+  try_vec_size(std::integral_constant<int64_t, 8>{});
+  try_vec_size(std::integral_constant<int64_t, 4>{});
+  try_vec_size(std::integral_constant<int64_t, 2>{});
+  if (!dispatched) {
+    fn(std::integral_constant<int64_t, 1>{});
+  }
+}
+
+// Picks the largest power-of-two width (<= max_vec_size) for which every
+// pointer in `ptrs` is aligned to `elem_size * vec_size` bytes, shrinking to
+// 1 (always safe) if needed. Only the physical load/store chunk width
+// shrinks; the per-lane algorithmic element count is unaffected.
+inline int64_t pick_aligned_vec_size(int64_t max_vec_size, int64_t elem_size, std::initializer_list<const void*> ptrs) {
+  int64_t vec_size = max_vec_size;
+  while (vec_size > 1) {
+    const int64_t align_bytes = elem_size * vec_size;
+    bool all_aligned = true;
+    for (const void* p : ptrs) {
+      if (reinterpret_cast<uintptr_t>(p) % align_bytes != 0) {
+        all_aligned = false;
+        break;
+      }
+    }
+    if (all_aligned) break;
+    vec_size >>= 1;
+  }
+  return vec_size;
+}
+
+// Caps the vector load/store chunk at 16 bytes (128-bit), matching
+// RMSNorm.cpp's convention, to avoid oversized vector instructions and
+// register pressure/spills for wide per-lane element counts.
+inline int64_t maxHwVecSize(int64_t elem_size) {
+  constexpr int64_t kMaxVecBytes = sizeof(float) * 4;
+  return std::max<int64_t>(1, kMaxVecBytes / elem_size);
+}
+
+// Caps work-group size for warp-per-(token,head) kernels: work-groups wider
+// than 512 sub-groups-of-16 add barrier/sync overhead without improving
+// occupancy, so the cap only applies at that width.
+inline int64_t capWorkgroupSize(int64_t maxWgSize, int64_t subgroupSize) {
+  if (subgroupSize == 16) {
+    maxWgSize = std::min<int64_t>(maxWgSize, 512);
+  }
+  return std::max(maxWgSize, subgroupSize);
+}
+
+// Computes an occupancy-aware, persistent-kernel launch config for kernels
+// where each sub-group handles one unit of work, with a grid-stride loop
+// consuming any remainder.
+//  - blockSize: sub-groups per work-group, capped by the max work-group size.
+//  - gridSize: capped by the device's resident work-item capacity (rescaled
+//    to this kernel's sub-group width) -- the SYCL analog of CUDA's "max
+//    active blocks per SM * SM count" -- so oversubscribed work is consumed
+//    by the in-kernel grid-stride loop instead of launching extra work-groups.
+inline PersistentLaunchConfig computePersistentLaunchConfig(int64_t totalWork, int64_t subgroupSize) {
+  auto dev_id = dpcppGetDeviceIdOfCurrentQueue();
+  const int64_t maxWgSize = capWorkgroupSize(dpcppMaxWorkGroupSize(dev_id), subgroupSize);
+
+  const int64_t maxSubgroupsPerWg = std::max<int64_t>(1, maxWgSize / subgroupSize);
+  const int64_t subgroupsPerWg = std::max<int64_t>(1, std::min<int64_t>(totalWork, maxSubgroupsPerWg));
+  const int64_t blockSize = subgroupsPerWg * subgroupSize;
+
+  const int64_t totalResource =
+      std::max<int64_t>(subgroupSize, dpcppMaxWorkItemsPerTile(dev_id) / dpcppMaxSubGroupSize(dev_id) * subgroupSize);
+  const int64_t maxResidentBlocks = std::max<int64_t>(1, totalResource / blockSize);
+  const int64_t neededBlocks = divUp(totalWork, subgroupsPerWg);
+  const int64_t gridSize = std::max<int64_t>(1, std::min(neededBlocks, maxResidentBlocks));
+
+  return {blockSize, gridSize};
+}
+
+// SYCL Kernel for Fused QK Norm and RoPE (packed QKV layout, legacy path):
+// analytic (YaRN-aware) RoPE frequencies computed on the fly, rather than
+// read from a cache. Not used by production sglang model code today (which
+// uses the cos_sin_cache op below); kept for existing test/benchmark
+// coverage. Each sub-group processes one (token, head) pair from Q or K
+// (V heads untouched).
+template <int head_dim, bool interleave, typename scalar_t, int VecSize>
 struct FusedQKNormRopeKernel {
   scalar_t* qkv;
   int num_heads_q;
@@ -80,116 +261,175 @@ struct FusedQKNormRopeKernel {
   float attention_factor;
   int rotary_dim;
 
-  void operator()(sycl::nd_item<1> item) const {
-    // Always use float for accumulation, regardless of scalar_t
+  [[sycl::reqd_sub_group_size(NUM_REDUCE_STAGES)]] void operator()(sycl::nd_item<1> item) const {
     using accscalar_t = float;
+    constexpr int numElemsPerThread = head_dim / NUM_REDUCE_STAGES;
+    static_assert(numElemsPerThread % VecSize == 0, "VecSize must evenly divide numElemsPerThread");
+    constexpr int numChunks = numElemsPerThread / VecSize;
+    using VecT = aligned_vector_loop<scalar_t, VecSize>;
 
-    const int sg_size = item.get_sub_group().get_max_local_range()[0];
-    const int warpsPerBlock = item.get_local_range(0) / sg_size;
-    const int warpId = item.get_local_id(0) / sg_size;
-    const int laneId = item.get_local_id(0) % sg_size;
-
-    const int globalWarpIdx = item.get_group(0) * warpsPerBlock + warpId;
-    const int total_qk_heads = num_heads_q + num_heads_k;
-
-    const int tokenIdx = globalWarpIdx / total_qk_heads;
-    const int localHeadIdx = globalWarpIdx % total_qk_heads;
-
-    if (tokenIdx >= num_tokens) return;
-
-    const bool isQ = localHeadIdx < num_heads_q;
-    const int headIdx = isQ ? localHeadIdx : localHeadIdx - num_heads_q;
-    const int num_heads = num_heads_q + num_heads_k + num_heads_v;
-
-    constexpr int numElemsPerThread = head_dim / 32;
-    accscalar_t elements[numElemsPerThread];
-
-    int offsetWarp;
-    if (isQ) {
-      offsetWarp = tokenIdx * num_heads * head_dim + headIdx * head_dim;
-    } else {
-      offsetWarp = tokenIdx * num_heads * head_dim + num_heads_q * head_dim + headIdx * head_dim;
-    }
-    int offsetThread = offsetWarp + laneId * numElemsPerThread;
-
-    // Load data and compute sum of squares for RMSNorm
-    accscalar_t sumOfSquares = 0.0f;
-    for (int i = 0; i < numElemsPerThread; i++) {
-      elements[i] = static_cast<accscalar_t>(qkv[offsetThread + i]);
-      sumOfSquares += elements[i] * elements[i];
-    }
-
-    // Reduce sum across sub-group (warp)
     auto sg = item.get_sub_group();
-    sumOfSquares = sycl::reduce_over_group(sg, sumOfSquares, sycl::plus<accscalar_t>{});
+    const int laneId = static_cast<int>(item.get_local_id(0) % NUM_REDUCE_STAGES);
+    const int warpId = static_cast<int>(item.get_local_id(0) / NUM_REDUCE_STAGES);
+    const int warpsPerBlock = static_cast<int>(item.get_local_range(0) / NUM_REDUCE_STAGES);
+    const int startWorkerId = static_cast<int>(item.get_group(0)) * warpsPerBlock + warpId;
+    const int numWorkers = static_cast<int>(item.get_group_range(0)) * warpsPerBlock;
 
-    // Compute RMS normalization factor
-    float rms_rcp = sycl::rsqrt(sumOfSquares / static_cast<float>(head_dim) + eps);
+    const int totalQKHeads = num_heads_q + num_heads_k;
+    const int totalWarps = num_tokens * totalQKHeads;
 
-    // Normalize elements
-    const scalar_t* weight_ptr = isQ ? q_weight : k_weight;
-    for (int i = 0; i < numElemsPerThread; i++) {
-      int dim = laneId * numElemsPerThread + i;
-      accscalar_t weight = static_cast<accscalar_t>(weight_ptr[dim]);
-      elements[i] *= rms_rcp * weight;
-    }
+    // Grid-stride loop: when the launch is persistent (fewer work-groups than
+    // totalWarps would need for a 1:1 mapping), each sub-group processes
+    // multiple (token, head) pairs in sequence instead of exactly one.
+    for (int globalWarpId = startWorkerId; globalWarpId < totalWarps; globalWarpId += numWorkers) {
+      const int tokenIdx = globalWarpId / totalQKHeads;
+      const int headIdx = globalWarpId % totalQKHeads;
+      const bool isQ = headIdx < num_heads_q;
+      const int localHeadIdx = isQ ? headIdx : (headIdx - num_heads_q);
 
-    // Apply RoPE to normalized elements
-    accscalar_t elements2[numElemsPerThread];
-    accscalar_t cos_vals[numElemsPerThread];
-    accscalar_t sin_vals[numElemsPerThread];
-    float pos_id = static_cast<float>(position_ids[tokenIdx]);
-    const int rotary_lanes = rotary_dim / numElemsPerThread;
-    const bool applyRotary = (laneId < rotary_lanes);
+      const int64_t totalHeads = static_cast<int64_t>(num_heads_q) + num_heads_k + num_heads_v;
+      const int64_t rowStride = totalHeads * head_dim;
+      const int64_t kColOffset = static_cast<int64_t>(num_heads_q) * head_dim;
+      const int64_t headColOffset = isQ ? static_cast<int64_t>(localHeadIdx) * head_dim
+                                        : kColOffset + static_cast<int64_t>(localHeadIdx) * head_dim;
+      const int64_t rowBase = static_cast<int64_t>(tokenIdx) * rowStride + headColOffset;
+      const int64_t offsetThread = rowBase + static_cast<int64_t>(laneId) * numElemsPerThread;
 
-    if (applyRotary) {
-      if constexpr (interleave) {
-        // Interleave mode
-        for (int i = 0; i < numElemsPerThread; i++) {
-          elements2[i] = (i % 2 == 0) ? -elements[i + 1] : elements[i - 1];
-
-          int dim_idx = laneId * numElemsPerThread + i;
-          int half_dim = dim_idx / 2;
-          float freq = compute_freq_yarn(base, rotary_dim, half_dim, factor, low, high);
-          float theta = pos_id * freq;
-          sin_vals[i] = sycl::sin(theta);
-          cos_vals[i] = sycl::cos(theta);
+      accscalar_t elements[numElemsPerThread];
+      accscalar_t sumOfSquares = 0;
+#pragma unroll
+      for (int c = 0; c < numChunks; c++) {
+        const VecT in_vec = *reinterpret_cast<const VecT*>(qkv + offsetThread + c * VecSize);
+#pragma unroll
+        for (int v = 0; v < VecSize; v++) {
+          accscalar_t val = static_cast<accscalar_t>(in_vec[v]);
+          elements[c * VecSize + v] = val;
+          sumOfSquares += val * val;
         }
-      } else {
-        // Neox style - use XOR shuffle like CUDA
-        sycl::group_barrier(sg);
-        const int half_rotary_lanes = rotary_lanes / 2;
+      }
 
-        for (int i = 0; i < numElemsPerThread; i++) {
-          // XOR shuffle to exchange between first and second half
-          elements2[i] = sycl::permute_group_by_xor(sg, elements[i], half_rotary_lanes);
-          if (laneId < half_rotary_lanes) {
-            elements2[i] = -elements2[i];
+      // Reduce sum across sub-group (warp)
+      sumOfSquares = subGroupReduceSum(sumOfSquares, sg);
+
+      // Compute RMS normalization factor
+      float rms_rcp = sycl::rsqrt(sumOfSquares / static_cast<float>(head_dim) + eps);
+
+      // Normalize elements
+      const scalar_t* weight_ptr = isQ ? q_weight : k_weight;
+#pragma unroll
+      for (int c = 0; c < numChunks; c++) {
+        const VecT w_vec = *reinterpret_cast<const VecT*>(weight_ptr + laneId * numElemsPerThread + c * VecSize);
+#pragma unroll
+        for (int v = 0; v < VecSize; v++) {
+          accscalar_t weight = static_cast<accscalar_t>(w_vec[v]);
+          elements[c * VecSize + v] *= rms_rcp * weight;
+        }
+      }
+
+      // Apply RoPE to normalized elements
+      accscalar_t elements2[numElemsPerThread];
+      accscalar_t cos_vals[numElemsPerThread];
+      accscalar_t sin_vals[numElemsPerThread];
+      float pos_id = static_cast<float>(position_ids[tokenIdx]);
+      const int rotary_lanes = rotary_dim / numElemsPerThread;
+      const bool applyRotary = (laneId < rotary_lanes);
+
+      if (applyRotary) {
+        if constexpr (interleave) {
+          // Interleave mode
+          for (int i = 0; i < numElemsPerThread; i++) {
+            elements2[i] = (i % 2 == 0) ? -elements[i + 1] : elements[i - 1];
+
+            int dim_idx = laneId * numElemsPerThread + i;
+            int half_dim = dim_idx / 2;
+            float freq = compute_freq_yarn(base, rotary_dim, half_dim, factor, low, high);
+            float theta = pos_id * freq;
+            sin_vals[i] = sycl::sin(theta);
+            cos_vals[i] = sycl::cos(theta);
           }
+        } else {
+          // Neox style - use XOR shuffle like CUDA
+          sycl::group_barrier(sg);
+          const int half_rotary_lanes = rotary_lanes / 2;
 
-          int dim_idx = laneId * numElemsPerThread + i;
-          dim_idx = (dim_idx * 2) % rotary_dim;
-          int half_dim = dim_idx / 2;
-          float freq = compute_freq_yarn(base, rotary_dim, half_dim, factor, low, high);
-          float theta = pos_id * freq;
-          sin_vals[i] = sycl::sin(theta);
-          cos_vals[i] = sycl::cos(theta);
+          for (int i = 0; i < numElemsPerThread; i++) {
+            // XOR shuffle to exchange between first and second half
+            elements2[i] = sycl::permute_group_by_xor(sg, elements[i], half_rotary_lanes);
+            if (laneId < half_rotary_lanes) {
+              elements2[i] = -elements2[i];
+            }
+
+            int dim_idx = laneId * numElemsPerThread + i;
+            dim_idx = (dim_idx * 2) % rotary_dim;
+            int half_dim = dim_idx / 2;
+            float freq = compute_freq_yarn(base, rotary_dim, half_dim, factor, low, high);
+            float theta = pos_id * freq;
+            sin_vals[i] = sycl::sin(theta);
+            cos_vals[i] = sycl::cos(theta);
+          }
+          sycl::group_barrier(sg);
         }
-        sycl::group_barrier(sg);
+
+        // Apply rotation with attention_factor
+        for (int i = 0; i < numElemsPerThread; i++) {
+          elements[i] = (elements[i] * cos_vals[i] + elements2[i] * sin_vals[i]) * attention_factor;
+        }
       }
 
-      // Apply rotation with attention_factor
-      for (int i = 0; i < numElemsPerThread; i++) {
-        elements[i] = (elements[i] * cos_vals[i] + elements2[i] * sin_vals[i]) * attention_factor;
+      // Store results
+#pragma unroll
+      for (int c = 0; c < numChunks; c++) {
+        VecT out_vec;
+#pragma unroll
+        for (int v = 0; v < VecSize; v++) {
+          out_vec[v] = static_cast<scalar_t>(elements[c * VecSize + v]);
+        }
+        *reinterpret_cast<VecT*>(qkv + offsetThread + c * VecSize) = out_vec;
       }
-    }
-
-    // Store results
-    for (int i = 0; i < numElemsPerThread; i++) {
-      qkv[offsetThread + i] = static_cast<scalar_t>(elements[i]);
     }
   }
 };
+
+template <int head_dim, bool interleave, typename scalar_t, int VecSize>
+void launchFusedQKNormRopeVecImpl(
+    void* qkv,
+    int num_tokens,
+    int num_heads_q,
+    int num_heads_k,
+    int num_heads_v,
+    float eps,
+    const void* q_weight,
+    const void* k_weight,
+    float base,
+    const int* position_ids,
+    float factor,
+    float low,
+    float high,
+    float attention_factor,
+    int rotary_dim,
+    sycl::queue& q,
+    int64_t gridSize,
+    int64_t blockSize) {
+  FusedQKNormRopeKernel<head_dim, interleave, scalar_t, VecSize> kernel{
+      static_cast<scalar_t*>(qkv),
+      num_heads_q,
+      num_heads_k,
+      num_heads_v,
+      eps,
+      static_cast<const scalar_t*>(q_weight),
+      static_cast<const scalar_t*>(k_weight),
+      base,
+      position_ids,
+      num_tokens,
+      factor,
+      low,
+      high,
+      attention_factor,
+      rotary_dim};
+
+  sycl_kernel_submit(sycl::range<1>(gridSize * blockSize), sycl::range<1>(blockSize), q, kernel);
+}
+
 template <int head_dim, bool interleave, typename scalar_t>
 void launchFusedQKNormRopeImpl(
     void* qkv,
@@ -208,30 +448,36 @@ void launchFusedQKNormRopeImpl(
     float attention_factor,
     int rotary_dim,
     sycl::queue& q) {
-  constexpr int blockSize = 256;
-  const int warpsPerBlock = blockSize / 32;
   const int totalQKHeads = num_heads_q + num_heads_k;
-  const int totalWarps = num_tokens * totalQKHeads;
-  const int gridSize = divUp(totalWarps, warpsPerBlock);
+  const int64_t totalWarps = static_cast<int64_t>(num_tokens) * totalQKHeads;
+  const auto launch_cfg = computePersistentLaunchConfig(totalWarps, NUM_REDUCE_STAGES);
 
-  FusedQKNormRopeKernel<head_dim, interleave, scalar_t> kernel{
-      static_cast<scalar_t*>(qkv),
-      num_heads_q,
-      num_heads_k,
-      num_heads_v,
-      eps,
-      static_cast<const scalar_t*>(q_weight),
-      static_cast<const scalar_t*>(k_weight),
-      base,
-      position_ids,
-      num_tokens,
-      factor,
-      low,
-      high,
-      attention_factor,
-      rotary_dim};
+  constexpr int64_t numElemsPerThread = head_dim / NUM_REDUCE_STAGES;
+  const int64_t maxVecSize = std::min<int64_t>(numElemsPerThread, maxHwVecSize(sizeof(scalar_t)));
+  const int64_t vec_size = pick_aligned_vec_size(maxVecSize, sizeof(scalar_t), {qkv, q_weight, k_weight});
 
-  sycl_kernel_submit(sycl::range<1>(gridSize * blockSize), sycl::range<1>(blockSize), q, kernel);
+  dispatchFusedQKNormRopeVecSize<numElemsPerThread>(vec_size, [&](auto vec_size_tag) {
+    constexpr int kVecSize = static_cast<int>(decltype(vec_size_tag)::value);
+    launchFusedQKNormRopeVecImpl<head_dim, interleave, scalar_t, kVecSize>(
+        qkv,
+        num_tokens,
+        num_heads_q,
+        num_heads_k,
+        num_heads_v,
+        eps,
+        q_weight,
+        k_weight,
+        base,
+        position_ids,
+        factor,
+        low,
+        high,
+        attention_factor,
+        rotary_dim,
+        q,
+        launch_cfg.gridSize,
+        launch_cfg.blockSize);
+  });
 }
 
 void fused_qk_norm_rope(
@@ -258,15 +504,17 @@ void fused_qk_norm_rope(
   TORCH_CHECK(k_weight.dim() == 1, "Key weights must be 1D: [head_dim]");
   TORCH_CHECK(q_weight.size(0) == head_dim, "Query weights size must match head dimension");
   TORCH_CHECK(k_weight.size(0) == head_dim, "Key weights size must match head dimension");
-  TORCH_CHECK(rotary_dim % (head_dim / 32) == 0, "rotary_dim must be divisible by numElemsPerThread");
+  TORCH_CHECK(rotary_dim % (head_dim / NUM_REDUCE_STAGES) == 0, "rotary_dim must be divisible by numElemsPerThread");
 
   if (is_neox) {
-    int64_t half_rotary_lanes = rotary_dim / (head_dim / 32) / 2;
+    int64_t half_rotary_lanes = rotary_dim / (head_dim / NUM_REDUCE_STAGES) / 2;
     TORCH_CHECK(
         half_rotary_lanes >= 1 && (half_rotary_lanes & (half_rotary_lanes - 1)) == 0,
         "half_rotary_lanes must be a power of 2 for neox style, got ",
         half_rotary_lanes);
   }
+
+  check_subgroup_size_supported(NUM_REDUCE_STAGES);
 
   CHECK_DEVICE(qkv);
   CHECK_CONTIGUOUS(qkv);
@@ -291,84 +539,388 @@ void fused_qk_norm_rope(
   auto queue = dpcppGetCurrentQueue();
   bool interleave = !is_neox;
 
-// Maps at::ScalarType to the corresponding SYCL/cutlass C++ type (scalar_t)
-// and immediately invokes the callable passed as the variadic argument.
-// Float8_e4m3fn uses the cutlass type because native SYCL float8 is not yet
-// supported; Half and BFloat16 use their respective SYCL types.
-#define SYCL_DISPATCH_FLOATING_TYPES(SCALAR_TYPE, KERNEL_NAME, ...)                 \
-  [&]() {                                                                           \
-    switch (SCALAR_TYPE) {                                                          \
-      case at::ScalarType::Half: {                                                  \
-        using scalar_t = sycl::half;                                                \
-        __VA_ARGS__();                                                              \
-        break;                                                                      \
-      }                                                                             \
-      case at::ScalarType::BFloat16: {                                              \
-        using scalar_t = sycl::ext::oneapi::bfloat16;                               \
-        __VA_ARGS__();                                                              \
-        break;                                                                      \
-      }                                                                             \
-      case at::ScalarType::Float8_e4m3fn: {                                         \
-        using scalar_t = float_e4m3_t;                                              \
-        __VA_ARGS__();                                                              \
-        break;                                                                      \
-      }                                                                             \
-      default:                                                                      \
-        TORCH_CHECK(false, "Unsupported dtype for " KERNEL_NAME ": ", SCALAR_TYPE); \
-    }                                                                               \
-  }()
+  dispatchFusedQKNormRopeScalarType<true>(qkv.scalar_type(), "fused_qk_norm_rope", [&](auto scalar_tag) {
+    using scalar_t = typename decltype(scalar_tag)::type;
+    dispatchFusedQKNormRopeHeadDim(head_dim, "fusedQKNormRope", [&](auto head_dim_tag) {
+      constexpr int64_t kHeadDimConst = decltype(head_dim_tag)::value;
+      if (interleave) {
+        launchFusedQKNormRopeImpl<kHeadDimConst, true, scalar_t>(
+            qkv.data_ptr(),
+            static_cast<int>(num_tokens),
+            static_cast<int>(num_heads_q),
+            static_cast<int>(num_heads_k),
+            static_cast<int>(num_heads_v),
+            static_cast<float>(eps),
+            q_weight.data_ptr(),
+            k_weight.data_ptr(),
+            static_cast<float>(base),
+            position_ids.data_ptr<int>(),
+            static_cast<float>(factor),
+            static_cast<float>(low),
+            static_cast<float>(high),
+            static_cast<float>(attention_factor),
+            static_cast<int>(rotary_dim),
+            queue);
+      } else {
+        launchFusedQKNormRopeImpl<kHeadDimConst, false, scalar_t>(
+            qkv.data_ptr(),
+            static_cast<int>(num_tokens),
+            static_cast<int>(num_heads_q),
+            static_cast<int>(num_heads_k),
+            static_cast<int>(num_heads_v),
+            static_cast<float>(eps),
+            q_weight.data_ptr(),
+            k_weight.data_ptr(),
+            static_cast<float>(base),
+            position_ids.data_ptr<int>(),
+            static_cast<float>(factor),
+            static_cast<float>(low),
+            static_cast<float>(high),
+            static_cast<float>(attention_factor),
+            static_cast<int>(rotary_dim),
+            queue);
+      }
+    });
+  });
+}
 
-// The lambda is wrapped in an extra () so that commas in the template argument
-// list <HD, IL, scalar_t> are hidden from the preprocessor's argument splitter.
-#define LAUNCH_KERNEL(HD, IL)                                                    \
-  SYCL_DISPATCH_FLOATING_TYPES(qkv.scalar_type(), "fused_qk_norm_rope", ([&]() { \
-                                 launchFusedQKNormRopeImpl<HD, IL, scalar_t>(    \
-                                     qkv.data_ptr(),                             \
-                                     static_cast<int>(num_tokens),               \
-                                     static_cast<int>(num_heads_q),              \
-                                     static_cast<int>(num_heads_k),              \
-                                     static_cast<int>(num_heads_v),              \
-                                     static_cast<float>(eps),                    \
-                                     q_weight.data_ptr(),                        \
-                                     k_weight.data_ptr(),                        \
-                                     static_cast<float>(base),                   \
-                                     position_ids.data_ptr<int>(),               \
-                                     static_cast<float>(factor),                 \
-                                     static_cast<float>(low),                    \
-                                     static_cast<float>(high),                   \
-                                     static_cast<float>(attention_factor),       \
-                                     static_cast<int>(rotary_dim),               \
-                                     queue);                                     \
-                               }))
+// SYCL Kernel for Fused QK Norm + RoPE using a precomputed cos/sin cache
+// (mirrors CUDA's qknorm_rope.cuh). q/k must be 3D contiguous tensors:
+// [num_tokens, num_heads, head_dim].
+template <int64_t kHeadDim, bool kIsNeox, typename scalar_t, typename IdType, int64_t kVecSize>
+struct FusedQKNormRopeCacheKernel {
+  static_assert(kHeadDim <= 256, "Only head_dim <= 256 is supported");
+  static_assert(
+      kHeadDim % NUM_REDUCE_STAGES == 0, "head_dim must be divisible by the sub-group size (NUM_REDUCE_STAGES)");
 
-  switch (head_dim) {
-    case 64:
-      if (interleave) {
-        LAUNCH_KERNEL(64, true);
+  static constexpr uint32_t kElemsPerThread = static_cast<uint32_t>(kHeadDim / NUM_REDUCE_STAGES);
+  static_assert(kElemsPerThread % kVecSize == 0, "kVecSize must evenly divide kElemsPerThread");
+  static constexpr uint32_t kNumChunks = kElemsPerThread / kVecSize;
+
+  scalar_t* q_ptr;
+  scalar_t* k_ptr;
+  const scalar_t* q_weight_ptr;
+  const scalar_t* k_weight_ptr;
+  const float* cos_sin_cache_ptr;  // [max_position, kRopeDim]
+  const IdType* positions;         // [num_tokens]
+  int64_t rope_dim;
+  int64_t rotary_lanes;
+  int64_t half_rotary_lanes;
+  int64_t q_token_stride;  // elements between consecutive tokens in q (== num_qo_heads * kHeadDim)
+  int64_t k_token_stride;  // elements between consecutive tokens in k (== num_kv_heads * kHeadDim)
+  uint32_t num_qo_heads;
+  uint32_t num_kv_heads;
+  uint32_t num_tokens;
+  float eps;
+
+  [[sycl::reqd_sub_group_size(NUM_REDUCE_STAGES)]] void operator()(sycl::nd_item<1> item) const {
+    auto sg = item.get_sub_group();
+    const uint32_t lane_id = static_cast<uint32_t>(item.get_local_id(0) % NUM_REDUCE_STAGES);
+    const uint32_t warp_id = static_cast<uint32_t>(item.get_local_id(0) / NUM_REDUCE_STAGES);
+    const uint32_t warps_per_block = static_cast<uint32_t>(item.get_local_range(0) / NUM_REDUCE_STAGES);
+    const uint32_t start_worker_id = static_cast<uint32_t>(item.get_group(0)) * warps_per_block + warp_id;
+    const uint32_t num_workers = static_cast<uint32_t>(item.get_group_range(0)) * warps_per_block;
+
+    const uint32_t num_qk_heads = num_qo_heads + num_kv_heads;
+    const uint32_t num_works = num_qk_heads * num_tokens;
+
+    for (uint32_t idx = start_worker_id; idx < num_works; idx += num_workers) {
+      const uint32_t token_id = idx / num_qk_heads;
+      const uint32_t head_id = idx % num_qk_heads;
+      const bool load_q = head_id < num_qo_heads;
+
+      scalar_t* row_ptr;
+      const scalar_t* weight_ptr;
+      if (load_q) {
+        row_ptr = q_ptr + static_cast<int64_t>(token_id) * q_token_stride + static_cast<int64_t>(head_id) * kHeadDim;
+        weight_ptr = q_weight_ptr;
       } else {
-        LAUNCH_KERNEL(64, false);
+        const uint32_t k_head_id = head_id - num_qo_heads;
+        row_ptr = k_ptr + static_cast<int64_t>(token_id) * k_token_stride + static_cast<int64_t>(k_head_id) * kHeadDim;
+        weight_ptr = k_weight_ptr;
       }
-      break;
-    case 128:
-      if (interleave) {
-        LAUNCH_KERNEL(128, true);
+
+      using VecT = aligned_vector_loop<scalar_t, kVecSize>;
+      float elems[kElemsPerThread];
+      float sum_of_squares = 0.0f;
+#pragma unroll
+      for (uint32_t c = 0; c < kNumChunks; ++c) {
+        const VecT in_vec = *reinterpret_cast<const VecT*>(row_ptr + lane_id * kElemsPerThread + c * kVecSize);
+#pragma unroll
+        for (uint32_t v = 0; v < kVecSize; ++v) {
+          const float x = static_cast<float>(in_vec[v]);
+          elems[c * kVecSize + v] = x;
+          sum_of_squares += x * x;
+        }
+      }
+
+      sum_of_squares = subGroupReduceSum(sum_of_squares, sg);
+      const float norm_factor = sycl::rsqrt(sum_of_squares / static_cast<float>(kHeadDim) + eps);
+
+#pragma unroll
+      for (uint32_t c = 0; c < kNumChunks; ++c) {
+        const VecT w_vec = *reinterpret_cast<const VecT*>(weight_ptr + lane_id * kElemsPerThread + c * kVecSize);
+#pragma unroll
+        for (uint32_t v = 0; v < kVecSize; ++v) {
+          const float w = static_cast<float>(w_vec[v]);
+          elems[c * kVecSize + v] *= norm_factor * w;
+        }
+      }
+
+      const int64_t pos = static_cast<int64_t>(positions[token_id]);
+      const float* cos_ptr = cos_sin_cache_ptr + pos * rope_dim;
+      const float* sin_ptr = cos_ptr + rope_dim / 2;
+      const bool apply_rotary = static_cast<int64_t>(lane_id) < rotary_lanes;
+
+      if constexpr (kIsNeox) {
+        sycl::group_barrier(sg);
+        float permuted[kElemsPerThread];
+#pragma unroll
+        for (uint32_t i = 0; i < kElemsPerThread; ++i) {
+          permuted[i] = sycl::permute_group_by_xor(sg, elems[i], static_cast<int>(half_rotary_lanes));
+        }
+        sycl::group_barrier(sg);
+        if (apply_rotary) {
+#pragma unroll
+          for (uint32_t i = 0; i < kElemsPerThread; ++i) {
+            float swapped = permuted[i];
+            if (static_cast<int64_t>(lane_id) < half_rotary_lanes) {
+              swapped = -swapped;
+            }
+
+            int dim_idx = static_cast<int>(lane_id * kElemsPerThread + i);
+            dim_idx = (dim_idx * 2) % static_cast<int>(rope_dim);
+            const int half_idx = dim_idx / 2;
+            const float cos = cos_ptr[half_idx];
+            const float sin = sin_ptr[half_idx];
+            elems[i] = elems[i] * cos + swapped * sin;
+          }
+        }
       } else {
-        LAUNCH_KERNEL(128, false);
+        if (apply_rotary) {
+#pragma unroll
+          for (uint32_t i = 0; i < kElemsPerThread; i += 2) {
+            const float x = elems[i];
+            const float y = elems[i + 1];
+            const int half_idx = static_cast<int>(lane_id * kElemsPerThread + i) / 2;
+            const float cos = cos_ptr[half_idx];
+            const float sin = sin_ptr[half_idx];
+            elems[i] = x * cos - y * sin;
+            elems[i + 1] = y * cos + x * sin;
+          }
+        }
       }
-      break;
-    case 256:
-      if (interleave) {
-        LAUNCH_KERNEL(256, true);
-      } else {
-        LAUNCH_KERNEL(256, false);
+
+#pragma unroll
+      for (uint32_t c = 0; c < kNumChunks; ++c) {
+        VecT out_vec;
+#pragma unroll
+        for (uint32_t v = 0; v < kVecSize; ++v) {
+          out_vec[v] = static_cast<scalar_t>(elems[c * kVecSize + v]);
+        }
+        *reinterpret_cast<VecT*>(row_ptr + lane_id * kElemsPerThread + c * kVecSize) = out_vec;
       }
-      break;
-    default:
-      TORCH_CHECK(false, "Unsupported head dimension for fusedQKNormRope: ", head_dim);
+    }
   }
+};
 
-#undef LAUNCH_KERNEL
-#undef SYCL_DISPATCH_FLOATING_TYPES
+template <int64_t kHeadDim, bool kIsNeox, typename scalar_t, typename IdType, int64_t kVecSize>
+void launchFusedQKNormRopeCacheVecImpl(
+    scalar_t* q_ptr,
+    scalar_t* k_ptr,
+    const scalar_t* q_weight_ptr,
+    const scalar_t* k_weight_ptr,
+    const float* cos_sin_cache_ptr,
+    const IdType* positions_ptr,
+    int64_t q_token_stride,
+    int64_t k_token_stride,
+    int64_t num_tokens,
+    int64_t num_qo_heads,
+    int64_t num_kv_heads,
+    int64_t rope_dim,
+    int64_t rotary_lanes,
+    int64_t half_rotary_lanes,
+    float eps,
+    sycl::queue& queue,
+    int64_t gridSize,
+    int64_t blockSize) {
+  using KernelT = FusedQKNormRopeCacheKernel<kHeadDim, kIsNeox, scalar_t, IdType, kVecSize>;
+  KernelT kernel{
+      q_ptr,
+      k_ptr,
+      q_weight_ptr,
+      k_weight_ptr,
+      cos_sin_cache_ptr,
+      positions_ptr,
+      rope_dim,
+      rotary_lanes,
+      half_rotary_lanes,
+      q_token_stride,
+      k_token_stride,
+      static_cast<uint32_t>(num_qo_heads),
+      static_cast<uint32_t>(num_kv_heads),
+      static_cast<uint32_t>(num_tokens),
+      eps};
+
+  sycl_kernel_submit(sycl::range<1>(gridSize * blockSize), sycl::range<1>(blockSize), queue, kernel);
+}
+
+template <int64_t kHeadDim, bool kIsNeox, typename scalar_t, typename IdType>
+void launchFusedQKNormRopeCacheImpl(
+    scalar_t* q_ptr,
+    scalar_t* k_ptr,
+    const scalar_t* q_weight_ptr,
+    const scalar_t* k_weight_ptr,
+    const float* cos_sin_cache_ptr,
+    const IdType* positions_ptr,
+    int64_t q_token_stride,
+    int64_t k_token_stride,
+    int64_t num_tokens,
+    int64_t num_qo_heads,
+    int64_t num_kv_heads,
+    int64_t rope_dim,
+    float eps,
+    sycl::queue& queue) {
+  const int64_t totalWork = num_tokens * (num_qo_heads + num_kv_heads);
+  const auto launch_cfg = computePersistentLaunchConfig(totalWork, NUM_REDUCE_STAGES);
+
+  constexpr int64_t kElemsPerThread = kHeadDim / NUM_REDUCE_STAGES;
+  TORCH_CHECK(rope_dim > 0 && rope_dim <= kHeadDim, "Invalid rope_dim: ", rope_dim);
+  TORCH_CHECK(rope_dim % kElemsPerThread == 0, "rope_dim must align with per-lane vector width");
+  const int64_t rotary_lanes = rope_dim / kElemsPerThread;
+  const int64_t half_rotary_lanes = rotary_lanes / 2;
+  if constexpr (kIsNeox) {
+    TORCH_CHECK(
+        rotary_lanes >= 2 && (rotary_lanes & (rotary_lanes - 1)) == 0,
+        "NeoX fused qknorm+rope requires rotary lane count to be a power of 2, got ",
+        rotary_lanes);
+  }
+  const int64_t maxVecSize = std::min<int64_t>(kElemsPerThread, maxHwVecSize(sizeof(scalar_t)));
+  const int64_t vec_size =
+      pick_aligned_vec_size(maxVecSize, sizeof(scalar_t), {q_ptr, k_ptr, q_weight_ptr, k_weight_ptr});
+
+  dispatchFusedQKNormRopeVecSize<kElemsPerThread>(vec_size, [&](auto vec_size_tag) {
+    constexpr int64_t kVecSize = decltype(vec_size_tag)::value;
+    launchFusedQKNormRopeCacheVecImpl<kHeadDim, kIsNeox, scalar_t, IdType, kVecSize>(
+        q_ptr,
+        k_ptr,
+        q_weight_ptr,
+        k_weight_ptr,
+        cos_sin_cache_ptr,
+        positions_ptr,
+        q_token_stride,
+        k_token_stride,
+        num_tokens,
+        num_qo_heads,
+        num_kv_heads,
+        rope_dim,
+        rotary_lanes,
+        half_rotary_lanes,
+        eps,
+        queue,
+        launch_cfg.gridSize,
+        launch_cfg.blockSize);
+  });
+}
+
+void fused_qk_norm_rope_with_cos_sin_cache_inplace(
+    torch::Tensor& q,
+    torch::Tensor& k,
+    torch::Tensor& q_weight,
+    torch::Tensor& k_weight,
+    torch::Tensor& cos_sin_cache,
+    torch::Tensor& positions,
+    bool is_neox,
+    double eps) {
+  TORCH_CHECK(q.dim() == k.dim(), "q and k must have the same rank, got q:", q.dim(), " k:", k.dim());
+  TORCH_CHECK(q.dim() == 3 || q.dim() == 4, "q/k must be 3D or 4D tensors, got q:", q.dim());
+  TORCH_CHECK(q.scalar_type() == k.scalar_type(), "q and k must have the same dtype");
+  TORCH_CHECK(q_weight.scalar_type() == q.scalar_type(), "q_weight dtype must match q dtype");
+  TORCH_CHECK(k_weight.scalar_type() == k.scalar_type(), "k_weight dtype must match k dtype");
+  TORCH_CHECK(cos_sin_cache.scalar_type() == at::ScalarType::Float, "cos_sin_cache must be float32");
+
+  CHECK_DEVICE(q);
+  CHECK_CONTIGUOUS(q);
+  CHECK_DEVICE(k);
+  CHECK_CONTIGUOUS(k);
+  CHECK_DEVICE(q_weight);
+  CHECK_CONTIGUOUS(q_weight);
+  CHECK_DEVICE(k_weight);
+  CHECK_CONTIGUOUS(k_weight);
+  CHECK_DEVICE(cos_sin_cache);
+  CHECK_CONTIGUOUS(cos_sin_cache);
+  CHECK_DEVICE(positions);
+  CHECK_CONTIGUOUS(positions);
+
+  auto q_view = q.dim() == 4 ? q.view({-1, q.size(2), q.size(3)}) : q;
+  auto k_view = k.dim() == 4 ? k.view({-1, k.size(2), k.size(3)}) : k;
+  TORCH_CHECK(q_view.dim() == 3 && k_view.dim() == 3, "Flattened q/k must be 3D tensors");
+  TORCH_CHECK(q_view.size(0) == k_view.size(0), "q and k must have the same token count after flattening");
+  TORCH_CHECK(q_view.size(2) == k_view.size(2), "q and k must have the same head_dim");
+
+  const int64_t num_tokens = q_view.size(0);
+  const int64_t num_qo_heads = q_view.size(1);
+  const int64_t num_kv_heads = k_view.size(1);
+  const int64_t head_dim = q_view.size(2);
+
+  TORCH_CHECK(q_weight.size(0) == head_dim, "q_weight size must match head_dim");
+  TORCH_CHECK(k_weight.size(0) == head_dim, "k_weight size must match head_dim");
+  TORCH_CHECK(cos_sin_cache.dim() == 2, "cos_sin_cache must be 2D [max_position, rope_dim]");
+  const int64_t rope_dim = cos_sin_cache.size(1);
+  TORCH_CHECK(rope_dim % 2 == 0, "rope_dim must be even");
+  TORCH_CHECK(rope_dim <= head_dim, "rope_dim must be <= head_dim");
+  TORCH_CHECK(positions.dim() == 1, "positions must be 1D [num_tokens]");
+  TORCH_CHECK(positions.size(0) == num_tokens, "positions size must match flattened q/k tokens");
+
+  check_subgroup_size_supported(NUM_REDUCE_STAGES);
+
+  auto queue = dpcppGetCurrentQueue();
+
+  dispatchFusedQKNormRopeScalarType<false>(
+      q_view.scalar_type(), "fused_qk_norm_rope_with_cos_sin_cache_inplace", [&](auto scalar_tag) {
+        using scalar_t = typename decltype(scalar_tag)::type;
+        dispatchFusedQKNormRopePositionsType(
+            positions.scalar_type(), "fused_qk_norm_rope_with_cos_sin_cache_inplace", [&](auto id_tag) {
+              using IdType = typename decltype(id_tag)::type;
+              dispatchFusedQKNormRopeHeadDim(
+                  head_dim, "fused_qk_norm_rope_with_cos_sin_cache_inplace", [&](auto head_dim_tag) {
+                    constexpr int64_t kHeadDimConst = decltype(head_dim_tag)::value;
+                    if (is_neox) {
+                      launchFusedQKNormRopeCacheImpl<kHeadDimConst, true, scalar_t, IdType>(
+                          static_cast<scalar_t*>(q_view.data_ptr()),
+                          static_cast<scalar_t*>(k_view.data_ptr()),
+                          static_cast<const scalar_t*>(q_weight.data_ptr()),
+                          static_cast<const scalar_t*>(k_weight.data_ptr()),
+                          static_cast<const float*>(cos_sin_cache.data_ptr()),
+                          static_cast<const IdType*>(positions.data_ptr()),
+                          q_view.stride(0),
+                          k_view.stride(0),
+                          num_tokens,
+                          num_qo_heads,
+                          num_kv_heads,
+                          rope_dim,
+                          static_cast<float>(eps),
+                          queue);
+                    } else {
+                      launchFusedQKNormRopeCacheImpl<kHeadDimConst, false, scalar_t, IdType>(
+                          static_cast<scalar_t*>(q_view.data_ptr()),
+                          static_cast<scalar_t*>(k_view.data_ptr()),
+                          static_cast<const scalar_t*>(q_weight.data_ptr()),
+                          static_cast<const scalar_t*>(k_weight.data_ptr()),
+                          static_cast<const float*>(cos_sin_cache.data_ptr()),
+                          static_cast<const IdType*>(positions.data_ptr()),
+                          q_view.stride(0),
+                          k_view.stride(0),
+                          num_tokens,
+                          num_qo_heads,
+                          num_kv_heads,
+                          rope_dim,
+                          static_cast<float>(eps),
+                          queue);
+                    }
+                  });
+            });
+      });
 }
 
 }  // namespace at::native::xpu

--- a/src/sycl/FusedQKNormRope.cpp
+++ b/src/sycl/FusedQKNormRope.cpp
@@ -61,30 +61,6 @@ inline float compute_freq_yarn(float base, int rotary_dim, int half_dim, float f
   return freq;
 }
 
-// ---------------------------------------------------------------------------
-// Sub-group width portability and occupancy-aware (persistent) launch sizing.
-//
-// Unlike CUDA's fixed 32-wide warp, Intel GPUs support a device-dependent set
-// of sub-group widths (commonly a subset of {8, 16, 32}). The kernels below
-// pin the width to NUM_REDUCE_STAGES via [[sycl::reqd_sub_group_size(...)]]
-// so compile-time lane arithmetic matches the runtime sub-group size, and
-// validate at launch time that the device actually supports that width.
-inline void check_subgroup_size_supported(int64_t required_size) {
-  auto* dev_prop = at::xpu::getDeviceProperties(dpcppGetDeviceIdOfCurrentQueue());
-  bool supported = false;
-  for (auto sz : dev_prop->sub_group_sizes) {
-    if (static_cast<int64_t>(sz) == required_size) {
-      supported = true;
-      break;
-    }
-  }
-  TORCH_CHECK(
-      supported,
-      "fused_qk_norm_rope kernels require sub-group size ",
-      required_size,
-      ", which is not supported by this device");
-}
-
 struct PersistentLaunchConfig {
   int64_t blockSize;
   int64_t gridSize;
@@ -146,18 +122,18 @@ inline void dispatchFusedQKNormRopeHeadDim(int64_t head_dim, const char* kernel_
   }
 }
 
-// Dispatches over vectorized VecSize instantiations (16/8/4/2), gated by
-// `kCandidate <= kElemsPerThread` so only widths that evenly divide the
-// per-lane element count are tried, then unconditionally falls back to
-// scalar (VecSize=1) -- always valid regardless of alignment -- if none
-// matched, guaranteeing the kernel is always launched. Shared by both the
-// packed-QKV and cos/sin-cache launch paths.
+// Dispatches over vectorized VecSize instantiations (16/8/4/2), accepting
+// only widths that both fit within the per-lane element count and divide it
+// evenly, then unconditionally falling back to scalar (VecSize=1) -- always
+// valid regardless of alignment -- if none matched, guaranteeing the kernel
+// is always launched. Shared by both the packed-QKV and cos/sin-cache launch
+// paths.
 template <int64_t kElemsPerThread, typename Fn>
 inline void dispatchFusedQKNormRopeVecSize(int64_t vec_size, Fn&& fn) {
   bool dispatched = false;
   auto try_vec_size = [&](auto vec_size_tag) {
     constexpr int64_t kCandidate = decltype(vec_size_tag)::value;
-    if constexpr (kCandidate <= kElemsPerThread) {
+    if constexpr (kCandidate <= kElemsPerThread && kElemsPerThread % kCandidate == 0) {
       if (!dispatched && vec_size == kCandidate) {
         fn(vec_size_tag);
         dispatched = true;
@@ -173,48 +149,45 @@ inline void dispatchFusedQKNormRopeVecSize(int64_t vec_size, Fn&& fn) {
   }
 }
 
-// Picks the largest power-of-two width (<= max_vec_size) for which every
-// pointer in `ptrs` is aligned to `elem_size * vec_size` bytes and every
-// stride in `elem_strides` (elements; row strides for non-contiguous q/k)
-// is a multiple of vec_size, shrinking to 1 (always safe) if needed.
+// Picks the largest power-of-two width (<= max_vec_size) for which:
+//   1. `elems_per_thread` (the per-lane algorithmic element count) is evenly
+//      divisible by vec_size -- required so the kernel's static_assert
+//      (kElemsPerThread % VecSize == 0) always holds;
+//   2. every pointer in `ptrs` is aligned to `elem_size * vec_size` bytes;
+//   3. every stride in `elem_strides` (elements; row strides for
+//      non-contiguous q/k) is itself a multiple of vec_size.
+// Falls back to 1 (always valid) if no larger width satisfies all three.
 // `elem_strides` defaults to empty for fully contiguous callers. Only the
-// physical load/store chunk width shrinks; the per-lane algorithmic
-// element count is unaffected.
+// physical load/store chunk width shrinks; `elems_per_thread` itself is
+// unaffected.
 inline int64_t pick_aligned_vec_size(
     int64_t max_vec_size,
     int64_t elem_size,
     std::initializer_list<const void*> ptrs,
+    int64_t elems_per_thread,
     std::initializer_list<int64_t> elem_strides = {}) {
-  int64_t vec_size = max_vec_size;
-  while (vec_size > 1) {
+  for (int64_t vec_size = max_vec_size; vec_size > 1; vec_size >>= 1) {
+    if (elems_per_thread % vec_size != 0) continue;
+
     const int64_t align_bytes = elem_size * vec_size;
-    bool all_aligned = true;
+    bool ok = true;
     for (const void* p : ptrs) {
       if (reinterpret_cast<uintptr_t>(p) % align_bytes != 0) {
-        all_aligned = false;
+        ok = false;
         break;
       }
     }
-    if (all_aligned) {
+    if (ok) {
       for (int64_t stride : elem_strides) {
         if (stride % vec_size != 0) {
-          all_aligned = false;
+          ok = false;
           break;
         }
       }
     }
-    if (all_aligned) break;
-    vec_size >>= 1;
+    if (ok) return vec_size;
   }
-  return vec_size;
-}
-
-// Caps the vector load/store chunk at 16 bytes (128-bit), matching
-// RMSNorm.cpp's convention, to avoid oversized vector instructions and
-// register pressure/spills for wide per-lane element counts.
-inline int64_t maxHwVecSize(int64_t elem_size) {
-  constexpr int64_t kMaxVecBytes = sizeof(float) * 4;
-  return std::max<int64_t>(1, kMaxVecBytes / elem_size);
+  return 1;
 }
 
 // Caps work-group size for warp-per-(token,head) kernels: work-groups wider
@@ -468,8 +441,10 @@ void launchFusedQKNormRopeImpl(
   const auto launch_cfg = computePersistentLaunchConfig(totalWarps, NUM_REDUCE_STAGES);
 
   constexpr int64_t numElemsPerThread = head_dim / NUM_REDUCE_STAGES;
-  const int64_t maxVecSize = std::min<int64_t>(numElemsPerThread, maxHwVecSize(sizeof(scalar_t)));
-  const int64_t vec_size = pick_aligned_vec_size(maxVecSize, sizeof(scalar_t), {qkv, q_weight, k_weight});
+  const int64_t preferredVecSize = preferred_vector_width(dpcppGetDeviceIdOfCurrentQueue(), sizeof(scalar_t));
+  const int64_t maxVecSize = std::min<int64_t>(numElemsPerThread, preferredVecSize);
+  const int64_t vec_size =
+      pick_aligned_vec_size(maxVecSize, sizeof(scalar_t), {qkv, q_weight, k_weight}, numElemsPerThread);
 
   dispatchFusedQKNormRopeVecSize<numElemsPerThread>(vec_size, [&](auto vec_size_tag) {
     constexpr int kVecSize = static_cast<int>(decltype(vec_size_tag)::value);
@@ -528,8 +503,6 @@ void fused_qk_norm_rope(
         "half_rotary_lanes must be a power of 2 for neox style, got ",
         half_rotary_lanes);
   }
-
-  check_subgroup_size_supported(NUM_REDUCE_STAGES);
 
   CHECK_DEVICE(qkv);
   CHECK_CONTIGUOUS(qkv);
@@ -824,7 +797,8 @@ void launchFusedQKNormRopeCacheImpl(
         "NeoX fused qknorm+rope requires rotary lane count to be a power of 2, got ",
         rotary_lanes);
   }
-  const int64_t maxVecSize = std::min<int64_t>(kElemsPerThread, maxHwVecSize(sizeof(scalar_t)));
+  const int64_t preferredVecSize = preferred_vector_width(dpcppGetDeviceIdOfCurrentQueue(), sizeof(scalar_t));
+  const int64_t maxVecSize = std::min<int64_t>(kElemsPerThread, preferredVecSize);
   // q/k rows may be non-contiguous beyond the last dimension (e.g. sliced
   // out of a larger packed buffer), so the chosen vector width must also
   // divide the token/head strides, not just satisfy base-pointer alignment.
@@ -832,6 +806,7 @@ void launchFusedQKNormRopeCacheImpl(
       maxVecSize,
       sizeof(scalar_t),
       {q_ptr, k_ptr, q_weight_ptr, k_weight_ptr},
+      kElemsPerThread,
       {q_token_stride, k_token_stride, q_head_stride, k_head_stride});
 
   dispatchFusedQKNormRopeVecSize<kElemsPerThread>(vec_size, [&](auto vec_size_tag) {
@@ -927,8 +902,6 @@ void fused_qk_norm_rope_with_cos_sin_cache_inplace(
   TORCH_CHECK(rope_dim <= head_dim, "rope_dim must be <= head_dim");
   TORCH_CHECK(positions.dim() == 1, "positions must be 1D [num_tokens]");
   TORCH_CHECK(positions.size(0) == num_tokens, "positions size must match flattened q/k tokens");
-
-  check_subgroup_size_supported(NUM_REDUCE_STAGES);
 
   auto queue = dpcppGetCurrentQueue();
 

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -200,6 +200,13 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "float eps, Tensor! q_weight, Tensor! k_weight, float base, bool is_neox, Tensor! position_ids, "
       "float factor, float low, float high, float attention_factor, int rotary_dim) -> ()");
   m.impl("fused_qk_norm_rope", torch::kXPU, &at::native::xpu::fused_qk_norm_rope);
+  m.def(
+      "fused_qk_norm_rope_with_cos_sin_cache_inplace(Tensor! q, Tensor! k, Tensor q_weight, Tensor k_weight, "
+      "Tensor cos_sin_cache, Tensor positions, bool is_neox, float eps) -> ()");
+  m.impl(
+      "fused_qk_norm_rope_with_cos_sin_cache_inplace",
+      torch::kXPU,
+      &at::native::xpu::fused_qk_norm_rope_with_cos_sin_cache_inplace);
   /*
    * Fused QK RoPE (no RMS_Norm)
    */

--- a/tests/test_fused_qk_norm_rope.py
+++ b/tests/test_fused_qk_norm_rope.py
@@ -8,6 +8,7 @@ import pytest
 import sgl_kernel
 import torch
 import utils
+from test_rope_utils import create_cos_sin_cache
 
 precision = {
     torch.bfloat16: 1e-2,
@@ -174,6 +175,48 @@ def fused_qk_norm_rope_reference(
     result = result.view(num_tokens, total_heads * head_dim)
 
     return result
+
+
+def fused_qk_norm_rope_with_cache_reference(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    is_neox: bool,
+    eps: float = 1e-6,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference implementation for the cache-based fused QK norm + RoPE path."""
+    head_dim = q.shape[-1]
+    rope_dim = cos_sin_cache.shape[-1]
+    positions = positions.flatten()
+    flat_tokens = positions.numel()
+
+    assert rope_dim % 2 == 0
+    assert rope_dim <= head_dim
+
+    cos_cache, sin_cache = cos_sin_cache.chunk(2, dim=-1)
+    cos = cos_cache[positions].to(q.dtype)
+    sin = sin_cache[positions].to(q.dtype)
+
+    q_view = q.reshape(flat_tokens, -1, head_dim)
+    k_view = k.reshape(flat_tokens, -1, head_dim)
+
+    q_norm = llama_rms_norm(q_view, q_weight, eps)
+    k_norm = llama_rms_norm(k_view, k_weight, eps)
+
+    q_rot = q_norm[..., :rope_dim]
+    q_pass = q_norm[..., rope_dim:]
+    q_rot = apply_rotary_emb_native(q_rot, cos, sin, is_neox)
+    q_out = torch.cat((q_rot, q_pass), dim=-1).reshape(q.shape)
+
+    k_rot = k_norm[..., :rope_dim]
+    k_pass = k_norm[..., rope_dim:]
+    k_rot = apply_rotary_emb_native(k_rot, cos, sin, is_neox)
+    k_out = torch.cat((k_rot, k_pass), dim=-1).reshape(k.shape)
+
+    return q_out, k_out
 
 
 @pytest.mark.parametrize("num_tokens", [1, 7, 32, 128])
@@ -507,6 +550,81 @@ def test_fused_qk_norm_rope_fp8_e4m3(
     # Compare results - use relaxed tolerance for FP8
     # FP8 has limited precision, so we need higher tolerance
     torch.testing.assert_close(qkv.to(torch.float32), output_ref, rtol=5e-2, atol=5e-2)
+
+
+@pytest.mark.parametrize(
+    "use_4d,batch_size,seq_len,num_qo_heads,num_kv_heads,head_dim,rope_dim,is_neox,dtype,position_dtype",
+    [
+        (False, 3, None, 4, 2, 64, 32, False, torch.bfloat16, torch.int32),
+        (False, 5, None, 8, 4, 128, 64, True, torch.float16, torch.int64),
+        (True, 2, 4, 16, 4, 128, 128, False, torch.bfloat16, torch.int32),
+        (True, 1, 8, 32, 8, 256, 128, True, torch.float16, torch.int64),
+    ],
+)
+def test_fused_qk_norm_rope_with_cache(
+    use_4d,
+    batch_size,
+    seq_len,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    rope_dim,
+    is_neox,
+    dtype,
+    position_dtype,
+):
+    """Test fused QK norm + RoPE with a precomputed cos/sin cache."""
+    torch.random.manual_seed(42)
+
+    assert rope_dim <= head_dim
+
+    if use_4d:
+        assert seq_len is not None
+        q = torch.randn(
+            batch_size, seq_len, num_qo_heads, head_dim, dtype=dtype, device=device
+        )
+        k = torch.randn(
+            batch_size, seq_len, num_kv_heads, head_dim, dtype=dtype, device=device
+        )
+        num_tokens = batch_size * seq_len
+    else:
+        q = torch.randn(batch_size, num_qo_heads, head_dim, dtype=dtype, device=device)
+        k = torch.randn(batch_size, num_kv_heads, head_dim, dtype=dtype, device=device)
+        num_tokens = batch_size
+
+    q_weight = torch.randn(head_dim, dtype=dtype, device=device)
+    k_weight = torch.randn(head_dim, dtype=dtype, device=device)
+    positions = torch.arange(num_tokens, dtype=position_dtype, device=device)
+    cos_sin_cache = create_cos_sin_cache(rope_dim, max_position=num_tokens + 1)
+
+    q_ref, k_ref = fused_qk_norm_rope_with_cache_reference(
+        q.clone().float(),
+        k.clone().float(),
+        q_weight.clone().float(),
+        k_weight.clone().float(),
+        cos_sin_cache,
+        positions,
+        is_neox,
+    )
+
+    q_test = q.clone()
+    k_test = k.clone()
+    sgl_kernel.fused_qk_norm_rope_with_cos_sin_cache_inplace(
+        q_test,
+        k_test,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        positions,
+        is_neox,
+    )
+
+    torch.testing.assert_close(
+        q_test, q_ref.to(dtype), rtol=precision[dtype], atol=precision[dtype]
+    )
+    torch.testing.assert_close(
+        k_test, k_ref.to(dtype), rtol=precision[dtype], atol=precision[dtype]
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_fused_qk_norm_rope.py
+++ b/tests/test_fused_qk_norm_rope.py
@@ -627,5 +627,106 @@ def test_fused_qk_norm_rope_with_cache(
     )
 
 
+@pytest.mark.parametrize(
+    "use_4d,batch_size,seq_len,num_qo_heads,num_kv_heads,head_dim,rope_dim,is_neox,dtype,position_dtype,last_dim_padding",
+    [
+        (False, 3, None, 4, 2, 64, 32, False, torch.bfloat16, torch.int32, 16),
+        (True, 2, 4, 16, 4, 128, 128, True, torch.float16, torch.int64, 32),
+    ],
+)
+def test_fused_qk_norm_rope_with_cache_last_dim_strided(
+    use_4d,
+    batch_size,
+    seq_len,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    rope_dim,
+    is_neox,
+    dtype,
+    position_dtype,
+    last_dim_padding,
+):
+    """Test fused QK norm + RoPE with non-contiguous Q/K views."""
+    torch.random.manual_seed(42)
+
+    assert rope_dim <= head_dim
+
+    if use_4d:
+        assert seq_len is not None
+        q_storage = torch.randn(
+            batch_size,
+            seq_len,
+            num_qo_heads,
+            head_dim + last_dim_padding,
+            dtype=dtype,
+            device=device,
+        )
+        k_storage = torch.randn(
+            batch_size,
+            seq_len,
+            num_kv_heads,
+            head_dim + last_dim_padding,
+            dtype=dtype,
+            device=device,
+        )
+        num_tokens = batch_size * seq_len
+    else:
+        q_storage = torch.randn(
+            batch_size,
+            num_qo_heads,
+            head_dim + last_dim_padding,
+            dtype=dtype,
+            device=device,
+        )
+        k_storage = torch.randn(
+            batch_size,
+            num_kv_heads,
+            head_dim + last_dim_padding,
+            dtype=dtype,
+            device=device,
+        )
+        num_tokens = batch_size
+
+    q = q_storage[..., :head_dim]
+    k = k_storage[..., :head_dim]
+    assert q.stride(-1) == 1
+    assert k.stride(-1) == 1
+    assert not q.is_contiguous()
+    assert not k.is_contiguous()
+
+    q_weight = torch.randn(head_dim, dtype=dtype, device=device)
+    k_weight = torch.randn(head_dim, dtype=dtype, device=device)
+    positions = torch.arange(num_tokens, dtype=position_dtype, device=device)
+    cos_sin_cache = create_cos_sin_cache(rope_dim, max_position=num_tokens + 1)
+
+    q_ref, k_ref = fused_qk_norm_rope_with_cache_reference(
+        q.clone().float(),
+        k.clone().float(),
+        q_weight.clone().float(),
+        k_weight.clone().float(),
+        cos_sin_cache,
+        positions,
+        is_neox,
+    )
+
+    sgl_kernel.fused_qk_norm_rope_with_cos_sin_cache_inplace(
+        q,
+        k,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        positions,
+        is_neox,
+    )
+
+    torch.testing.assert_close(
+        q, q_ref.to(dtype), rtol=precision[dtype], atol=precision[dtype]
+    )
+    torch.testing.assert_close(
+        k, k_ref.to(dtype), rtol=precision[dtype], atol=precision[dtype]
+    )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
### Motivation
Add `fused_qk_norm_rope_with_cos_sin_cache_inplace` to fuse QK RMSNorm + RoPE with a precomputed cos/sin cache for the FLUX model.
Note: There is a legacy SYCL Kernel for Fused QK Norm + RoPE which uses packed QKV and YaRN RoPE frequencies computed on the fly, rather than read from a cache. To maintain code readability, no implementation reuse is enforced. Furthermore, considering that the current SGLANG does not use this legacy SYCL kernel, it will be retained for now and may be removed in the future.

Generated by Agent.

### Test
Added `test_fused_qk_norm_rope_with_cache`, `test_fused_qk_norm_rope_with_cache_last_dim_strided` and benchmarks.
Overall average speedup: 5.74x
Overall max speedup:     22.32x
Overall min speedup:     3.05x

