### PR TITLE
tests: stop-at-first-failure and disable tensor sampling in reprs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,14 @@
 import pytest
 import torch
 
+# Disable tensor content sampling in reprs. pytest's saferepr calls
+# `torch/_tensor_str.py:get_summarized_data` when formatting a failed assertion,
+# which reads the tensor's data — for an XPU tensor whose backing buffer has
+# been left in a bad state by a kernel failure, that read SIGSEGVs the process
+# and hides the real assertion. threshold=0 makes torch print the tensor's
+# metadata only, keeping the traceback intact.
+torch.set_printoptions(threshold=0)
+
 
 # This fixture ensures the torch defaults don't get left in modified states between
 # tests (e.g., when a test fails before restoring the original value), which

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,8 +75,13 @@ def run_unittest_files(files: List[TestFile], timeout_per_file: float):
             )
             tic = time.perf_counter()
 
+            # Run via `pytest -x --tb=short` so the first failing parametrization
+            # stops the file. Without -x, one bad case that wedges the XPU/L0
+            # context cascades into thousands of downstream failures and can
+            # eventually SIGSEGV pytest inside saferepr on a corrupt tensor —
+            # burying the real first failure and bloating CI time.
             process = subprocess.Popen(
-                ["python3", filename],
+                ["python3", "-m", "pytest", "-x", "--tb=short", filename],
                 stdout=None,
                 stderr=None,
                 env=os.environ,


### PR DESCRIPTION
## Summary

Make failing CI runs surface the first bad test instead of a SIGSEGV-terminated wall of tracebacks (see [run 29384056553](https://github.com/sgl-project/sgl-kernel-xpu/actions/runs/29384056553/job/87253537908) — `test_moe_gemm.py` cascaded ~1500 F's in 22 min and crashed pytest).

- `tests/test_utils.py`: run each file via `pytest -x --tb=short` so one bad parametrization stops the file instead of poisoning downstream XPU state.
- `tests/conftest.py`: `torch.set_printoptions(threshold=0)` — stops `saferepr` from segfaulting on a wedged XPU tensor during failure formatting.

No new deps. No overhead on green runs. Red runs get faster.

## Test plan

- [ ] Green run wall-clock unchanged.
- [ ] Force a failure — CI reports first failing parametrization with a short traceback, no SIGSEGV.
