### PR TITLE
Make bias optional for moe_fused_gate

### DIFF
--- a/benchmark/bench_moe_fused_gate.py
+++ b/benchmark/bench_moe_fused_gate.py
@@ -10,7 +10,7 @@ all_results = []
 def biased_grouped_topk_native(
     hidden_states: torch.Tensor,
     gating_output: torch.Tensor,
-    correction_bias: torch.Tensor,
+    correction_bias: Optional[torch.Tensor],
     topk: int,
     renormalize: bool,
     num_expert_group: Optional[int] = None,
@@ -31,7 +31,9 @@ def biased_grouped_topk_native(
         raise ValueError(f"Unknown scoring_func: {scoring_func}")
     num_token = scores.shape[0]
     num_experts = scores.shape[1]
-    scores_for_choice = scores.view(num_token, -1) + correction_bias.unsqueeze(0)
+    scores_for_choice = scores.view(num_token, -1)
+    if correction_bias is not None:
+        scores_for_choice = scores_for_choice + correction_bias.unsqueeze(0)
     group_sum_count = 1 if scoring_func == "softmax" else 2
     group_scores = (
         scores_for_choice.view(num_token, num_expert_group, -1)
@@ -85,7 +87,12 @@ def biased_grouped_topk_native(
 
 
 def biased_grouped_topk_org(
-    scores, bias, num_expert_group, topk_group, topk, scoring_func
+    scores,
+    bias: Optional[torch.Tensor],
+    num_expert_group,
+    topk_group,
+    topk,
+    scoring_func,
 ):
     return biased_grouped_topk_native(
         scores,
@@ -103,7 +110,12 @@ def biased_grouped_topk_org(
 
 
 def biased_grouped_topk_org_kernel(
-    scores, bias, num_expert_group, topk_group, topk, scoring_func
+    scores,
+    bias: Optional[torch.Tensor],
+    num_expert_group,
+    topk_group,
+    topk,
+    scoring_func,
 ):
     return moe_fused_gate(
         input_tensor=scores,
@@ -160,7 +172,8 @@ def benchmark(seq_length, provider):
 
     scores = torch.randn((seq_length, num_experts), device=device, dtype=dtype)
     if scoring_func == "softmax":
-        bias = torch.zeros(num_experts, device=device, dtype=dtype)
+        # grouped topk with softmax does not use correction bias
+        bias = None
     else:
         bias = torch.rand(num_experts, device=device, dtype=dtype)
 
@@ -170,7 +183,7 @@ def benchmark(seq_length, provider):
         ms, min_ms, max_ms = triton.testing.do_bench(
             lambda: biased_grouped_topk_org(
                 scores.clone(),
-                bias.clone(),
+                None if bias is None else bias.clone(),
                 num_expert_group,
                 topk_group,
                 topk,
@@ -182,7 +195,7 @@ def benchmark(seq_length, provider):
         ms, min_ms, max_ms = triton.testing.do_bench(
             lambda: biased_grouped_topk_org_kernel(
                 scores.clone(),
-                bias.clone(),
+                None if bias is None else bias.clone(),
                 num_expert_group,
                 topk_group,
                 topk,

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -321,7 +321,7 @@ torch::Tensor swiglu_gpt_oss_sigmoid_alpha(torch::Tensor x, double alpha, double
 
 std::vector<at::Tensor> moe_fused_gate(
     at::Tensor& input,
-    at::Tensor& bias,
+    const std::optional<at::Tensor>& bias,
     int64_t num_expert_group,
     int64_t topk_group,
     int64_t topk,

--- a/python/sgl_kernel/moe.py
+++ b/python/sgl_kernel/moe.py
@@ -100,7 +100,7 @@ def moe_sum(
 
 def moe_fused_gate(
     input_tensor,
-    bias,
+    bias: Optional[torch.Tensor],
     num_expert_group,
     topk_group,
     topk,

--- a/src/sycl/MoE_fused_gate.cpp
+++ b/src/sycl/MoE_fused_gate.cpp
@@ -122,7 +122,7 @@ struct moe_fused_gate_impl {
     int64_t token_row_chunk_offset = token_row_offset + thread_id * params_.VPT;
 
     auto* thread_row_ptr = input_ + token_row_chunk_offset;
-    auto* bias_ptr = bias_ + thread_id * params_.VPT;
+    auto* bias_ptr = bias_ ? (bias_ + thread_id * params_.VPT) : nullptr;
 
     T row_chunk[MAX_VPT];
     T bias_chunk[MAX_VPT];
@@ -130,7 +130,6 @@ struct moe_fused_gate_impl {
 #pragma unroll
       for (int i = 0; i < params_.VPT; ++i) {
         row_chunk[i] = thread_row_ptr[i];
-        bias_chunk[i] = bias_ptr[i];
       }
 
       if (scoring_func_ == static_cast<int32_t>(ScoringFunc::kSigmoid)) {
@@ -142,7 +141,7 @@ struct moe_fused_gate_impl {
 ////////////////////// Add Bias //////////////////////
 #pragma unroll
       for (int i = 0; i < params_.VPT; ++i) {
-        bias_chunk[i] = row_chunk[i] + bias_chunk[i];
+        bias_chunk[i] = row_chunk[i] + (bias_ptr ? bias_ptr[i] : T(0));
       }
     }
     ////////////////////// Exclude Groups //////////////////////
@@ -355,7 +354,7 @@ struct KernelParams {
 template <typename T, int VPT, int NUM_EXPERTS, int THREADS_PER_ROW>
 void moe_fused_gate_kernel(
     const torch::Tensor& input,
-    const torch::Tensor& bias,
+    const T* bias_ptr,
     torch::Tensor& output,
     torch::Tensor& indices,
     int64_t num_rows,
@@ -367,7 +366,6 @@ void moe_fused_gate_kernel(
     double routed_scaling_factor,
     bool apply_routed_scaling_factor_on_output) {
   auto input_ptr = reinterpret_cast<T*>(input.data_ptr());
-  auto bias_ptr = reinterpret_cast<T*>(bias.data_ptr());
   auto output_ptr = reinterpret_cast<float*>(output.data_ptr());
   auto indices_ptr = reinterpret_cast<int32_t*>(indices.data_ptr());
 
@@ -406,7 +404,7 @@ void moe_fused_gate_kernel(
     constexpr int VPT = (EXPERTS) / (EXPERT_GROUP);           \
     moe_fused_gate_kernel<T, VPT, (EXPERTS), (EXPERT_GROUP)>( \
         input,                                                \
-        bias,                                                 \
+        bias_ptr,                                             \
         output,                                               \
         indices,                                              \
         num_rows,                                             \
@@ -432,7 +430,7 @@ struct KernelParamsDynamic {
 template <typename T>
 void moe_fused_gate_kernel_dynamic(
     const torch::Tensor& input,
-    const torch::Tensor& bias,
+    const T* bias_ptr,
     torch::Tensor& output,
     torch::Tensor& indices,
     int64_t num_rows,
@@ -445,7 +443,6 @@ void moe_fused_gate_kernel_dynamic(
     double routed_scaling_factor,
     bool apply_routed_scaling_factor_on_output) {
   auto input_ptr = reinterpret_cast<T*>(input.data_ptr());
-  auto bias_ptr = reinterpret_cast<T*>(bias.data_ptr());
   auto output_ptr = reinterpret_cast<float*>(output.data_ptr());
   auto indices_ptr = reinterpret_cast<int32_t*>(indices.data_ptr());
   int32_t num_experts = input.size(1);
@@ -487,7 +484,7 @@ void moe_fused_gate_kernel_dynamic(
 //------------------------------------------------------------------------------
 std::vector<at::Tensor> moe_fused_gate(
     at::Tensor& input,
-    at::Tensor& bias,
+    const std::optional<at::Tensor>& bias,
     int64_t num_expert_group,
     int64_t topk_group,
     int64_t topk,
@@ -496,7 +493,16 @@ std::vector<at::Tensor> moe_fused_gate(
     bool renormalize,
     double routed_scaling_factor,
     bool apply_routed_scaling_factor_on_output) {
-  TORCH_CHECK(input.dtype() == bias.dtype(), "input and bias should have the same dtype");
+  if (bias.has_value()) {
+    TORCH_CHECK(input.dtype() == bias->dtype(), "input and bias should have the same dtype");
+    TORCH_CHECK(bias->dim() == 1, "bias must be a 1D tensor when provided");
+    TORCH_CHECK(
+        bias->size(0) == input.size(1),
+        "bias size must match the number of experts, but got ",
+        bias->size(0),
+        " vs ",
+        input.size(1));
+  }
   TORCH_CHECK(
       scoring_func == static_cast<int64_t>(ScoringFunc::kSigmoid) ||
           scoring_func == static_cast<int64_t>(ScoringFunc::kSoftmax),
@@ -537,6 +543,8 @@ std::vector<at::Tensor> moe_fused_gate(
 
   SYCL_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::BFloat16, at::ScalarType::Half, input.scalar_type(), "moe_sum_reduce_impl", [&]() {
+        auto bias_ptr = bias.has_value() ? reinterpret_cast<const scalar_t*>(bias->data_ptr())
+                                         : static_cast<const scalar_t*>(nullptr);
         switch (num_experts) {
           case 512:
             if (num_expert_group == 16) {
@@ -565,7 +573,7 @@ std::vector<at::Tensor> moe_fused_gate(
           // currently only support num_experts / num_expert_group <= 32 for dynamic kernels
           moe_fused_gate_kernel_dynamic<scalar_t>(
               input,
-              bias,
+              bias_ptr,
               output,
               indices,
               num_rows,

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -80,7 +80,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def("swiglu_gpt_oss_sigmoid_alpha(Tensor x, float alpha, float limit) -> Tensor");
   m.impl("swiglu_gpt_oss_sigmoid_alpha", torch::kXPU, &swiglu_gpt_oss_sigmoid_alpha);
   m.def(
-      "moe_fused_gate(Tensor input, Tensor bias, int num_expert_group, int topk_group, int topk, int "
+      "moe_fused_gate(Tensor input, Tensor? bias, int num_expert_group, int topk_group, int topk, int "
       "num_fused_shared_experts, int scoring_func, bool renormalize, float routed_scaling_factor, bool "
       "apply_routed_scaling_factor_on_output) -> "
       "(Tensor[])");

--- a/tests/test_moe_fused_gate.py
+++ b/tests/test_moe_fused_gate.py
@@ -17,7 +17,7 @@ from sgl_kernel import moe_fused_gate
 def biased_grouped_topk_native(
     hidden_states: torch.Tensor,
     gating_output: torch.Tensor,
-    correction_bias: torch.Tensor,
+    correction_bias: Optional[torch.Tensor],
     topk: int,
     renormalize: bool,
     num_expert_group: Optional[int] = None,
@@ -39,7 +39,9 @@ def biased_grouped_topk_native(
 
     num_token = scores.shape[0]
     num_experts = scores.shape[1]
-    scores_for_choice = scores.view(num_token, -1) + correction_bias.unsqueeze(0)
+    scores_for_choice = scores.view(num_token, -1)
+    if correction_bias is not None:
+        scores_for_choice = scores_for_choice + correction_bias.unsqueeze(0)
     group_sum_count = 1 if scoring_func == "softmax" else 2
     group_scores = (
         scores_for_choice.view(num_token, num_expert_group, -1)
@@ -125,8 +127,8 @@ def test_moe_fused_gate_combined(
     tensor = torch.rand((seq_length, num_experts), dtype=dtype, device="xpu")
     scores = tensor.clone()
     if scoring_func == "softmax":
-        # grouped_topk with softmax activation doesn't have bias
-        bias = torch.zeros(num_experts, dtype=dtype, device="xpu")
+        # grouped_topk with softmax activation does not use correction bias.
+        bias = None
     else:
         bias = torch.rand(num_experts, dtype=dtype, device="xpu")
     topk = topk + num_fused_shared_experts


### PR DESCRIPTION
"grouped_topk" does not have bias, so make it optional could remove unnecessary allocation of zero bias.