### PR TITLE
ci(xpu): pin GPU compute driver + retry infra crashes

### DIFF
--- a/Dockerfile.xpu_kernel
+++ b/Dockerfile.xpu_kernel
@@ -19,13 +19,40 @@ ARG SG_LANG_BRANCH=main
 ARG SG_LANG_KERNEL_REPO=https://github.com/sgl-project/sgl-kernel-xpu.git
 ARG SG_LANG_KERNEL_BRANCH=main
 
-# Install the latest UMD driver for SYCL-TLA
+# Pin the compute UMD + IGC. The kobuk-team PPA is rolling; an untested build
+# mismatched the host xe KMD and faulted libze_intel_gpu.so on the B580 runner.
+# Must stay in lockstep with the host KMD; override via --build-arg per workflow.
+ARG COMPUTE_RUNTIME_VERSION=26.05.37020.3
+ARG IGC_VERSION=2.28.4+20760
+ARG GMM_VERSION=22.9.0
 RUN apt-get install -y software-properties-common && \
     add-apt-repository -y ppa:kobuk-team/intel-graphics && \
     apt-get update  && \
-    apt-get install -y libze-intel-gpu1 libze1 intel-metrics-discovery intel-opencl-icd clinfo intel-gsc && \
+    # Loader + media/metrics from the PPA; GPU driver itself is pinned below.
+    apt-get install -y libze1 intel-metrics-discovery clinfo intel-gsc && \
     apt-get install -y intel-media-va-driver-non-free libmfx-gen1 libvpl2 libvpl-tools libva-glx2 va-driver-all vainfo && \
-    apt-get install -y libze-dev intel-ocloc
+    apt-get install -y libze-dev && \
+    # IGC first: libze-intel-gpu1 / intel-opencl-icd depend on it.
+    cd /tmp && \
+    igc_url="https://github.com/intel/intel-graphics-compiler/releases/download/v${IGC_VERSION%%+*}" && \
+    cr_url="https://github.com/intel/compute-runtime/releases/download/${COMPUTE_RUNTIME_VERSION}" && \
+    curl -fsSL -O "${igc_url}/intel-igc-core-2_${IGC_VERSION}_amd64.deb" && \
+    curl -fsSL -O "${igc_url}/intel-igc-opencl-2_${IGC_VERSION}_amd64.deb" && \
+    curl -fsSL -O "${cr_url}/libze-intel-gpu1_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb" && \
+    curl -fsSL -O "${cr_url}/intel-opencl-icd_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb" && \
+    curl -fsSL -O "${cr_url}/intel-ocloc_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb" && \
+    curl -fsSL -O "${cr_url}/libigdgmm12_${GMM_VERSION}_amd64.deb" && \
+    apt-get install -y --allow-downgrades \
+        ./intel-igc-core-2_${IGC_VERSION}_amd64.deb \
+        ./intel-igc-opencl-2_${IGC_VERSION}_amd64.deb \
+        ./libigdgmm12_${GMM_VERSION}_amd64.deb \
+        ./libze-intel-gpu1_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb \
+        ./intel-opencl-icd_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb \
+        ./intel-ocloc_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb && \
+    rm -f /tmp/*.deb && \
+    # Hold so a later apt upgrade cannot pull the rolling PPA version.
+    apt-mark hold libze-intel-gpu1 intel-opencl-icd intel-ocloc libigdgmm12 \
+        intel-igc-core-2 intel-igc-opencl-2
 
 # Install Miniforge & PyTorch/Triton
 RUN curl -fsSL -v -o miniforge.sh -O https://github.com/conda-forge/miniforge/releases/download/25.1.1-0/Miniforge3-Linux-x86_64.sh && \

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,11 +13,29 @@ class TestFile:
     estimated_time: float = 60
 
 
+# Retry a signal-killed (likely GPU-faulted) test file this many times.
+MAX_INFRA_RETRIES = int(os.environ.get("SGL_KERNEL_INFRA_RETRIES", "1"))
+
+# Wait for the GPU engine reset / L0 teardown to settle before retrying.
+_XPU_RECOVER_WAIT = float(os.environ.get("SGL_KERNEL_XPU_RECOVER_WAIT", "20"))
+
+
+def _recover_xpu() -> None:
+    """Wait for the XPU to reset; log health via xpu-smi if available."""
+    time.sleep(_XPU_RECOVER_WAIT)
+    try:
+        subprocess.run(
+            ["xpu-smi", "health", "-d", "0"],
+            timeout=30,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+
 def _terminate_process_tree(process: Optional[subprocess.Popen]) -> None:
-    # On XPU the child holds a Level Zero context; leaving it alive after a
-    # timeout wedges the device for later CI jobs on the same runner. The
-    # subprocess is launched with start_new_session=True so its PID is a
-    # process-group leader — SIGKILL to that PGID reaps the whole tree.
+    # SIGKILL the whole PGID: the child owns an L0 context that wedges
+    # the XPU for later CI jobs if left alive.
     if process is None or process.poll() is not None:
         return
     try:
@@ -75,11 +93,8 @@ def run_unittest_files(files: List[TestFile], timeout_per_file: float):
             )
             tic = time.perf_counter()
 
-            # Run via `pytest -x --tb=short` so the first failing parametrization
-            # stops the file. Without -x, one bad case that wedges the XPU/L0
-            # context cascades into thousands of downstream failures and can
-            # eventually SIGSEGV pytest inside saferepr on a corrupt tensor —
-            # burying the real first failure and bloating CI time.
+            # -x stops at first failure so an XPU-wedging case does not
+            # cascade into thousands of downstream failures / a saferepr SIGSEGV.
             process = subprocess.Popen(
                 ["python3", "-m", "pytest", "-x", "--tb=short", filename],
                 stdout=None,
@@ -96,20 +111,53 @@ def run_unittest_files(files: List[TestFile], timeout_per_file: float):
             )
             return process.returncode
 
+        # Negative return code = killed by signal (GPU fault); retry.
+        # Positive return code = real test failure; do not retry.
+        crashed = False
+        for attempt in range(MAX_INFRA_RETRIES + 1):
+            try:
+                ret_code = run_with_timeout(
+                    run_one_file, args=(filename,), timeout=timeout_per_file
+                )
+            except TimeoutError:
+                _terminate_process_tree(process)
+                time.sleep(5)
+                print(
+                    f"\nTimeout after {timeout_per_file} seconds when running {filename}\n",
+                    flush=True,
+                )
+                crashed = True
+                break
+
+            if ret_code >= 0:
+                break
+
+            if attempt < MAX_INFRA_RETRIES:
+                print(
+                    f"\n{filename} was killed by signal {-ret_code} "
+                    f"(likely a GPU/driver fault, not a test failure). "
+                    f"Recovering device and retrying "
+                    f"(attempt {attempt + 1}/{MAX_INFRA_RETRIES}).\n",
+                    flush=True,
+                )
+                _recover_xpu()
+            else:
+                print(
+                    f"\n{filename} still crashing with signal {-ret_code} after "
+                    f"{MAX_INFRA_RETRIES} retry(ies); treating as failure.\n",
+                    flush=True,
+                )
+
+        if crashed:
+            success = False
+            break
+
         try:
-            ret_code = run_with_timeout(
-                run_one_file, args=(filename,), timeout=timeout_per_file
-            )
             assert (
                 ret_code == 0
             ), f"expected return code 0, but {filename} returned {ret_code}"
-        except TimeoutError:
-            _terminate_process_tree(process)
-            time.sleep(5)
-            print(
-                f"\nTimeout after {timeout_per_file} seconds when running {filename}\n",
-                flush=True,
-            )
+        except AssertionError as e:
+            print(f"\n{e}\n", flush=True)
             success = False
             break
 


### PR DESCRIPTION
## Summary

The B580 (Battlemage) runner intermittently failed PR CI on a *different* test file each attempt (`test_moe_gemm.py` SIGSEGV one run, `test_flash_attention.py` SIGABRT the next) with no code change. Root cause was the CI image, not the tests.

- **Pin the Level Zero compute UMD + matching IGC** (`Dockerfile.xpu_kernel`). The rolling `kobuk-team/intel-graphics` PPA + `docker build --no-cache` was silently pulling whatever was newest; build `26.22.38646` mismatched the host `xe` KMD and threw a general protection fault in `libze_intel_gpu.so`, sending the GPU into repeated engine resets. Now fetching known-good `.deb`s from the permanent `intel/compute-runtime` and `intel/intel-graphics-compiler` release archives, `apt-mark hold`ing them, and defaulting to the runner host's versions (overridable via `--build-arg COMPUTE_RUNTIME_VERSION` / `IGC_VERSION`).
- **Retry signal-killed test files once** (`tests/test_utils.py`). `run_unittest_files` was treating any non-zero exit as a test failure. A *negative* exit code means the file was killed by a signal (GPU/driver fault), not an assertion failure, so retry after letting the device settle. Real test failures (positive exit code) are never retried.

## Test plan

- [x] Validated on `bmg-754`: 5x cases-only CI runs + 3x full CI (cases + benchmarks, fresh build on run 1) — all green, zero crashes (vs 100% failure before).
- [ ] Reviewer: confirm the pinned `COMPUTE_RUNTIME_VERSION` / `IGC_VERSION` / `GMM_VERSION` in `Dockerfile.xpu_kernel` still match `dpkg -l libze-intel-gpu1` on the current runner host.
- [ ] Reviewer: sanity-check that `MAX_INFRA_RETRIES=1` is acceptable — a genuinely crashing kernel gets one extra run before we fail the job.