### PR TITLE
Replace chunk prefill with AppendKV FMHA prefill

### DIFF
--- a/benchmark/bench_flash_attn.py
+++ b/benchmark/bench_flash_attn.py
@@ -96,11 +96,9 @@ num_heads_q = [16]
 num_heads_kv = [4, 8]
 kv_seq_length_range = [4096]
 page_size_range = [0, 128]
-# KV cache element type: "bf16" (default) or fp8. FP8 has two formats,
-# e5m2 and e4m3; both are exercised ("fp8_e4m3" / "fp8_e5m2"), dequantized
-# in-kernel via per-tensor k_descale / v_descale. fp8 only runs on the paged
-# path.
-kv_dtype_range = ["bf16", "fp8_e4m3", "fp8_e5m2"]
+# KV cache element type: "bf16" (default) or fp8. FP8 is exercised only on
+# the supported paged decode path; prefill uses bf16 KV cache.
+kv_dtype_range = ["bf16", "fp8_e4m3"]
 configs = list(
     filter(
         lambda cfg: (
@@ -116,9 +114,12 @@ configs = list(
             and (cfg[9] != 0 or not cfg[2])
             # Condition 6: sink is only supported for head_size == 64
             and (not cfg[2] or cfg[5] == 64)
-            # Condition 7: fp8 KV cache requires the paged path and is exercised
-            # without sinks / local masking (matches the supported fp8 path)
-            and (cfg[10] == "bf16" or (cfg[9] != 0 and not cfg[2] and not cfg[1]))
+            # Condition 7: fp8 KV cache requires the paged decode path and is
+            # exercised without sinks / local masking.
+            and (
+                cfg[10] == "bf16"
+                or (cfg[4] == 1 and cfg[9] != 0 and not cfg[2] and not cfg[1])
+            )
         ),
         [
             cfg
@@ -255,9 +256,7 @@ def benchmark(
     if not local:
         window_size = (-1, -1)
     else:
-        window_size = tuple(
-            int(value) for value in torch.randint(0, kv_seq_length, (2,)).tolist()
-        )
+        window_size = (kv_seq_length // 2, kv_seq_length // 2)
 
     sinks = torch.randn(num_heads_q, device=device, dtype=dtype) if use_sinks else None
 

--- a/include/sgl_flash_kernel_ops.h
+++ b/include/sgl_flash_kernel_ops.h
@@ -74,7 +74,10 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    std::optional<at::Tensor>& out_);
+    std::optional<at::Tensor>& out_,
+    std::optional<const at::Tensor>& k_new_,
+    std::optional<const at::Tensor>& v_new_,
+    std::optional<const at::Tensor>& cu_seqlens_k_new_);
 
 void flash_mla_decode(
     torch::Tensor& out,

--- a/python/sgl_kernel/flash_attn.py
+++ b/python/sgl_kernel/flash_attn.py
@@ -264,6 +264,12 @@ def flash_attn_with_kvcache(
     if cache_seqlens is not None:
         assert cache_seqlens.size(0) + 1 == cu_seqlens_q.size(0)
         cu_seqlens_k = cache_seqlens
+    native_max_seqlen_k = max_seqlen_k
+    if native_max_seqlen_k is None or native_max_seqlen_k == 0:
+        if k is not None:
+            native_max_seqlen_k = k.shape[1] if k.dim() == 4 else (max_seqlen_q or 1)
+        else:
+            native_max_seqlen_k = 1
     out, softmax_lse, *rest = torch.ops.sgl_kernel.fwd.default(
         q,
         k_cache,
@@ -272,7 +278,7 @@ def flash_attn_with_kvcache(
         cu_seqlens_q,
         cu_seqlens_k,
         max_seqlen_q,
-        1,
+        native_max_seqlen_k,
         page_table,
         cache_batch_idx,
         cache_leftpad,
@@ -294,6 +300,9 @@ def flash_attn_with_kvcache(
         pack_gqa,
         sm_margin,
         out,
+        k,
+        v,
+        cu_seqlens_k_new,
     )
     return (out, softmax_lse, *rest) if return_softmax_lse else out
 

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -40,8 +40,8 @@
 
 namespace {
 
-const float*
-get_per_tensor_descale_ptr(const at::Tensor& descale, const at::Tensor& ref, const char* name, const char* context) {
+void* get_per_tensor_descale_ptr(
+    const at::Tensor& descale, const at::Tensor& ref, const char* name, const char* context) {
   TORCH_CHECK(descale.scalar_type() == at::ScalarType::Float, name, " must be float32");
   TORCH_CHECK(
       descale.device() == ref.device(),
@@ -74,9 +74,8 @@ get_per_tensor_descale_ptr(const at::Tensor& descale, const at::Tensor& ref, con
 namespace decode {
 
 // Non-paged (contiguous ragged KV) decode entry. Dedicated decode path: it
-// drives the decode kernel (FmhaDecodeRunner with PagedKV = false) rather than
-// reusing the prefill kernel, so the single-query decode batches selected by the
-// chunkprefill dispatcher run on the decode-optimized kernel. The non-paged
+// drives the decode kernel (FmhaDecodeRunner with PagedKV = false), so pure
+// single-query decode batches run on the decode-optimized kernel. The non-paged
 // decode kernel carries its own tile configuration (FMHA_DECODE_TILED_KV_NP_*)
 // so it can be tuned independently of both the paged decode and prefill paths.
 std::vector<at::Tensor> mha_fwd_nopage(
@@ -93,8 +92,7 @@ std::vector<at::Tensor> mha_fwd_nopage(
     int window_size_left,
     int window_size_right,
     float const softcap,
-    std::optional<at::Tensor> out_opt,
-    std::optional<at::Tensor> skip_batch_mask_opt) {
+    std::optional<at::Tensor> out_opt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
       q_type == at::ScalarType::Half || q_type == at::ScalarType::BFloat16,
@@ -178,13 +176,12 @@ std::vector<at::Tensor> mha_fwd_nopage(
   params.o_row_stride = out.stride(-3);
   params.o_head_stride = out.stride(-2);
 
-  // Per-batch skip mask for the chunkprefill two-launch path (may be null).
-  params.skip_batch_mask_ptr = skip_batch_mask_opt.has_value() ? skip_batch_mask_opt->data_ptr() : nullptr;
-
   params.cu_seqlens_q = cu_seqlens_q.data_ptr<int>();
   params.cu_seqlens_k = cu_seqlens_k.data_ptr<int>();
   // No "new" KV: the whole sequence lives in the contiguous cache buffer, so the
   // decode kernel reads everything from the K/V cache pointers (knew = 0).
+  params.knew_ptr = nullptr;
+  params.vnew_ptr = nullptr;
   params.cu_seqlens_knew = nullptr;
   params.seqlen_knew = 0;
   params.total_knew = 0;
@@ -213,6 +210,8 @@ std::vector<at::Tensor> mha_fwd_nopage(
   }
   params.softcap = softcap;
   params.p_dropout = 1.f;
+  params.is_e4m3 = false;
+  params.is_e5m2 = false;
 
   // Decode never needs a causal mask (each selected batch has seqlen_q <= 1, so
   // a single query attends to the full cache); sliding-window/local masking is
@@ -299,10 +298,7 @@ std::vector<at::Tensor> mha_fwd(
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    // chunkprefill two-launch path: pre-allocated shared output, and a per-batch
-    // bool mask (length = batch) whose true entries are skipped by the kernel.
-    std::optional<at::Tensor> out_opt = std::nullopt,
-    std::optional<at::Tensor> skip_batch_mask_opt = std::nullopt) {
+    std::optional<at::Tensor> out_opt = std::nullopt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
       q_type == at::ScalarType::Half || q_type == at::ScalarType::BFloat16,
@@ -311,9 +307,6 @@ std::vector<at::Tensor> mha_fwd(
 
   // FP8 KV cache: Q stays bf16/fp16 while K/V cache may be fp8 (e4m3 or e5m2).
   // The decode mainloop dequantizes K/V with per-tensor k_descale/v_descale.
-  // When launched as the decode sub-kernel of a pure-prefill chunkprefill batch
-  // the descale pointers are still forwarded; the kernel simply skips every
-  // batch.
   bool const is_e4m3_kv = k.scalar_type() == at::ScalarType::Float8_e4m3fn;
   bool const is_e5m2_kv = k.scalar_type() == at::ScalarType::Float8_e5m2;
   bool const is_fp8_kv = is_e4m3_kv || is_e5m2_kv;
@@ -329,9 +322,7 @@ std::vector<at::Tensor> mha_fwd(
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(k);
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(v);
 
-  // Non-paged (page_table == nullopt) decode sub-launch of chunkprefill. Uses
-  // the decode-specific non-paged entry (decode::mha_fwd_nopage) so it can carry
-  // its own parameter configuration independently of the prefill path.
+  // Non-paged (page_table == nullopt) decode.
   if (!page_table.has_value()) {
     return mha_fwd_nopage(
         q,
@@ -347,8 +338,7 @@ std::vector<at::Tensor> mha_fwd(
         window_size_left,
         window_size_right,
         softcap,
-        std::move(out_opt),
-        std::move(skip_batch_mask_opt));
+        std::move(out_opt));
   }
 
   TORCH_CHECK(page_table.value().dtype() == torch::kInt32, "page_table must have dtype torch.int32");
@@ -511,13 +501,13 @@ std::vector<at::Tensor> mha_fwd(
   params.o_row_stride = out.stride(-3);
   params.o_head_stride = out.stride(-2);
 
-  // Per-batch skip mask for the chunkprefill two-launch path
-  // (vllm-xpu-kernels#218). When provided, decode skips batches where
-  // mask[idx_b] == true (i.e. the prefill rows).
-  params.skip_batch_mask_ptr = skip_batch_mask_opt.has_value() ? skip_batch_mask_opt->data_ptr() : nullptr;
-
   params.cu_seqlens_q = cu_seqlens_q.data_ptr<int>();
   params.cu_seqlens_k = cu_seqlens_k.data_ptr<int>();
+  params.knew_ptr = nullptr;
+  params.vnew_ptr = nullptr;
+  params.cu_seqlens_knew = nullptr;
+  params.seqlen_knew = 0;
+  params.total_knew = 0;
   params.num_kv_splits = num_kv_splits;
 
   // Softmax sum
@@ -667,10 +657,7 @@ std::vector<at::Tensor> mha_fwd(
 
 namespace prefill {
 
-// Non-paged (contiguous ragged KV) prefill entry. Drives both the prefill and
-// the decode sub-launches of the no-page chunkprefill two-launch path: the
-// caller passes a shared output (out_opt) and a per-batch skip mask
-// (skip_batch_mask_opt) selecting which batches this launch processes.
+// Non-paged (contiguous ragged KV) prefill entry.
 std::vector<at::Tensor> mha_fwd_nopage(
     const at::Tensor& q,             // (total_q, h, d)
     const at::Tensor& k,             // (total_k, h_k, d)
@@ -685,8 +672,7 @@ std::vector<at::Tensor> mha_fwd_nopage(
     int window_size_left,
     int window_size_right,
     float const softcap,
-    std::optional<at::Tensor> out_opt,
-    std::optional<at::Tensor> skip_batch_mask_opt) {
+    std::optional<at::Tensor> out_opt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
       q_type == at::ScalarType::Half || q_type == at::ScalarType::BFloat16,
@@ -768,11 +754,14 @@ std::vector<at::Tensor> mha_fwd_nopage(
   params.o_row_stride = out.stride(-3);
   params.o_head_stride = out.stride(-2);
 
-  // Per-batch skip mask for the chunkprefill two-launch path (may be null).
-  params.skip_batch_mask_ptr = skip_batch_mask_opt.has_value() ? skip_batch_mask_opt->data_ptr() : nullptr;
-
   params.cu_seqlens_q = cu_seqlens_q.data_ptr<int>();
   params.cu_seqlens_k = cu_seqlens_k.data_ptr<int>();
+  params.knew_ptr = nullptr;
+  params.vnew_ptr = nullptr;
+  params.cu_seqlens_knew = nullptr;
+  params.cache_seqlens_old = nullptr;
+  params.seqlen_knew = 0;
+  params.total_knew = 0;
 
   params.softmax_lse_ptr = softmax_lse.data_ptr();
 
@@ -884,26 +873,24 @@ std::vector<at::Tensor> mha_fwd(
     int num_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    // chunkprefill two-launch path: pre-allocated shared output, and a per-batch
-    // bool mask (length = batch) whose true entries are skipped by the kernel.
-    std::optional<at::Tensor> out_opt = std::nullopt,
-    std::optional<at::Tensor> skip_batch_mask_opt = std::nullopt) {
+    std::optional<at::Tensor> out_opt,
+    std::optional<const at::Tensor>& k_new_,
+    std::optional<const at::Tensor>& v_new_,
+    std::optional<const at::Tensor>& cu_seqlens_k_new_) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
       q_type == at::ScalarType::Half || q_type == at::ScalarType::BFloat16,
       "mha_fwd only supports Half and BFloat16, got",
       q_type);
 
-  // FP8 KV cache: Q stays bf16/fp16 while K/V cache may be fp8 (e4m3 or e5m2).
+  // FP8 KV cache: Q stays bf16/fp16 while K/V cache may be fp8 e4m3.
   // In that case per-tensor k_descale/v_descale must be supplied. Otherwise K/V
   // must match the Q dtype.
   bool const is_e4m3_kv = k.scalar_type() == at::ScalarType::Float8_e4m3fn;
-  bool const is_e5m2_kv = k.scalar_type() == at::ScalarType::Float8_e5m2;
-  bool const is_fp8_kv = is_e4m3_kv || is_e5m2_kv;
+  TORCH_CHECK(k.scalar_type() != at::ScalarType::Float8_e5m2, "fp8 e5m2 KV cache is not supported");
+  bool const is_fp8_kv = is_e4m3_kv;
   if (is_fp8_kv) {
-    TORCH_CHECK(
-        v.scalar_type() == k.scalar_type(),
-        "fp8 KV cache requires key and value to have the same fp8 dtype (both float8_e4m3fn or both float8_e5m2)");
+    TORCH_CHECK(v.scalar_type() == k.scalar_type(), "fp8 KV cache requires key and value to both use float8_e4m3fn");
     TORCH_CHECK(k_descale_.has_value() && v_descale_.has_value(), "fp8 KV cache requires k_descale and v_descale");
   } else {
     TORCH_CHECK(k.scalar_type() == q_type, "query and key must have the same dtype");
@@ -913,8 +900,11 @@ std::vector<at::Tensor> mha_fwd(
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(k);
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(v);
 
+  bool const has_new_kv = k_new_.has_value() || v_new_.has_value() || cu_seqlens_k_new_.has_value();
+
   // Non-paged (page_table == nullopt) prefill: contiguous ragged KV cache.
   if (!page_table.has_value()) {
+    TORCH_CHECK(!has_new_kv, "AppendKV requires paged KV cache");
     return mha_fwd_nopage(
         q,
         k,
@@ -929,8 +919,7 @@ std::vector<at::Tensor> mha_fwd(
         window_size_left,
         window_size_right,
         softcap,
-        std::move(out_opt),
-        std::move(skip_batch_mask_opt));
+        std::move(out_opt));
   }
 
   TORCH_CHECK(page_table.value().dtype() == torch::kInt32, "page_table must have dtype torch.int32");
@@ -1030,9 +1019,6 @@ std::vector<at::Tensor> mha_fwd(
   params.o_row_stride = out.stride(-3);
   params.o_head_stride = out.stride(-2);
 
-  // Per-batch skip mask for the chunkprefill two-launch dispatcher.
-  params.skip_batch_mask_ptr = skip_batch_mask_opt.has_value() ? skip_batch_mask_opt->data_ptr() : nullptr;
-
   params.cu_seqlens_q = cu_seqlens_q.data_ptr<int>();
   params.cu_seqlens_k = cu_seqlens_k.data_ptr<int>();
 
@@ -1060,16 +1046,10 @@ std::vector<at::Tensor> mha_fwd(
 
   params.softcap = softcap;
 
-  // FP8 KV cache: flag the kernel dispatch so the fp8 mainloop is selected.
+  // FP8 KV cache is not emitted for the copied prefill runner.
   params.is_e4m3 = is_e4m3_kv;
-  params.is_e5m2 = is_e5m2_kv;
   if (is_fp8_kv) {
-    TORCH_CHECK(
-        k_descale_.has_value() && v_descale_.has_value(), "fp8 KV cache prefill requires k_descale and v_descale");
-    // Per-tensor dequant: the kernel only dereferences one float, so accept a
-    // true scalar or a tensor whose elements are all the same repeated value.
-    params.k_scale_ptr = get_per_tensor_descale_ptr(k_descale_.value(), k, "k_descale", "fp8 KV cache prefill");
-    params.v_scale_ptr = get_per_tensor_descale_ptr(v_descale_.value(), v, "v_descale", "fp8 KV cache prefill");
+    TORCH_CHECK(false, "fp8 KV cache prefill is not supported");
   }
 
   // Set this to probability of keeping an element to simplify things.
@@ -1098,6 +1078,53 @@ std::vector<at::Tensor> mha_fwd(
   params.max_num_pages_per_seq = max_num_pages_per_seq;
   params.page_size = page_size;
   params.num_pages = num_pages;
+
+  params.knew_ptr = nullptr;
+  params.vnew_ptr = nullptr;
+  params.cu_seqlens_knew = nullptr;
+  params.cache_seqlens_old = nullptr;
+  params.seqlen_knew = 0;
+  params.total_knew = 0;
+  if (has_new_kv) {
+    TORCH_CHECK(k_new_.has_value() && v_new_.has_value(), "AppendKV requires both k_new and v_new");
+    auto const& k_new = k_new_.value();
+    auto const& v_new = v_new_.value();
+    CHECK_LAST_DIM_CONTIGUOUS_INPUT(k_new);
+    CHECK_LAST_DIM_CONTIGUOUS_INPUT(v_new);
+    TORCH_CHECK(k_new.scalar_type() == k.scalar_type(), "k_new dtype must match KV cache key dtype");
+    TORCH_CHECK(v_new.scalar_type() == v.scalar_type(), "v_new dtype must match KV cache value dtype");
+    TORCH_CHECK(k_new.dim() == 3 || k_new.dim() == 4, "k_new must be [total_k_new, h_k, d] or [b, s, h_k, d]");
+    TORCH_CHECK(v_new.dim() == k_new.dim(), "v_new rank must match k_new rank");
+    int total_knew = 0;
+    int seqlen_knew = max_seqlen_k > 0 ? max_seqlen_k : max_seqlen_q;
+    if (k_new.dim() == 3) {
+      total_knew = k_new.size(0);
+      CHECK_SHAPE(k_new, total_knew, num_heads_k, head_size);
+      CHECK_SHAPE(v_new, total_knew, num_heads_k, head_size_v);
+      TORCH_CHECK(
+          cu_seqlens_k_new_.has_value() || seqlen_knew > 0,
+          "ragged k_new requires cu_seqlens_k_new or positive max_seqlen_k");
+    } else {
+      TORCH_CHECK(k_new.size(0) == batch_size, "batched k_new first dimension must match batch size");
+      int const k_new_seqlen = k_new.size(1);
+      total_knew = batch_size * k_new_seqlen;
+      seqlen_knew = max_seqlen_k > 0 ? max_seqlen_k : k_new_seqlen;
+      CHECK_SHAPE(k_new, batch_size, k_new_seqlen, num_heads_k, head_size);
+      CHECK_SHAPE(v_new, batch_size, k_new_seqlen, num_heads_k, head_size_v);
+    }
+    if (cu_seqlens_k_new_.has_value()) {
+      auto const& cu_seqlens_k_new = cu_seqlens_k_new_.value();
+      CHECK_INPUT(cu_seqlens_k_new);
+      TORCH_CHECK(cu_seqlens_k_new.dtype() == torch::kInt32, "cu_seqlens_k_new must have dtype torch.int32");
+      CHECK_SHAPE(cu_seqlens_k_new, batch_size + 1);
+      params.cu_seqlens_knew = cu_seqlens_k_new.data_ptr<int>();
+    }
+    params.knew_ptr = k_new.data_ptr();
+    params.vnew_ptr = v_new.data_ptr();
+    params.cache_seqlens_old = cu_seqlens_k.data_ptr<int>();
+    params.seqlen_knew = seqlen_knew;
+    params.total_knew = total_knew;
+  }
 
   if (q_v_.has_value()) {
     TORCH_CHECK(head_size <= 64, "q_v is only supported for head_size <= 64");
@@ -1191,120 +1218,6 @@ std::vector<at::Tensor> mha_fwd(
 
 }  // namespace prefill
 
-namespace chunkprefill {
-
-// Two-launch mix-batch dispatcher (vllm-xpu-kernels#218).
-//
-// Build a per-batch ``is_prefill`` bool mask on device, then launch the
-// decode kernel skipping prefill batches and the prefill kernel skipping
-// decode batches. Both launches write into the same output tensor.
-//
-// Limitations: paged KV cache required; rotary / q_v / descale / scheduler
-// metadata are not supported on this path. Sliding window and attention sinks
-// are forwarded to both sub-kernels, which support them.
-std::vector<at::Tensor> mha_fwd(
-    const at::Tensor& q,
-    const at::Tensor& k,
-    const at::Tensor& v,
-    std::optional<const at::Tensor>& q_v_,
-    const at::Tensor& cu_seqlens_q,
-    const at::Tensor& cu_seqlens_k,  // per-batch cache_seqlens (size = batch) in paged mode
-    int max_seqlen_q,
-    int max_seqlen_k,
-    std::optional<const at::Tensor>& page_table,
-    std::optional<const at::Tensor>& kv_batch_idx_,
-    std::optional<const at::Tensor>& leftpad_k_,
-    std::optional<const at::Tensor>& rotary_cos_,
-    std::optional<const at::Tensor>& rotary_sin_,
-    std::optional<const at::Tensor>& seqlens_rotary_,
-    std::optional<at::Tensor>& q_descale_,
-    std::optional<at::Tensor>& k_descale_,
-    std::optional<at::Tensor>& v_descale_,
-    const float softmax_scale_,
-    std::optional<const at::Tensor>& sinks_,
-    bool is_causal,
-    int window_size_left,
-    int window_size_right,
-    float const softcap,
-    bool const is_rotary_interleaved,
-    std::optional<at::Tensor>& scheduler_metadata_,
-    int num_kv_splits,
-    std::optional<bool> pack_gqa_,
-    int const sm_margin,
-    std::optional<at::Tensor> out_ = std::nullopt) {
-  // Supports both paged (page_table != None) and non-paged (contiguous ragged
-  // KV, page_table == None) layouts.
-  // ``seqlens_rotary_`` is intentionally not checked here: callers pass it
-  // alongside ``cache_seqlens`` even when rotary is disabled, and the
-  // sub-kernels only consume it inside the ``rotary_cos_.has_value()`` branch.
-  TORCH_CHECK(
-      !q_v_.has_value() && !rotary_cos_.has_value() && !rotary_sin_.has_value() && !q_descale_.has_value() &&
-          !scheduler_metadata_.has_value(),
-      "chunkprefill two-launch path does not yet support q_v / rotary / q_descale / scheduler_metadata.");
-  TORCH_CHECK(cu_seqlens_q.scalar_type() == at::kInt, "cu_seqlens_q must be int32.");
-  // Pre-allocated out requires paged KV: on the non-paged path zero-KV-length
-  // rows are never written by the kernel, so a caller buffer would retain stale
-  // values on graph replay. SGLang always provides page_table (paged KV cache),
-  // so this check should never fire in practice.
-  TORCH_CHECK(
-      !out_.has_value() || page_table.has_value(), "chunkprefill: out buffer requires page_table (paged KV cache).");
-
-  int64_t batch_size = cu_seqlens_q.size(0) - 1;
-  TORCH_CHECK(batch_size >= 0, "cu_seqlens_q must have at least 1 element.");
-
-  auto seqlens_q = cu_seqlens_q.slice(0, 1, batch_size + 1).sub(cu_seqlens_q.slice(0, 0, batch_size));
-  auto is_prefill = seqlens_q.gt(1).contiguous();  // true for prefill batches
-
-  // Forward every shared argument to a sub-kernel, overriding only the output
-  // tensor (out_opt) and the per-batch skip mask.
-  auto launch = [&](auto&& fn, std::optional<at::Tensor> out_opt, std::optional<at::Tensor> skip_mask) {
-    return fn(
-        q,
-        k,
-        v,
-        q_v_,
-        cu_seqlens_q,
-        cu_seqlens_k,
-        max_seqlen_q,
-        max_seqlen_k,
-        page_table,
-        kv_batch_idx_,
-        leftpad_k_,
-        rotary_cos_,
-        rotary_sin_,
-        seqlens_rotary_,
-        q_descale_,
-        k_descale_,
-        v_descale_,
-        softmax_scale_,
-        sinks_,
-        is_causal,
-        window_size_left,
-        window_size_right,
-        softcap,
-        is_rotary_interleaved,
-        scheduler_metadata_,
-        num_kv_splits,
-        pack_gqa_,
-        sm_margin,
-        std::move(out_opt),
-        std::move(skip_mask));
-  };
-
-  // Launch 1: decode allocates the shared output (or reuses the caller-provided
-  // out_ buffer) and skips prefill batches.
-  auto out = launch(decode::mha_fwd, std::move(out_), is_prefill)[0];
-  // Launch 2: prefill writes into the same output and skips decode batches.
-  launch(prefill::mha_fwd, out, is_prefill.logical_not());
-
-  // softmax_lse / accum tensors are not stitched here; return empty
-  // placeholders to keep the Python ABI stable.
-  auto empty_f = at::empty({0}, q.options().dtype(at::kFloat));
-  return {out, empty_f, empty_f, empty_f};
-}
-
-}  // namespace chunkprefill
-
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
     const at::Tensor& q,  // (total_q, h, d) — ragged 3D
     const at::Tensor& k,  // (total_k, h_k, d) if non-paged, or (num_pages, page_size, h_k, d) if paged
@@ -1334,7 +1247,10 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    std::optional<at::Tensor>& out_) {
+    std::optional<at::Tensor>& out_,
+    std::optional<const at::Tensor>& k_new_,
+    std::optional<const at::Tensor>& v_new_,
+    std::optional<const at::Tensor>& cu_seqlens_k_new_) {
   TORCH_CHECK(q.dim() == 3, "query must be in ragged format (total_q, h, d)");
   // k and v may be 3D (total_k, h_k, d) for non-paged or 4D (num_pages, page_size, h_k, d)
   // for paged KV cache; sub-functions validate their own shapes.
@@ -1349,64 +1265,74 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
     TORCH_CHECK(out_val.stride(-1) == 1, "out must have a contiguous last dimension");
   }
   auto to_tuple = [](std::vector<at::Tensor> v) { return std::make_tuple(v[0], v[1], v[2], v[3]); };
-  int const num_heads = q.size(-2);
-  int const num_heads_k = k.size(-2);
-  int64_t batch_size = cu_seqlens_q.size(0) - 1;
-
-  // decode / prefill / chunkprefill all take the same leading argument list;
-  // only the trailing parameters differ. Bind the shared arguments once here so
-  // each branch reduces to a single call. ``tail`` carries the callee-specific
-  // suffix: decode and prefill additionally accept a per-batch skip mask (unused
-  // at this top level, so left as std::nullopt); chunkprefill has no such slot.
-  auto dispatch = [&](auto&& fn, auto&&... tail) {
-    return to_tuple(
-        fn(q,
-           k,
-           v,
-           q_v_,
-           cu_seqlens_q,
-           cu_seqlens_k,
-           max_seqlen_q,
-           max_seqlen_k,
-           page_table,
-           kv_batch_idx_,
-           leftpad_k_,
-           rotary_cos_,
-           rotary_sin_,
-           seqlens_rotary_,
-           q_descale_,
-           k_descale_,
-           v_descale_,
-           softmax_scale_,
-           sinks_,
-           is_causal,
-           window_size_left,
-           window_size_right,
-           softcap,
-           is_rotary_interleaved,
-           scheduler_metadata_,
-           num_kv_splits,
-           pack_gqa_,
-           sm_margin,
-           out_,
-           std::forward<decltype(tail)>(tail)...));
-  };
-
-  if (max_seqlen_q == 1) {
-    // Pure decode path
-    return dispatch(decode::mha_fwd, std::nullopt);
-  } else if (!page_table.has_value() || batch_size == 1) {
-    // Pure prefill path
-    // Non-paged attn: assumption of all seqlen_q > 1;
-    // Paged attn: Proving "all prefill" for batch_size > 1 would require
-    // is_prefill.all() — a device reduction + D2H sync that costs more than it saves.
-    // But batch_size == 1 makes it provable from host scalars:
-    // a single sequence with max_seqlen_q > 1 is prefill
-    return dispatch(prefill::mha_fwd, std::nullopt);
+  if (max_seqlen_q == 1 && page_table.has_value()) {
+    TORCH_CHECK(
+        !k_new_.has_value() && !v_new_.has_value() && !cu_seqlens_k_new_.has_value(),
+        "AppendKV is routed through prefill and is not supported on the pure decode path");
+    return to_tuple(decode::mha_fwd(
+        q,
+        k,
+        v,
+        q_v_,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        page_table,
+        kv_batch_idx_,
+        leftpad_k_,
+        rotary_cos_,
+        rotary_sin_,
+        seqlens_rotary_,
+        q_descale_,
+        k_descale_,
+        v_descale_,
+        softmax_scale_,
+        sinks_,
+        is_causal,
+        window_size_left,
+        window_size_right,
+        softcap,
+        is_rotary_interleaved,
+        scheduler_metadata_,
+        num_kv_splits,
+        pack_gqa_,
+        sm_margin,
+        out_));
   } else {
-    // Chunk prefill path
-    // Paged attn with max_seqlen_q > 1 and batch_size > 1
-    return dispatch(chunkprefill::mha_fwd);
+    return to_tuple(prefill::mha_fwd(
+        q,
+        k,
+        v,
+        q_v_,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        page_table,
+        kv_batch_idx_,
+        leftpad_k_,
+        rotary_cos_,
+        rotary_sin_,
+        seqlens_rotary_,
+        q_descale_,
+        k_descale_,
+        v_descale_,
+        softmax_scale_,
+        sinks_,
+        is_causal,
+        window_size_left,
+        window_size_right,
+        softcap,
+        is_rotary_interleaved,
+        scheduler_metadata_,
+        num_kv_splits,
+        pack_gqa_,
+        sm_margin,
+        out_,
+        k_new_,
+        v_new_,
+        cu_seqlens_k_new_));
   }
 }
 #undef SYCL_INTEL_TARGET

--- a/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_epilogue.hpp
+++ b/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_epilogue.hpp
@@ -150,12 +150,45 @@ class FMHAFwdEpilogue {
       FragARow& tA_sum,                       // Softmax row-wise sum accumulator
       QVCoord blk_qv,                         // WG tile indices: (q,v)
       int thr_id,                             // Work-item ID
-      float scale_v = 1.0f,                   // Per-tensor V dequant scale (fp8 path)
       ElementSink sink_val = ElementSink{},   // Per-head sink logit (non-packed, used when Sink==true)
       const ElementSink* sink_ptr = nullptr,  // Per-row sink logits base (PackGQA, used when Sink==true)
       int head_group_q = 0) {                 // # packed query heads in the M tile (PackGQA)
     using namespace cute;
     using ElementA = typename FragA::element_type;
+
+    /* PackGQA decode: each packed M row is a distinct query head sharing the
+       same decode position, so the sink logit is per-row. Add it to the
+       per-subgroup running sum BEFORE the cross-subgroup reduction (mirrors the
+       split-decode epilogue): lane `l` of subgroup 0 owns packed row `l`, and
+       reduce_A rescales this contribution by exp2(sg0_max - global_max). The
+       running max/sum are kept in log2 units (exp2 space), so the sink logit is
+       likewise scaled by log2e. */
+    if constexpr (Sink && PackGQA_) {
+      constexpr double kLog2e = 1.4426950408889634074;
+      int sg_id = thr_id / intel::sg_size;
+      int lane = thr_id % intel::sg_size;
+      if (sg_id == 0 && lane < head_group_q) {
+        const ElementA s = static_cast<ElementA>(sink_ptr[lane] * kLog2e);
+        if (tA_sum(0) != ElementA(0)) {
+          // Subgroup 0 holds in-window tokens for this row: add the sink
+          // relative to its partial max. reduce_A later rescales this whole
+          // contribution by exp2(sg0_max - global_max), giving exp2(sink -
+          // global_max) regardless of which subgroup owns the global max.
+          tA_sum(0) += sycl::native::exp2(s - tA_max(0));
+        } else {
+          // Subgroup 0 has no in-window tokens for this row (partial max is
+          // -inf), but other subgroups (k-blocks) may. The old guard dropped
+          // the sink here, shrinking the denominator; removing it instead
+          // overflowed exp2(s - (-inf)) to +inf -> inf*0 = NaN after rescale.
+          // Seed sg0's max with the sink logit and its sum with exp2(s - s) = 1
+          // so the cross-subgroup reduction rescales the sink to the true
+          // global max. Fully-masked rows (no tokens anywhere) end up with
+          // denominator 1 and zero P*V, i.e. output 0, matching the reference.
+          tA_max(0) = s;
+          tA_sum(0) = ElementA(1);
+        }
+      }
+    }
 
     // Reduce k-blocks of A and A_sum across WG, if needed.
     auto [rA, rA_max_local, rA_sum, active] = reduce_A(tArA, tA_max, tA_sum, thr_id);
@@ -163,9 +196,9 @@ class FMHAFwdEpilogue {
     /* Some subgroups may not have any work to do; if so, quit early. */
     if (!active) return;
 
-    /* Non-packed sink (prefill / MHA decode): every row in this tile belongs to
-       the SAME query head, so a single scalar sink applies to all rows. Add
-       exp2(sink_val * log2e - row_max) to each row's running sum. */
+    /* Add sink token contribution to softmax denominator.
+       sink_val is the raw logit for the sink token (same for every query row).
+       We add exp2(sink_val * log2e - row_max) to each row's running sum. */
     if constexpr (Sink && !PackGQA_) {
       constexpr double kLog2e = 1.4426950408889634074;
       CUTLASS_PRAGMA_UNROLL
@@ -178,8 +211,23 @@ class FMHAFwdEpilogue {
       }
     }
 
-    /* Tile output coordinates. cO/gO are identity tensors, so tOgO exposes the
-       (q,v) coordinate of each output fragment element. */
+    /* Complete softmax, dividing out sums. Rows whose denominator is exactly
+       zero attend to no (unmasked) keys -- e.g. a batch with zero KV length --
+       so emit 0 instead of NaN to match the reference implementation. */
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < rA_sum.size(); i++) {
+      if constexpr (CollectiveMainloop::LocalMask || CollectiveMainloop::CausalMask) {
+        rA_sum(i) = safe_recip(rA_sum(i));
+      } else {
+        rA_sum(i) = ElementA(1) / rA_sum(i);
+      }
+    }
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < rA.size(); i++)
+      rA(i) *= broadcast<0>(rA_sum, rA, i);
+
+    /* Tile output */
     Tensor cO = make_identity_tensor(O.shape());       // (q,v)
     Tensor gO = local_tile(cO, TileShapeO{}, blk_qv);  // (q,v)
 
@@ -190,87 +238,9 @@ class FMHAFwdEpilogue {
     auto tOrO = thr_copy_o.partition_sg_fragment_S(gO);
     auto tOgO = thr_copy_o.partition_D(gO);
 
-    if constexpr (Sink && PackGQA_) {
-      /* Packed-GQA decode stacks head_group_q distinct query heads into the row
-         dimension, so each row needs its OWN sink logit. Unlike the split-decode
-         epilogue, the general mainloop's reduced row fragment does NOT preserve
-         the query-head order across (subgroup, lane), so we cannot index the
-         sink by lane. Instead fold the per-row sink into the denominator in
-         OUTPUT-element space, where tOgO gives each element's q coordinate
-         (= query head within the KV group). Build the per-element denominator
-         (sum of weights) and row max in the A layout via broadcast<0>, reorder
-         both into the output fragment layout, then divide each element by
-         (sum_w + sink_term) using that element's own head. */
-      constexpr double kLog2e = 1.4426950408889634074;
-      auto denom_e = rA;  // per-element softmax denominator (sum of weights)
-      auto max_e = rA;    // per-element row max
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < rA.size(); i++) {
-        denom_e(i) = broadcast<0>(rA_sum, rA, i);
-        max_e(i) = broadcast<0>(rA_max_local, rA, i);
-      }
-      // Keep numerator / denominator / row max in float (ElementA); the output
-      // fragment tOrO is ElementO (e.g. bf16), so doing the division there would
-      // round the denominator and degrade accuracy. Only the final result casts
-      // to ElementO when written into tOrO. reorder() requires SubgroupTensor
-      // destinations, so wrap the float fragments with tOrO's TV layout.
-      auto tv = tOrO.tv_layout();
-      auto tO_num = make_subgroup_tensor(make_fragment_like<ElementA>(tOrO.layout()), tv);
-      auto tO_denom = make_subgroup_tensor(make_fragment_like<ElementA>(tOrO.layout()), tv);
-      auto tO_max = make_subgroup_tensor(make_fragment_like<ElementA>(tOrO.layout()), tv);
-      reorder(rA, tO_num);  // un-normalized accumulator in output layout
-      reorder(denom_e, tO_denom);
-      reorder(max_e, tO_max);
-
-      CUTLASS_PRAGMA_UNROLL
-      for (int j = 0; j < int(tO_num.size()); j++) {
-        ElementA denom = tO_denom(j);
-        int head_off = int(get<0>(tOgO(j)));
-        // Guard against padded rows (qg_sz rounded up beyond head_group_q).
-        if (head_off < head_group_q) {
-          ElementA sink_term = sycl::native::exp2(static_cast<ElementA>(sink_ptr[head_off] * kLog2e) - tO_max(j));
-          if (sycl::isfinite(sink_term)) {
-            denom += sink_term;
-          }
-        }
-        // Rows that attend to no (unmasked) keys have denom==0 -> emit 0, not NaN.
-        ElementA outv = (denom != ElementA(0)) ? (tO_num(j) / denom) : ElementA(0);
-        //  For an fp8 KV cache the per-tensor V dequant scale is folded in here
-        //  (O = scale_v * (P @ V_fp8) / sum), avoiding a per-element V scale in the
-        //  mainloop GEMM2.
-        if constexpr (CollectiveMainloop::Fp8KV) {
-          outv *= ElementA(scale_v);
-        }
-        tOrO(j) = static_cast<ElementO>(outv);
-      }
-      copy(copy_o, tOrO, tOgO);
-    } else {
-      /* Complete softmax, dividing out sums. Rows whose denominator is exactly
-         zero attend to no (unmasked) keys -- e.g. a batch with zero KV length --
-         so emit 0 instead of NaN to match the reference implementation.
-         For an fp8 KV cache the per-tensor V dequant scale is folded in here
-         (O = scale_v * (P @ V_fp8) / sum), avoiding a per-element V scale in the
-         mainloop GEMM2. */
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < rA_sum.size(); i++) {
-        if constexpr (CollectiveMainloop::LocalMask || CollectiveMainloop::CausalMask) {
-          rA_sum(i) = safe_recip(rA_sum(i));
-        } else {
-          rA_sum(i) = ElementA(1) / rA_sum(i);
-        }
-        if constexpr (CollectiveMainloop::Fp8KV) {
-          rA_sum(i) *= ElementA(scale_v);
-        }
-      }
-
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < rA.size(); i++)
-        rA(i) *= broadcast<0>(rA_sum, rA, i);
-
-      /* Reorder tile and write out */
-      reorder(rA, tOrO);
-      copy(copy_o, tOrO, tOgO);
-    }
+    /* Reorder tile and write out */
+    reorder(rA, tOrO);
+    copy(copy_o, tOrO, tOgO);
   }
 
   // Reduce k-blocks of A and A_sum across WG, if needed.
@@ -483,13 +453,12 @@ class DecodeFwdEpilogue {
 
   template <typename QVCoord>
   CUTLASS_DEVICE void operator()(
-      TensorO2D const& O,      // Global O tensor: (q,v)
-      FragA& tArA,             // O accumulator:   (q,v)
-      FragARow& tA_max,        // Softmax row-wise max accumulator
-      FragARow& tA_sum,        // Softmax row-wise sum accumulator
-      QVCoord blk_qv,          // WG tile indices: (q,v)
-      int thr_id,              // Work-item ID
-      float scale_v = 1.0f) {  // Per-tensor V dequant scale (fp8 path)
+      TensorO2D const& O,  // Global O tensor: (q,v)
+      FragA& tArA,         // O accumulator:   (q,v)
+      FragARow& tA_max,    // Softmax row-wise max accumulator
+      FragARow& tA_sum,    // Softmax row-wise sum accumulator
+      QVCoord blk_qv,      // WG tile indices: (q,v)
+      int thr_id) {        // Work-item ID
 
     using namespace cute;
     using ElementA = typename FragA::element_type;
@@ -502,19 +471,13 @@ class DecodeFwdEpilogue {
 
     /* Complete softmax, dividing out sums. Rows whose denominator is exactly
        zero attend to no (unmasked) keys -- e.g. a batch with zero KV length --
-       so emit 0 instead of NaN to match the reference implementation..
-       FP8 KV cache: the per-tensor V dequant scale (O = scale_v * (P @ V_fp8) /
-       sum) is folded into the 1/rA_sum reciprocal, so the output is scaled in
-       the same multiply that normalizes it instead of a separate pass. */
+       so emit 0 instead of NaN to match the reference implementation. */
     CUTLASS_PRAGMA_UNROLL
     for (int i = 0; i < rA_sum.size(); i++) {
       if constexpr (CollectiveMainloop::LocalMask || CollectiveMainloop::CausalMask) {
         rA_sum(i) = safe_recip(rA_sum(i));
       } else {
         rA_sum(i) = ElementA(1) / rA_sum(i);
-      }
-      if constexpr (CollectiveMainloop::Fp8KV) {
-        rA_sum(i) *= ElementA(scale_v);
       }
     }
 
@@ -547,7 +510,6 @@ class DecodeFwdEpilogue {
       FragARow& tA_sum,               // Softmax row-wise sum accumulator
       QVCoord blk_qv,                 // WG tile indices: (q,v)
       int thr_id,                     // Work-item ID
-      float scale_v,                  // Per-tensor V dequant scale (fp8 path)
       const TensorLSE2D& exp_sums,    // Global exp sum tensor
       const TensorLSE2D& max_logits,  // Global max logits tensor
       int idx_kv_split,
@@ -601,27 +563,16 @@ class DecodeFwdEpilogue {
     /* Complete softmax: normalize output for single-split sequences
        (so ReduceSplitK pass-through gives correct result).
        For multi-split, store unnormalized to avoid divide-multiply
-       precision loss in the reduce roundtrip.
-       FP8 KV cache: the per-tensor V dequant scale (O = scale_v * (P @ V_fp8) /
-       sum) is folded into the 1/rA_sum reciprocal, so the output is scaled in
-       the same multiply that normalizes it instead of a separate pass. */
+       precision loss in the reduce roundtrip. */
     if (is_single_split || num_kv_splits <= 1) {
       CUTLASS_PRAGMA_UNROLL
       for (int i = 0; i < rA_sum.size(); i++) {
-        if constexpr (CollectiveMainloop::Fp8KV)
-          rA_sum(i) = ElementA(scale_v) / rA_sum(i);
-        else
-          rA_sum(i) = ElementA(1) / rA_sum(i);
+        rA_sum(i) = ElementA(1) / rA_sum(i);
       }
 
       CUTLASS_PRAGMA_UNROLL
       for (int i = 0; i < rA.size(); i++) {
         rA(i) *= broadcast<0>(rA_sum, rA, i);
-      }
-    } else if constexpr (CollectiveMainloop::Fp8KV) {
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < rA.size(); i++) {
-        rA(i) *= ElementA(scale_v);
       }
     }
 

--- a/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_mainloop.hpp
+++ b/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_mainloop.hpp
@@ -31,12 +31,15 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "cute/algorithm/functional.hpp"
 #include "cute/algorithm/gemm.hpp"
 #include "cute/algorithm/subgroup_algorithms.hpp"
 #include "cute/atom/mma_atom.hpp"
 #include "cutlass/cutlass.h"
 #include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/sycl_vector_types.h"
 #include "fmha_fusion.hpp"
 
 namespace cutlass::fmha {
@@ -49,6 +52,21 @@ class XeDefault {};  // Default FMHA mainloop, P in registers.
 namespace cutlass::fmha::collective {
 
 using namespace cute;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <bool AppendKV_, class ElementK_, class ElementV_>
+struct AppendKVParams {};
+
+template <class ElementK_, class ElementV_>
+struct AppendKVParams<true, ElementK_, ElementV_> {
+  ElementK_ const* ptr_K_new = nullptr;
+  ElementV_ const* ptr_V_new = nullptr;
+  int const* ptr_cu_seqlens_k_new = nullptr;
+  int const* ptr_cache_seqlens = nullptr;
+  int seq_len_kv_new = 0;
+  int total_k_new = 0;
+};
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -75,7 +93,8 @@ template <
     // (decode only, seq_len_qo == 1). All packed rows share the single decode
     // KV position, so per-row masking must use a fixed decode row. Default
     // false keeps prefill (and non-packed decode) unaffected.
-    bool PackGQA_ = false>
+    bool PackGQA_ = false,
+    bool AppendKV_ = false>
 struct FMHAFwdMainloop {
   static_assert(cutlass::detail::dependent_false<DispatchPolicy_>, "Could not find a mainloop specialization.");
 };
@@ -101,7 +120,8 @@ template <
     class TiledCopyK_cache_,
     class TiledCopyV_cache_,
     bool LocalMask_,
-    bool PackGQA_>
+    bool PackGQA_,
+    bool AppendKV_>
 struct FMHAFwdMainloop<
     XeDefault<Stages>,
     CausalMask_,
@@ -121,7 +141,8 @@ struct FMHAFwdMainloop<
     TiledCopyK_cache_,
     TiledCopyV_cache_,
     LocalMask_,
-    PackGQA_> {
+    PackGQA_,
+    AppendKV_> {
   //
   // Type Aliases
   //
@@ -136,9 +157,6 @@ struct FMHAFwdMainloop<
   using TensorQ = TensorQ_;
   using TensorK = TensorK_;
   using TensorV = TensorV_;
-
-  using ElementQ = typename TensorQ::engine_type::value_type;
-  using ElementK = typename TensorK::engine_type::value_type;
 
   using TensorQ2D = decltype(TensorQ_{}(append<rank_v<TensorQ_>>(make_coord(_, _), 0)));
   using TensorK2D = decltype(TensorK_{}(append<rank_v<TensorK_>>(make_coord(_, _), 0)));
@@ -194,11 +212,9 @@ struct FMHAFwdMainloop<
   static constexpr bool PagedKV = PagedKV_;
   static constexpr bool LocalMask = LocalMask_;
   static constexpr bool PackGQA = PackGQA_;
-
-  // FP8 KV cache: enabled when the K element type is an 8-bit float. The fp8
-  // K/V are dequantized (cast to ElementQ and multiplied by the per-tensor
-  // scale) inside the mainloop after the block-2D load.
-  static constexpr bool Fp8KV = is_any_of_v<ElementK, float_e5m2_t, float_e4m3_t>;
+  static constexpr bool AppendKV = AppendKV_;
+  using AppendKVStorage =
+      AppendKVParams<AppendKV, typename TensorK_cache::element_type, typename TensorV_cache::element_type>;
 
   // User-facing arguments
   struct Arguments {
@@ -208,6 +224,7 @@ struct FMHAFwdMainloop<
     int max_num_pages_per_seq = 0;
     int window_size_left = -1;
     int window_size_right = -1;
+    AppendKVStorage append{};
   };
 
   // Kernel-facing parameters
@@ -233,7 +250,8 @@ struct FMHAFwdMainloop<
         args.page_size,
         args.max_num_pages_per_seq,
         args.window_size_left,
-        args.window_size_right};
+        args.window_size_right,
+        args.append};
   }
 
   CUTLASS_HOST_DEVICE static bool can_implement(Arguments const&) {
@@ -254,6 +272,185 @@ struct FMHAFwdMainloop<
     return params.ptr_page_table[batch_offset + next_page_logical_idx] * tiles_per_page + K % tiles_per_page;
   }
 
+  CUTLASS_DEVICE
+  int get_k_new_len(int batch) const {
+    if constexpr (AppendKV) {
+      if (params.append.ptr_K_new == nullptr || params.append.ptr_V_new == nullptr ||
+          params.append.ptr_cache_seqlens == nullptr || params.append.total_k_new <= 0 ||
+          (params.append.ptr_cu_seqlens_k_new == nullptr && params.append.seq_len_kv_new <= 0)) {
+        return 0;
+      }
+      if (params.append.ptr_cu_seqlens_k_new != nullptr) {
+        return params.append.ptr_cu_seqlens_k_new[batch + 1] - params.append.ptr_cu_seqlens_k_new[batch];
+      }
+      return params.append.seq_len_kv_new;
+    } else {
+      (void)batch;
+      return 0;
+    }
+  }
+
+  CUTLASS_DEVICE
+  void store_kv_new(
+      TensorK_cache2D const& K_cache_2D,
+      TensorV_cache2D const& V_cache_2D,
+      int batch,
+      int kv_head,
+      int num_heads_kv,
+      int thr_id,
+      int append_store_len = -1) const {
+    if constexpr (AppendKV) {
+      int const new_len_total = get_k_new_len(batch);
+      int const new_len =
+          append_store_len < 0 ? new_len_total : (append_store_len < new_len_total ? append_store_len : new_len_total);
+      if (new_len <= 0) {
+        return;
+      }
+
+      auto& K_dst = const_cast<TensorK_cache2D&>(K_cache_2D);
+      auto& V_dst = const_cast<TensorV_cache2D&>(V_cache_2D);
+      int const lane_idx = thr_id % intel::sg_size;
+      int const sub_group_id = thr_id / intel::sg_size;
+      int const new_begin = params.append.ptr_cu_seqlens_k_new != nullptr ? params.append.ptr_cu_seqlens_k_new[batch]
+                                                                          : batch * params.append.seq_len_kv_new;
+      int const cache_len_old = params.append.ptr_cache_seqlens[batch];
+      int const head_size_qk = size<1>(K_cache_2D);
+      int const head_size_vo = size<0>(V_cache_2D);
+      int const max_hd = head_size_qk > head_size_vo ? head_size_qk : head_size_vo;
+
+      // Every WG that can read this appended KV range scatters the same source
+      // k_new/v_new values before loading K/V. Multiple WGs, including GQA
+      // query heads that map to one kv_head, therefore overwrite identical bit
+      // patterns at the same cache address; the append is intentionally
+      // idempotent and does not rely on a grid-wide producer.
+      if constexpr (
+          sizeof(typename TensorK_cache::element_type) == 2 && sizeof(typename TensorV_cache::element_type) == 2) {
+        // NHD bf16 rows are 16B-aligned when head_size is divisible by 8.
+        constexpr int kVecElems = 8;
+        using StoreVec = cutlass::ulonglong2;
+        if (head_size_qk == head_size_vo && (head_size_qk % kVecElems) == 0) {
+          // Large appends are bandwidth-bound, so split tokens across SGs;
+          // small appends keep the old single-SG path to avoid control overhead.
+          constexpr int kMinMultiSgTokens = 64;
+          int const active_sg_count = new_len >= kMinMultiSgTokens ? int(SGPerWG::value) : 1;
+          if (sub_group_id >= active_sg_count) {
+            return;
+          }
+          int const head_size = head_size_qk;
+          int const vecs_per_token = head_size / kVecElems;
+          bool single_dst_page = true;
+          int single_row_base = cache_len_old;
+          if constexpr (PagedKV) {
+            int const first_dst_page = cache_len_old / params.page_size;
+            int const last_dst_page = (cache_len_old + new_len - 1) / params.page_size;
+            single_dst_page = first_dst_page == last_dst_page;
+            if (single_dst_page) {
+              int const first_page_token = first_dst_page * params.page_size;
+              int const logical_page = batch * params.max_num_pages_per_seq + first_dst_page;
+              int const phys_page = params.ptr_page_table[logical_page];
+              single_row_base = phys_page * params.page_size + (cache_len_old - first_page_token);
+            }
+          }
+
+          if constexpr (PagedKV) {
+            if (!single_dst_page) {
+              // Cross-page append is common for large k_new; resolve the page
+              // table once per destination page instead of once per token.
+              for (int new_tok0 = 0; new_tok0 < new_len;) {
+                int const dst_tok0 = cache_len_old + new_tok0;
+                int const page = dst_tok0 / params.page_size;
+                int const tok_in_page0 = dst_tok0 - page * params.page_size;
+                int const tokens_in_page = params.page_size - tok_in_page0;
+                int const page_len = tokens_in_page < (new_len - new_tok0) ? tokens_in_page : (new_len - new_tok0);
+                int const logical_page = batch * params.max_num_pages_per_seq + page;
+                int const phys_page = params.ptr_page_table[logical_page];
+                int const row_base = phys_page * params.page_size + tok_in_page0;
+                size_t src_base =
+                    ((size_t)(new_begin + new_tok0) * (size_t)num_heads_kv + (size_t)kv_head) * (size_t)head_size;
+                size_t const token_stride = (size_t)num_heads_kv * (size_t)head_size;
+
+                for (int page_tok = sub_group_id; page_tok < page_len; page_tok += active_sg_count) {
+                  int const dst_row = row_base + page_tok;
+                  size_t const token_src_base = src_base + (size_t)page_tok * token_stride;
+                  for (int d_vec = lane_idx; d_vec < vecs_per_token; d_vec += intel::sg_size) {
+                    int const d = d_vec * kVecElems;
+                    size_t const src = token_src_base + (size_t)d;
+                    StoreVec const k_value = *reinterpret_cast<StoreVec const*>(params.append.ptr_K_new + src);
+                    StoreVec const v_value = *reinterpret_cast<StoreVec const*>(params.append.ptr_V_new + src);
+                    *reinterpret_cast<StoreVec*>(&K_dst(dst_row, d)) = k_value;
+                    *reinterpret_cast<StoreVec*>(&V_dst(d, dst_row)) = v_value;
+                  }
+                }
+                new_tok0 += page_len;
+              }
+              return;
+            }
+          }
+
+          for (int new_tok = sub_group_id; new_tok < new_len; new_tok += active_sg_count) {
+            int const new_abs_tok = new_begin + new_tok;
+            int dst_row = single_row_base + new_tok;
+            if constexpr (PagedKV) {
+              if (!single_dst_page) {
+                int const dst_tok = cache_len_old + new_tok;
+                int const page = dst_tok / params.page_size;
+                int const tok_in_page = dst_tok - page * params.page_size;
+                int const logical_page = batch * params.max_num_pages_per_seq + page;
+                int const phys_page = params.ptr_page_table[logical_page];
+                dst_row = phys_page * params.page_size + tok_in_page;
+              }
+            }
+
+            size_t const src_base = ((size_t)new_abs_tok * (size_t)num_heads_kv + (size_t)kv_head) * (size_t)head_size;
+            for (int d_vec = lane_idx; d_vec < vecs_per_token; d_vec += intel::sg_size) {
+              int const d = d_vec * kVecElems;
+              size_t const src = src_base + (size_t)d;
+              StoreVec const k_value = *reinterpret_cast<StoreVec const*>(params.append.ptr_K_new + src);
+              StoreVec const v_value = *reinterpret_cast<StoreVec const*>(params.append.ptr_V_new + src);
+              *reinterpret_cast<StoreVec*>(&K_dst(dst_row, d)) = k_value;
+              *reinterpret_cast<StoreVec*>(&V_dst(d, dst_row)) = v_value;
+            }
+          }
+          return;
+        }
+      }
+
+      for (int linear = lane_idx; linear < new_len * max_hd; linear += intel::sg_size) {
+        int const d = linear % max_hd;
+        int const new_tok = linear / max_hd;
+        int const new_abs_tok = new_begin + new_tok;
+        int const dst_tok = cache_len_old + new_tok;
+        int dst_row = dst_tok;
+        if constexpr (PagedKV) {
+          int const page = dst_tok / params.page_size;
+          int const tok_in_page = dst_tok - page * params.page_size;
+          int const logical_page = batch * params.max_num_pages_per_seq + page;
+          int const phys_page = params.ptr_page_table[logical_page];
+          dst_row = phys_page * params.page_size + tok_in_page;
+        }
+
+        if (d < head_size_qk) {
+          size_t const src =
+              ((size_t)new_abs_tok * (size_t)num_heads_kv + (size_t)kv_head) * (size_t)head_size_qk + (size_t)d;
+          K_dst(dst_row, d) = params.append.ptr_K_new[src];
+        }
+        if (d < head_size_vo) {
+          size_t const src =
+              ((size_t)new_abs_tok * (size_t)num_heads_kv + (size_t)kv_head) * (size_t)head_size_vo + (size_t)d;
+          V_dst(d, dst_row) = params.append.ptr_V_new[src];
+        }
+      }
+    } else {
+      (void)K_cache_2D;
+      (void)V_cache_2D;
+      (void)batch;
+      (void)kv_head;
+      (void)num_heads_kv;
+      (void)thr_id;
+      (void)append_store_len;
+    }
+  }
+
   template <typename QVCoord>
   CUTLASS_DEVICE void operator()(
       TensorQ2D const& Q_2D,  // (q,d)
@@ -271,11 +468,13 @@ struct FMHAFwdMainloop<
       int seq_len,
       int seq_len_kv_cache,
       int l_coord,
+      int kv_head,
+      int num_heads_kv,
       int full_tile_offset,
       int discard_seq_coord,
+      int append_store_len = -1,
       TensorK_cache2D const& K_cache_2D = TensorK_cache2D{},
-      TensorV_cache2D const& V_cache_2D = TensorV_cache2D{},
-      float scale_k = 1.0f) {  // FP8 K per-tensor dequant scale
+      TensorV_cache2D const& V_cache_2D = TensorV_cache2D{}) {
     using namespace sycl::ext::oneapi::this_work_item;
 
     // Short dimension names:
@@ -365,19 +564,27 @@ struct FMHAFwdMainloop<
     // Kernel
     // ------
 
+    if constexpr (AppendKV) {
+      store_kv_new(K_cache_2D, V_cache_2D, l_coord, kv_head, num_heads_kv, thr_id, append_store_len);
+      barrier();
+    }
+
     /* Initialization steps for first block: Q/K prefetch, O init */
     /* TODO: limit D prefetch for large head size, and reorder K prefetches */
     int kblocks_cache = ceil_div(seq_len_kv_cache, get<1>(TileShapeQK{}));
     int page_idx = blk_k0;
     int next_page_idx = blk_k0;
-    if constexpr (PagedKV) {
-      next_page_idx = get_physical_k_tile(blk_k0, l_coord, seq_len_kv_cache);
-    }
     for (int D = 0; D < size<3>(pQgQ); D++) {
       prefetch(prefetch_q, pQgQ(_, _, _, D));
     }
-    for (int D = 0; D < size<4>(pKgK); D++) {
-      prefetch(prefetch_k_cache, pKgK_cache(_, _, _, next_page_idx, D));
+    bool has_prefetch_k = blk_k0 < blk_k1 && blk_k0 < kblocks_cache;
+    if (has_prefetch_k) {
+      if constexpr (PagedKV) {
+        next_page_idx = get_physical_k_tile(blk_k0, l_coord, seq_len_kv_cache);
+      }
+      for (int D = 0; D < size<4>(pKgK); D++) {
+        prefetch(prefetch_k_cache, pKgK_cache(_, _, _, next_page_idx, D));
+      }
     }
     // Always initialize the per-WG accumulators: the caller (kernel) may pass
     // blk_k0 > 0 when sliding-window pruning skips leading K blocks, so we can
@@ -388,15 +595,6 @@ struct FMHAFwdMainloop<
 
     /* Check if */
     bool check_remainder_k = (seq_len % get<1>(TileShapeQK{}) != 0);
-
-    // FP8 K dequant: S = Q*K is linear in K, so the per-tensor scale_k is folded
-    // into the softmax Q*K scale (qk_scale = params.scale * scale_k) instead of
-    // rescaling every K register element in GEMM1. The V dequant scale (scale_v)
-    // is likewise folded into the epilogue normalization.
-    ElementS qk_scale = params.scale;
-    if constexpr (Fp8KV) {
-      qk_scale = params.scale * static_cast<ElementS>(scale_k);
-    }
 
     /* Main loop, blocked in k. */
     for (int K = blk_k0; K < blk_k1 && K < kblocks_cache; K++) {
@@ -409,9 +607,13 @@ struct FMHAFwdMainloop<
       }
 
       page_idx = next_page_idx;
-      next_page_idx = K + 1;
+      int next_k = K + 1;
+      bool has_next_k = next_k < blk_k1 && next_k < kblocks_cache;
+      next_page_idx = next_k;
       if constexpr (PagedKV) {
-        next_page_idx = get_physical_k_tile(next_page_idx, l_coord, seq_len_kv_cache);
+        if (has_next_k) {
+          next_page_idx = get_physical_k_tile(next_k, l_coord, seq_len_kv_cache);
+        }
       }
 
       /* GEMM 1: S = K * Q */
@@ -434,25 +636,16 @@ struct FMHAFwdMainloop<
       /* Causal masking */
       if constexpr (CausalMask) {
         if (need_causal) {
-          /* Masking scalars */
-          // TODO: use a more general code path for causal masking.
-          int lane_id = thr_id % intel::sg_size;
-          constexpr int sg_tile_q = get<0>(TileShapeQK{}) / SGPerWG::value;
-          int row_base = get<0>(blk_qv) * get<0>(TileShapeQK{}) + (thr_id / intel::sg_size) * sg_tile_q;
-
-          constexpr int kTileK = get<1>(TileShapeQK{});
-          constexpr int n_reps = kTileK / intel::sg_size;
-          constexpr int elems_per_n = tSrS.size() / n_reps;
-          int k_base = K * kTileK;
+          // Need to get global col and row indices to mask the elements
+          Tensor cPgP = make_identity_tensor(make_shape(seq_len, seq_len));
+          Tensor gP = local_tile(cPgP, take<0, 2>(TileShapeQK{}), make_coord(get<0>(blk_qv), K));
+          auto cS_thread = thr_mma_qk.partition_C(gP);
           CUTLASS_PRAGMA_UNROLL
-          for (int n = 0; n < n_reps; n++) {
-            int col = k_base + n * intel::sg_size + lane_id;
-            int causal_bound = col - full_tile_offset - row_base;
-            CUTLASS_PRAGMA_UNROLL
-            for (int j = 0; j < elems_per_n; j++) {
-              if (j < causal_bound) {
-                tSrS(n * elems_per_n + j) = ElementS(-INFINITY);
-              }
+          for (int i = 0; i < tSrS.size(); ++i) {
+            int row_idx = get<0>(cS_thread(i));
+            int col_idx = get<1>(cS_thread(i));
+            if (row_idx < col_idx - full_tile_offset) {
+              tSrS(i) = ElementS(-INFINITY);
             }
           }
         }
@@ -495,7 +688,7 @@ struct FMHAFwdMainloop<
       }
 
       /* Apply softmax and scaling (tA rescaling fused into GEMM2 VTile loop) */
-      auto rescale = softmax(K == blk_k0, tSrS, tA_max, tA_sum, qk_scale);
+      auto rescale = softmax(K == blk_k0, tSrS, tA_max, tA_sum);
       reorder(tSrS, tArP);
 
       /* GEMM 2: A += P * V, split in v dimension. */
@@ -513,8 +706,10 @@ struct FMHAFwdMainloop<
       }
 
       /* K prefetch */
-      for (int D = 0; D < size<4>(pKgK); D++) {
-        prefetch(prefetch_k_cache, pKgK_cache(_, _, _, next_page_idx, D));
+      if (has_next_k) {
+        for (int D = 0; D < size<4>(pKgK); D++) {
+          prefetch(prefetch_k_cache, pKgK_cache(_, _, _, next_page_idx, D));
+        }
       }
 
       barrier_wait(ScopeWorkgroup);
@@ -524,11 +719,10 @@ struct FMHAFwdMainloop<
   // Single step of blocked softmax.
   CUTLASS_DEVICE
   FragSRow softmax(
-      bool first_block,     // First softmax block?
-      FragS& tS,            // Softmax src/dst block
-      FragSRow& tS_max,     // Softmax row-wise max accumulator
-      FragSRow& tS_sum,     // Softmax row-wise sum accumulator
-      ElementS qk_scale) {  // Q*K scale (folds in fp8 K per-tensor scale_k)
+      bool first_block,    // First softmax block?
+      FragS& tS,           // Softmax src/dst block
+      FragSRow& tS_max,    // Softmax row-wise max accumulator
+      FragSRow& tS_sum) {  // Softmax row-wise sum accumulator
 
     /* Compute row-wise maxima for this block */
     auto tS_bmax = reduce<1>(tS, sycl::maximum{});
@@ -537,7 +731,7 @@ struct FMHAFwdMainloop<
     FragSRow rescale;
     CUTLASS_PRAGMA_UNROLL
     for (int i = 0; i < tS_max.size(); i++) {
-      ElementS new_max = sycl::max(tS_max(i), qk_scale * tS_bmax(i));
+      ElementS new_max = sycl::max(tS_max(i), params.scale * tS_bmax(i));
       rescale(i) = sycl::native::exp2(tS_max(i) - new_max);
       tS_max(i) = new_max;
     }
@@ -545,7 +739,7 @@ struct FMHAFwdMainloop<
     /* Scale S and subtract maxima, then exponentiate */
     CUTLASS_PRAGMA_UNROLL
     for (int i = 0; i < tS.size(); i++)
-      tS(i) = sycl::native::exp2(qk_scale * tS(i) - broadcast<0>(tS_max, tS, i));
+      tS(i) = sycl::native::exp2(params.scale * tS(i) - broadcast<0>(tS_max, tS, i));
 
     /* Rescale existing S sums */
     if (!first_block) {
@@ -676,6 +870,8 @@ struct DecodeFwdMainloop<
   // User-facing arguments
   struct Arguments {
     ElementS const scale;
+    void* const scale_k;
+    void* const scale_v;
     // Paged KV Cache
     int const* ptr_page_table;
     int page_size;
@@ -705,6 +901,8 @@ struct DecodeFwdMainloop<
     ElementS val = args.scale * static_cast<ElementS>(kLog2e);
     return Params{
         val,
+        args.scale_k,
+        args.scale_v,
         args.ptr_page_table,
         args.page_size,
         args.max_pages_per_seq,
@@ -733,8 +931,7 @@ struct DecodeFwdMainloop<
       int thr_id,
       int seq_len,
       int full_tile_offset,
-      int discard_seq_coord,
-      float scale_k = 1.0f) {  // FP8 K per-tensor dequant scale (applied in GEMM1)
+      int discard_seq_coord) {
     using namespace sycl::ext::oneapi::this_work_item;
 
     // Short dimension names:
@@ -836,13 +1033,11 @@ struct DecodeFwdMainloop<
     /* Check if */
     bool check_remainder_k = (seq_len % get<1>(TileShapeQK{}) != 0);
 
-    // FP8 K dequant: S = Q*K is linear in K, so the per-tensor scale_k is folded
-    // into the softmax Q*K scale (qk_scale = params.scale * scale_k) instead of
-    // rescaling every K register element in GEMM1. The V dequant scale (scale_v)
-    // is folded into the softmax normalization in the epilogue, not here.
-    ElementS qk_scale = params.scale;
+    // FP8 KV Scale: Currently we only support per-tensor scale for KV
+    float scale_k = 1.f, scale_v = 1.f;
     if constexpr (Fp8KV) {
-      qk_scale = params.scale * static_cast<ElementS>(scale_k);
+      scale_k = *static_cast<const float*>(params.scale_k);
+      scale_v = *static_cast<const float*>(params.scale_v);
     }
 
     /* Main loop, blocked in k. */
@@ -862,6 +1057,11 @@ struct DecodeFwdMainloop<
 
         reorder(tQrQ, tSrQ);
         reorder(tKrK, tSrK);
+        if constexpr (Fp8KV) {
+          for (int i = 0; i < tSrK.size(); ++i) {
+            tSrK(i) = static_cast<ElementQ>(scale_k * static_cast<float>(tSrK(i)));
+          }
+        }
 
         cute::gemm(mma_qk, tSrQ, tSrK, tSrS);
       }
@@ -921,7 +1121,7 @@ struct DecodeFwdMainloop<
       }
 
       /* Apply softmax and scaling */
-      softmax(K == 0, tSrS, tA_max, tA_sum, tArA, qk_scale);
+      softmax(K == 0, tSrS, tA_max, tA_sum, tArA);
       reorder(tSrS, tArP);
 
       /* GEMM 2: A += P * V, split in v dimension */
@@ -929,7 +1129,12 @@ struct DecodeFwdMainloop<
       for (int VV = 0; VV < VTiles; VV++) {
         copy(copy_v, tVgV_cache(_, _, _, VV), tVrV);
         reorder(tVrV, tArV);
-        // FP8 V dequant (scale_v) is deferred to the epilogue.
+        if constexpr (Fp8KV) {
+          CUTLASS_PRAGMA_UNROLL
+          for (int i = 0; i < tArV.size(); ++i) {
+            tArV(i) = static_cast<ElementQ>(scale_v * static_cast<float>(tArV(i)));
+          }
+        }
         cute::gemm(mma_pv, tArP, tArV, tArA(_, _, _, VV));
       }
 
@@ -961,12 +1166,11 @@ struct DecodeFwdMainloop<
   // Single step of blocked softmax.
   CUTLASS_DEVICE
   void softmax(
-      bool first_block,     // First softmax block?
-      FragS& tS,            // Softmax src/dst block
-      FragSRow& tS_max,     // Softmax row-wise max accumulator
-      FragSRow& tS_sum,     // Softmax row-wise sum accumulator
-      FragA& tA,            // O accumulator (for rescaling)
-      ElementS qk_scale) {  // Q*K scale (folds in fp8 K per-tensor scale_k)
+      bool first_block,  // First softmax block?
+      FragS& tS,         // Softmax src/dst block
+      FragSRow& tS_max,  // Softmax row-wise max accumulator
+      FragSRow& tS_sum,  // Softmax row-wise sum accumulator
+      FragA& tA) {       // O accumulator (for rescaling)
 
     /* Compute row-wise maxima for this block */
     auto tS_bmax = reduce<1>(tS, sycl::maximum{});
@@ -975,13 +1179,13 @@ struct DecodeFwdMainloop<
     auto tS_prev_max = tS_max;
     CUTLASS_PRAGMA_UNROLL
     for (int i = 0; i < tS_max.size(); i++) {
-      tS_max(i) = sycl::max(tS_max(i), qk_scale * tS_bmax(i));
+      tS_max(i) = sycl::max(tS_max(i), params.scale * tS_bmax(i));
     }
 
     /* Scale S and subtract maxima, then exponentiate */
     CUTLASS_PRAGMA_UNROLL
     for (int i = 0; i < tS.size(); i++)
-      tS(i) = sycl::native::exp2(qk_scale * tS(i) - broadcast<0>(tS_max, tS, i));
+      tS(i) = sycl::native::exp2(params.scale * tS(i) - broadcast<0>(tS_max, tS, i));
 
     /* Rescale existing S sums and O accumulator */
     if (!first_block) {

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_fhma_fwd_kernel.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_fhma_fwd_kernel.hpp
@@ -151,11 +151,6 @@ class XeFMHAFwdKernel {
     // Per-batch skip mask for two-kernel mix-batch dispatch
     // If non-null, the tile loop skips batches where mask[idx_b] is true.
     const bool* skip_batch_mask = nullptr;
-    // FP8 KV per-tensor dequant scales. Device pointers to the single descale
-    // scalar; the kernel dereferences them on-device, so the caller never does
-    // a host-side D2H sync (tensor.item()). Null => non-fp8 KV (scale = 1.0f).
-    const float* scale_k_ptr = nullptr;
-    const float* scale_v_ptr = nullptr;
   };
   using KernelParams = KernelArguments;
 
@@ -243,6 +238,25 @@ class XeFMHAFwdKernel {
   }
 
   CUTLASS_DEVICE
+  int get_k_new_len(MainloopParams const& mainloop, int batch) {
+    if constexpr (CollectiveMainloop::AppendKV) {
+      if (mainloop.append.ptr_K_new == nullptr || mainloop.append.ptr_V_new == nullptr ||
+          mainloop.append.ptr_cache_seqlens == nullptr || mainloop.append.total_k_new <= 0 ||
+          (mainloop.append.ptr_cu_seqlens_k_new == nullptr && mainloop.append.seq_len_kv_new <= 0)) {
+        return 0;
+      }
+      if (mainloop.append.ptr_cu_seqlens_k_new != nullptr) {
+        return mainloop.append.ptr_cu_seqlens_k_new[batch + 1] - mainloop.append.ptr_cu_seqlens_k_new[batch];
+      }
+      return mainloop.append.seq_len_kv_new;
+    } else {
+      (void)mainloop;
+      (void)batch;
+      return 0;
+    }
+  }
+
+  CUTLASS_DEVICE
   void operator()(Params const& params, char* smem_buf) {
     using namespace sycl::ext::oneapi::this_work_item;
 
@@ -275,6 +289,13 @@ class XeFMHAFwdKernel {
 
       auto sequence_length_shape = get_sequence_length_shape(s, idx_b);
       auto [seq_len_qo, seq_len_kv, seq_len_kv_cache] = sequence_length_shape;
+      int seq_k_eff = seq_len_kv_cache;
+      if constexpr (CollectiveMainloop::AppendKV) {
+        int const seq_k_new = get_k_new_len(params.mainloop, idx_b);
+        if (seq_k_new > 0) {
+          seq_k_eff = params.mainloop.append.ptr_cache_seqlens[idx_b] + seq_k_new;
+        }
+      }
       // M extent of the Q/O tile: the packed GQA group for decode, otherwise the
       // query sequence length. Masking below still uses the real seq_len_qo so
       // the decode KV position (seq_len_kv_cache - seq_len_qo) stays correct.
@@ -286,7 +307,7 @@ class XeFMHAFwdKernel {
       // auto offset = cute::min(seq_len_qo, seq_len_kv_cache);
       auto offset = seq_len_qo;
       auto discard_seq_coord = seq_len_qo - offset;
-      auto full_tile_offset = seq_len_kv_cache - offset;
+      auto full_tile_offset = seq_k_eff - offset;
       int seq_coord = cute::min(seq_len_qo, (blk_q * get<0>(TileShapeQK{}) + q_offset_sg));
 
       // if (CollectiveMainloop::CausalMask && seq_coord < discard_seq_coord) continue;
@@ -297,12 +318,28 @@ class XeFMHAFwdKernel {
       // const int seq_len = seq_len_new + seq_len_kv_cache;
       // const int k_blocks = cute::ceil_div(seq_len, get<1>(TileShapeQK{}));
 
-      const int seq_len = CollectiveMainloop::CausalMask
-                              ? cute::min(seq_len_kv_cache, full_tile_offset + seq_coord + q_sg_tile)
-                              : seq_len_kv_cache;
+      const int seq_len =
+          CollectiveMainloop::CausalMask ? cute::min(seq_k_eff, full_tile_offset + seq_coord + q_sg_tile) : seq_k_eff;
       const int k_blocks = cute::ceil_div(seq_len, get<1>(TileShapeQK{}));
       const int k_blocks_causal =
           CollectiveMainloop::CausalMask ? (seq_coord + full_tile_offset) / get<1>(TileShapeQK{}) : 0;
+      int append_store_len = -1;
+      if constexpr (CollectiveMainloop::AppendKV) {
+        int const seq_k_new = get_k_new_len(params.mainloop, idx_b);
+        if (seq_k_new > 0) {
+          append_store_len = seq_k_new;
+          if constexpr (CollectiveMainloop::CausalMask && !PackGQA_) {
+            // Without a grid-wide barrier, each WG must write every appended
+            // token it may read; causal tiles only need the visible prefix.
+            int const cache_len_old = params.mainloop.append.ptr_cache_seqlens[idx_b];
+            int const tile_q = get<0>(TileShapeQK{});
+            int const q_tile_end = cute::min(seq_len_qo, (blk_q + 1) * tile_q);
+            int const visible_k_end = cute::min(seq_k_eff, full_tile_offset + q_tile_end);
+            append_store_len = cute::max(0, visible_k_end - cache_len_old);
+            append_store_len = cute::min(append_store_len, seq_k_new);
+          }
+        }
+      }
 
       // Sliding-window pruning: skip K blocks that are entirely outside the
       // [row - window_size_left, row + window_size_right] band for all rows in
@@ -386,15 +423,6 @@ class XeFMHAFwdKernel {
       // With PackGQA the Q/O head dimension is indexed by the KV head; otherwise
       // by the (un-grouped) query head.
       int q_head_idx = PackGQA_ ? head : head_q;
-      // FP8 KV: the per-tensor dequant scale baked into KernelArguments is
-      // passed as a float function argument (scale_k) to the mainloop GEMM1.
-      // It defaults to 1.0f for non-fp8 KV; the fp8 dequant scalar is read
-      // on-device from scale_k_ptr (avoids a host-side .item() D2H sync) only
-      // in the fp8 instantiation, so non-fp8 kernels compile the read out.
-      float scale_k = 1.0f;
-      if constexpr (CollectiveMainloop::Fp8KV) {
-        scale_k = *p.scale_k_ptr;
-      }
       CollectiveMainloop mainloop(params.mainloop, shared_storage.mainloop);
       mainloop(
           Q(_, _, q_head_idx, l_coord),
@@ -410,13 +438,15 @@ class XeFMHAFwdKernel {
           k_blocks_causal,
           thr_id,
           seq_len,
-          seq_len_kv_cache,
+          seq_k_eff,
           idx_b,
+          head,
+          s.num_heads_kv,
           full_tile_offset,
           discard_seq_coord,
+          append_store_len,
           K_cache(_, _, head, l_coord),
-          V_cache(_, _, head, l_coord),
-          scale_k);
+          V_cache(_, _, head, l_coord));
 
       if constexpr (!is_empty_v<MainloopSharedStorage> && !is_empty_v<EpilogueSharedStorage>) {
         sycl::group_barrier(get_work_group<3>());
@@ -424,14 +454,6 @@ class XeFMHAFwdKernel {
 
       // Epilogue
       CollectiveEpilogue epilogue{params.epilogue, shared_storage.epilogue};
-      // FP8 KV: the per-tensor V dequant scale is applied once in the epilogue
-      // (folded into the softmax normalization) instead of per V element in the
-      // mainloop GEMM2. It defaults to 1.0f for non-fp8 KV; the fp8 dequant
-      // scalar is read on-device from scale_v_ptr only in the fp8 instantiation.
-      float scale_v = 1.0f;
-      if constexpr (CollectiveMainloop::Fp8KV) {
-        scale_v = *p.scale_v_ptr;
-      }
       if constexpr (Sink) {
         if constexpr (PackGQA_) {
           // Packed decode: pass the per-row sink base for this KV head's group
@@ -444,15 +466,14 @@ class XeFMHAFwdKernel {
               tA_sum,
               blk_qv,
               thr_id,
-              scale_v,
               ElementSink{},
               p.sm_sink + head * head_group_q,
               head_group_q);
         } else {
-          epilogue(O(_, _, q_head_idx, l_coord), tArA, tA_max, tA_sum, blk_qv, thr_id, scale_v, p.sm_sink[q_head_idx]);
+          epilogue(O(_, _, q_head_idx, l_coord), tArA, tA_max, tA_sum, blk_qv, thr_id, p.sm_sink[q_head_idx]);
         }
       } else {
-        epilogue(O(_, _, q_head_idx, l_coord), tArA, tA_max, tA_sum, blk_qv, thr_id, scale_v);
+        epilogue(O(_, _, q_head_idx, l_coord), tArA, tA_max, tA_sum, blk_qv, thr_id);
       }
     }
   }
@@ -541,11 +562,6 @@ class XeFMHAFwdDynamicSplitKernel {
     // mix-batch path) but kept for uniform aggregate initialization in the
     // shared runner template.
     const bool* skip_batch_mask = nullptr;
-    // FP8 KV per-tensor dequant scales. Device pointers to the single descale
-    // scalar (DynamicSplit does not support fp8, so these stay null and the
-    // scale resolves to 1.0f); present for uniform aggregate initialization.
-    const float* scale_k_ptr = nullptr;
-    const float* scale_v_ptr = nullptr;
   };
   using KernelParams = KernelArguments;
 
@@ -906,14 +922,7 @@ class XeFMHAFwdDynamicSplitKernel {
 
         // Epilogue
         CollectiveEpilogue epilogue{params.epilogue, shared_storage.epilogue};
-        // FP8 KV: apply the per-tensor V dequant scale once in the epilogue.
-        // It defaults to 1.0f for non-fp8 KV; read on-device only in the fp8
-        // instantiation.
-        float scale_v = 1.0f;
-        if constexpr (CollectiveMainloop::Fp8KV) {
-          scale_v = *p.scale_v_ptr;
-        }
-        epilogue(O(_, _, head_q, idx_b), tArA, tA_max, tA_sum, blk_qv, thr_id, scale_v);
+        epilogue(O(_, _, head_q, idx_b), tArA, tA_max, tA_sum, blk_qv, thr_id);
       }
     }
   }
@@ -998,11 +1007,6 @@ class XeFMHAFwdSplitKVKernel {
     // Per-batch skip mask for two-kernel mix-batch dispatch
     // (see https://github.com/vllm-project/vllm-xpu-kernels/pull/218).
     const bool* skip_batch_mask = nullptr;
-    // FP8 KV per-tensor dequant scales. Device pointers to the single descale
-    // scalar; the kernel dereferences them on-device, so the caller never does
-    // a host-side D2H sync (tensor.item()). Null => non-fp8 KV (scale = 1.0f).
-    const float* scale_k_ptr = nullptr;
-    const float* scale_v_ptr = nullptr;
   };
   using KernelParams = KernelArguments;
 
@@ -1221,18 +1225,6 @@ class XeFMHAFwdSplitKVKernel {
       int start_blk = kv_split_offset;
       int end_blk = kv_split_offset + num_effective_kv_blocks;
 
-      // FP8 KV: the per-tensor dequant scales baked into KernelArguments.
-      // scale_k is applied to K in the mainloop GEMM1; scale_v is folded into
-      // the softmax normalization in the epilogue (not the mainloop GEMM2).
-      // Both default to 1.0f for non-fp8 KV; the fp8 dequant scalars are read
-      // on-device from the descale pointers only in the fp8 instantiation
-      // (avoids a host-side .item() D2H sync).
-      float scale_k = 1.0f;
-      float scale_v = 1.0f;
-      if constexpr (CollectiveMainloop::Fp8KV) {
-        scale_k = *p.scale_k_ptr;
-        scale_v = *p.scale_v_ptr;
-      }
       CollectiveMainloop mainloop(params.mainloop, shared_storage.mainloop);
 
       mainloop(
@@ -1250,8 +1242,7 @@ class XeFMHAFwdSplitKVKernel {
           thr_id,
           seq_len,
           full_tile_offset,
-          discard_seq_coord,
-          scale_k);
+          discard_seq_coord);
 
       if constexpr (!is_empty_v<MainloopSharedStorage> && !is_empty_v<EpilogueSharedStorage>) {
         sycl::group_barrier(get_work_group<3>());
@@ -1268,7 +1259,6 @@ class XeFMHAFwdSplitKVKernel {
             tA_sum,
             blk_qv,
             thr_id,
-            scale_v,
             exp_sums(_, _, head, l_coord),
             max_logits(_, _, head, l_coord),
             idx_kv_split,
@@ -1284,7 +1274,6 @@ class XeFMHAFwdSplitKVKernel {
             tA_sum,
             blk_qv,
             thr_id,
-            scale_v,
             exp_sums(_, _, head, l_coord),
             max_logits(_, _, head, l_coord),
             idx_kv_split,

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
@@ -54,11 +54,8 @@ struct Arguments {
   void* __restrict__ k_ptr;
   void* __restrict__ v_ptr;
 
-  // FP8 KV cache per-tensor descale. The single scalar lives on-device; the
-  // kernel dereferences these pointers so no host-side D2H sync (.item()) is
-  // needed. Null => no fp8 dequant (scale = 1.0f).
-  const float* k_scale_ptr = nullptr;
-  const float* v_scale_ptr = nullptr;
+  void* __restrict__ k_scale_ptr = nullptr;
+  void* __restrict__ v_scale_ptr = nullptr;
 
   void* __restrict__ temp_out_ptr = nullptr;
   void* __restrict__ exp_sums_ptr = nullptr;
@@ -186,8 +183,8 @@ struct Arguments {
 
   bool is_bf16;
   bool is_fp32;
-  bool is_e4m3 = false;
-  bool is_e5m2 = false;
+  bool is_e4m3;
+  bool is_e5m2;
 
   bool is_rotary_interleaved;
 
@@ -325,8 +322,6 @@ struct DecodeRunner {
             stride_V_cache,
             static_cast<const typename FMHADecodeKernel::ElementSink*>(params.softmax_sink_ptr),
             static_cast<const bool*>(params.skip_batch_mask_ptr),
-            params.k_scale_ptr,
-            params.v_scale_ptr,
         },
         {params.softmax_scale,
          params.page_table,
@@ -488,10 +483,10 @@ struct SplitDecodeKernelRunner {
             stride_max_logits,
             reinterpret_cast<ElementQ*>(params.softmax_sink_ptr),
             static_cast<const bool*>(params.skip_batch_mask_ptr),
-            params.k_scale_ptr,
-            params.v_scale_ptr,
         },
         {params.softmax_scale,
+         params.k_scale_ptr,
+         params.v_scale_ptr,
          static_cast<int*>(params.page_table),
          params.page_size,
          params.max_num_pages_per_seq,

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_dispatch.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_dispatch.hpp
@@ -56,6 +56,6 @@ EXTERN_FMHA_PREFILL_RUNNER(512)
 // Directly call struct operator() - no function pointers.
 // Expands inside prefill::mha_fwd where a local `params` is in scope.
 
-#define DISPATCH_PREFILL_KERNEL(HD) FmhaPrefillRunner<HD>{}(params)
+#define DISPATCH_PREFILL_KERNEL(HD) ::prefill::FmhaPrefillRunner<HD>{}(params)
 
 }  // namespace prefill

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -48,6 +48,7 @@
 
 using namespace cute;
 namespace prefill {
+
 struct Arguments {
   // The QKV matrices.
   void* __restrict__ q_ptr;
@@ -95,12 +96,6 @@ struct Arguments {
   void* softmax_sink_ptr;
   float softcap;
 
-  // FP8 KV cache per-tensor descale. The single scalar lives on-device; the
-  // kernel dereferences these pointers so no host-side D2H sync (.item()) is
-  // needed. Null => no fp8 dequant (scale = 1.0f).
-  const float* k_scale_ptr = nullptr;
-  const float* v_scale_ptr = nullptr;
-
   // array of length b+1 holding starting offset of each sequence.
   int* __restrict__ cu_seqlens_q;
   int* __restrict__ cu_seqlens_k;
@@ -110,6 +105,7 @@ struct Arguments {
   // If provided, the actual length of each q/k sequence.
   int* __restrict__ seqused_q;
   int* __restrict__ seqused_k;
+  int* __restrict__ cache_seqlens_old;
 
   // The stride between rows of Oaccum.
   int64_t oaccum_split_stride;
@@ -170,8 +166,7 @@ struct Arguments {
 
   bool is_bf16;
   bool is_fp32;
-  bool is_e4m3 = false;
-  bool is_e5m2 = false;
+  bool is_e4m3;
   bool is_causal;
   bool is_local;
 
@@ -293,6 +288,22 @@ struct PrefillRunner {
   cutlass::Status run(const Arguments& params, const cutlass::KernelHardwareInfo& hw_info) {
     ProblemShapeType shape = initialize(params);
 
+    typename FMHAPrefillKernel::MainloopArguments mainloop_args{
+        params.softmax_scale,
+        params.page_table,
+        params.page_size,
+        params.max_num_pages_per_seq,
+        params.window_size_left,
+        params.window_size_right};
+    if constexpr (CollectiveMainloop::AppendKV) {
+      mainloop_args.append.ptr_K_new = static_cast<const ElementK*>(params.knew_ptr);
+      mainloop_args.append.ptr_V_new = static_cast<const ElementV*>(params.vnew_ptr);
+      mainloop_args.append.ptr_cu_seqlens_k_new = params.cu_seqlens_knew;
+      mainloop_args.append.ptr_cache_seqlens = params.cache_seqlens_old;
+      mainloop_args.append.seq_len_kv_new = params.seqlen_knew;
+      mainloop_args.append.total_k_new = params.total_knew;
+    }
+
     typename FMHAPrefillKernel::Arguments arguments{
         {
             shape,
@@ -310,17 +321,8 @@ struct PrefillRunner {
             stride_V_cache,
             static_cast<const typename FMHAPrefillKernel::ElementSink*>(params.softmax_sink_ptr),
             static_cast<const bool*>(params.skip_batch_mask_ptr),
-            params.k_scale_ptr,
-            params.v_scale_ptr,
         },
-        {
-            params.softmax_scale,
-            params.page_table,
-            params.page_size,
-            params.max_num_pages_per_seq,
-            params.window_size_left,
-            params.window_size_right,
-        },
+        mainloop_args,
         {},
         hw_info};
 
@@ -381,7 +383,7 @@ struct FMHAConfig {
       decltype(cutlass::fmha::collective::get_sg_layout_pv(SubgroupLayoutQK{})),
       SubgroupLayoutPV_>;
 
-  template <bool isVarLen, bool CachedKV, bool PagedKV, class Scheduler>
+  template <bool isVarLen, bool CachedKV, bool PagedKV, bool AppendKV, class Scheduler>
   static int run(const Arguments& params) {
     // The KernelHardwareInfo struct holds the number of EUs on the GPU with a given device ID. This
     // information is used by the underlying kernel.
@@ -431,7 +433,9 @@ struct FMHAConfig {
         GmemTiledCopyV,
         GmemTiledCopyK_cache,
         GmemTiledCopyV_cache,
-        LocalMask>;
+        LocalMask,
+        false,
+        AppendKV>;
 
     // Epilogue
     using CollectiveEpilogue =
@@ -460,14 +464,36 @@ struct FMHAConfig {
 
   // Paged KV cache: the page table encodes absolute KV positions.
   static int run_paged(const Arguments& params) {
-    // template <bool isVarLen, bool CachedKV, bool PagedKV, class Scheduler>
-    return run<true, true, true, cutlass::fmha::kernel::XeFHMAIndividualTileScheduler>(params);
+    TORCH_CHECK(params.cu_seqlens_q != nullptr, "paged prefill requires cu_seqlens_q");
+    TORCH_CHECK(params.cu_seqlens_k != nullptr, "paged prefill requires per-batch cache lengths in cu_seqlens_k");
+    TORCH_CHECK(params.page_table != nullptr, "paged prefill requires page_table");
+    TORCH_CHECK(params.page_size > 0, "paged prefill requires a positive page_size");
+    TORCH_CHECK(params.max_num_pages_per_seq > 0, "paged prefill requires max_num_pages_per_seq");
+    TORCH_CHECK(params.seqlen_q > 0 && params.seqlen_k > 0, "paged prefill requires positive max sequence lengths");
+    TORCH_CHECK(params.total_q > 0 && params.total_k > 0, "paged prefill requires positive total sequence lengths");
+    bool const has_append = params.total_knew > 0 && params.knew_ptr != nullptr && params.vnew_ptr != nullptr &&
+                            params.cache_seqlens_old != nullptr;
+    // template <bool isVarLen, bool CachedKV, bool PagedKV, bool AppendKV, class Scheduler>
+    if (has_append) {
+      return run<true, true, true, true, cutlass::fmha::kernel::XeFHMAIndividualTileScheduler>(params);
+    }
+    return run<true, true, true, false, cutlass::fmha::kernel::XeFHMAIndividualTileScheduler>(params);
   }
 
   // Non-paged (contiguous ragged) KV cache: addressed via cu_seqlens_k offsets.
   static int run_nopaged(const Arguments& params) {
-    // template <bool isVarLen, bool CachedKV, bool PagedKV, class Scheduler>
-    return run<true, true, false, cutlass::fmha::kernel::XeFHMAIndividualTileScheduler>(params);
+    TORCH_CHECK(params.cu_seqlens_q != nullptr, "non-paged prefill requires cu_seqlens_q");
+    TORCH_CHECK(params.cu_seqlens_k != nullptr, "non-paged prefill requires cumulative cu_seqlens_k");
+    TORCH_CHECK(params.page_table == nullptr, "non-paged prefill expects page_table to be null");
+    TORCH_CHECK(params.seqlen_q > 0 && params.seqlen_k > 0, "non-paged prefill requires positive max sequence lengths");
+    TORCH_CHECK(params.total_q > 0 && params.total_k > 0, "non-paged prefill requires positive total sequence lengths");
+    bool const has_append = params.total_knew > 0 && params.knew_ptr != nullptr && params.vnew_ptr != nullptr &&
+                            params.cache_seqlens_old != nullptr;
+    // template <bool isVarLen, bool CachedKV, bool PagedKV, bool AppendKV, class Scheduler>
+    if (has_append) {
+      return run<true, true, false, true, cutlass::fmha::kernel::XeFHMAIndividualTileScheduler>(params);
+    }
+    return run<true, true, false, false, cutlass::fmha::kernel::XeFHMAIndividualTileScheduler>(params);
   }
 
   static int run(const Arguments& params) {

--- a/src/sycl/xe_fmha_fwd_prefill_kernel.cpp.in
+++ b/src/sycl/xe_fmha_fwd_prefill_kernel.cpp.in
@@ -73,93 +73,76 @@ void FmhaPrefillRunner<@HEAD_DIM@>::operator()(const Arguments& params) const {
   using SubgroupLayoutQK =
       cute::Layout<cute::Shape<cute::Int<@NUM_SG@>, cute::_1, cute::_1>, cute::Stride<cute::_1, cute::_1, cute::_1>>;
 
-  if (params.is_e4m3 || params.is_e5m2) {
-    // FP8 KV cache: Q is bf16 or fp16, K/V cache are fp8 (e4m3 or e5m2). The
-    // mainloop dequantizes K/V with the per-tensor k_scale/v_scale (Fp8KV path).
-    TORCH_CHECK(
-        !use_sink, "fp8 KV cache prefill does not support sink logits");
+#if @HEAD_DIM@ == 128
+  if (params.seqlen_q <= 256 &&
+      static_cast<int64_t>(params.total_q) * 2 <= static_cast<int64_t>(params.b) * params.seqlen_q &&
+      params.d == 128 && params.dv == 128) {
+    using MixedTileShapeQK = cute::Shape<cute::Int<64>, cute::Int<64>, cute::_32>;
+    using MixedTileShapePV = cute::Shape<cute::Int<64>, cute::_32, cute::Int<64>>;
+    using MixedTileShapeOutput = cute::Shape<cute::Int<64>, cute::Int<128>>;
+    using MixedSubgroupLayoutQK =
+        cute::Layout<cute::Shape<cute::Int<8>, cute::_1, cute::_1>, cute::Stride<cute::_1, cute::_1, cute::_1>>;
+    TORCH_CHECK(!use_sink, "sink is only supported for head_size == 64, got @HEAD_DIM@");
     AT_DISPATCH_BOOL_NO_RETURN(params.is_local, LocalMask, {
       AT_DISPATCH_BOOL_NO_RETURN(params.is_causal, Causal, {
-        if (params.is_bf16) {
-          if (params.is_e4m3) {
-            FMHAConfig<
-                Causal,
-                LocalMask,
-                false,
-                TileShapeQK,
-                TileShapePV,
-                TileShapeOutput,
-                SubgroupLayoutQK,
-                void,
-                2,
-                false,
-                cutlass::bfloat16_t,
-                cutlass::float_e4m3_t,
-                cutlass::float_e4m3_t,
-                cutlass::bfloat16_t>::run_paged(params);
-          } else {
-            FMHAConfig<
-                Causal,
-                LocalMask,
-                false,
-                TileShapeQK,
-                TileShapePV,
-                TileShapeOutput,
-                SubgroupLayoutQK,
-                void,
-                2,
-                false,
-                cutlass::bfloat16_t,
-                cutlass::float_e5m2_t,
-                cutlass::float_e5m2_t,
-                cutlass::bfloat16_t>::run_paged(params);
-          }
-        } else {
-#if @EMIT_FP8_FP16@
-          if (params.is_e4m3) {
-            FMHAConfig<
-                Causal,
-                LocalMask,
-                false,
-                TileShapeQK,
-                TileShapePV,
-                TileShapeOutput,
-                SubgroupLayoutQK,
-                void,
-                2,
-                false,
-                cutlass::half_t,
-                cutlass::float_e4m3_t,
-                cutlass::float_e4m3_t,
-                cutlass::half_t>::run_paged(params);
-          } else {
-            FMHAConfig<
-                Causal,
-                LocalMask,
-                false,
-                TileShapeQK,
-                TileShapePV,
-                TileShapeOutput,
-                SubgroupLayoutQK,
-                void,
-                2,
-                false,
-                cutlass::half_t,
-                cutlass::float_e5m2_t,
-                cutlass::float_e5m2_t,
-                cutlass::half_t>::run_paged(params);
-          }
-#else
-          TORCH_CHECK(
-              false,
-              "fp8 KV cache with fp16 query is disabled at compile time; "
-              "rebuild with -DSGL_FMHA_FP8_KV_ENABLE_FP16=ON to enable it");
-#endif
-        }
+        FMHAConfig<
+            Causal,
+            LocalMask,
+            false,
+            MixedTileShapeQK,
+            MixedTileShapePV,
+            MixedTileShapeOutput,
+            MixedSubgroupLayoutQK>::run_paged(params);
       });
     });
     return;
   }
+
+  if (params.seqlen_q <= 32 && params.d == 128 && params.dv == 128) {
+    using SmallTileShapeQK = cute::Shape<cute::Int<32>, cute::Int<64>, cute::_32>;
+    using SmallTileShapePV = cute::Shape<cute::Int<32>, cute::_32, cute::Int<64>>;
+    using SmallTileShapeOutput = cute::Shape<cute::Int<32>, cute::Int<128>>;
+    using SmallSubgroupLayoutQK =
+        cute::Layout<cute::Shape<cute::Int<4>, cute::_1, cute::_1>, cute::Stride<cute::_1, cute::_1, cute::_1>>;
+    TORCH_CHECK(!use_sink, "sink is only supported for head_size == 64, got @HEAD_DIM@");
+    AT_DISPATCH_BOOL_NO_RETURN(params.is_local, LocalMask, {
+      AT_DISPATCH_BOOL_NO_RETURN(params.is_causal, Causal, {
+        FMHAConfig<
+            Causal,
+            LocalMask,
+            false,
+            SmallTileShapeQK,
+            SmallTileShapePV,
+            SmallTileShapeOutput,
+            SmallSubgroupLayoutQK>::run_paged(params);
+      });
+    });
+    return;
+  }
+
+  if (params.seqlen_q <= 64 && params.d == 128 && params.dv == 128) {
+    using SmallTileShapeQK = cute::Shape<cute::Int<64>, cute::Int<64>, cute::_32>;
+    using SmallTileShapePV = cute::Shape<cute::Int<64>, cute::_32, cute::Int<64>>;
+    using SmallTileShapeOutput = cute::Shape<cute::Int<64>, cute::Int<128>>;
+    using SmallSubgroupLayoutQK =
+        cute::Layout<cute::Shape<cute::Int<8>, cute::_1, cute::_1>, cute::Stride<cute::_1, cute::_1, cute::_1>>;
+    TORCH_CHECK(!use_sink, "sink is only supported for head_size == 64, got @HEAD_DIM@");
+    AT_DISPATCH_BOOL_NO_RETURN(params.is_local, LocalMask, {
+      AT_DISPATCH_BOOL_NO_RETURN(params.is_causal, Causal, {
+        FMHAConfig<
+            Causal,
+            LocalMask,
+            false,
+            SmallTileShapeQK,
+            SmallTileShapePV,
+            SmallTileShapeOutput,
+            SmallSubgroupLayoutQK>::run_paged(params);
+      });
+    });
+    return;
+  }
+
+#endif
 
 #if @HEAD_DIM@ == 64
   AT_DISPATCH_BOOL_NO_RETURN(use_sink, Sink, {

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -167,7 +167,10 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "    int      num_kv_splits,"
       "    bool?    pack_gqa,"
       "    int      sm_margin,"
-      "    Tensor(a!)?  out=None) -> (Tensor(a!), Tensor, Tensor, Tensor)");
+      "    Tensor(a!)?  out=None,"
+      "    Tensor?  k_new=None,"
+      "    Tensor?  v_new=None,"
+      "    Tensor?  cu_seqlens_k_new=None) -> (Tensor(a!), Tensor, Tensor, Tensor)");
   m.impl("fwd", torch::kXPU, make_pytorch_shim(&mha_fwd));
 
   m.def("flash_mla_get_workspace_size", &flash_mla_get_workspace_size);

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -59,7 +59,7 @@ DISABLE_BACKWARD = True
 
 DISABLE_SPLIT = True
 DISABLE_PAGEDKV = False
-DISABLE_APPENDKV = True
+DISABLE_APPENDKV = False
 DISABLE_LOCAL = True
 DISABLE_SOFTCAP = True
 DISABLE_PACKGQA = True
@@ -479,7 +479,7 @@ def generate_qkv(
     "dtype", [torch.bfloat16] + ([torch.float8_e4m3fn] if not DISABLE_FP8 else [])
 )
 @pytest.mark.parametrize("nheads_q,nheads_kv", [(16, 16), (16, 4)])
-@pytest.mark.parametrize("new_kv", [False])
+@pytest.mark.parametrize("new_kv", [False, True])
 @pytest.mark.parametrize("causal,local", [(False, True), (False, False), (True, False)])
 @pytest.mark.parametrize("use_sinks", [True, False])
 @pytest.mark.parametrize("seqlen_new_eq_seqlen_q", [True])
@@ -691,10 +691,13 @@ def test_flash_attn_kvcache(
                 dtype,
                 dtype_ref,
             )
+        cache_seqlens_high = seqlen_k - seqlen_new + 1 if new_kv else seqlen_k
+        if cache_seqlens_high <= seqlen_q:
+            pytest.skip("new_kv requires room for appended KV")
         cache_seqlens = torch.randint(
             seqlen_q,
             # If we don't use seqlen_q in the case of causal and rotary, cos/sin won't be long enough
-            seqlen_k,
+            cache_seqlens_high,
             (batch_size,),
             dtype=torch.int32,
             device=device,
@@ -880,6 +883,7 @@ def test_flash_attn_kvcache(
                     cu_seqlens_q=cu_seqlens_q,
                     cu_seqlens_k_new=cu_seqlens_k_new,
                     max_seqlen_q=max_seqlen_q,
+                    max_seqlen_k=seqlen_new if new_kv else max_seqlen_k,
                     rotary_seqlens=rotary_seqlens,
                     causal=causal,
                     window_size=window_size,


### PR DESCRIPTION
## Summary
- Replace the old two-launch `chunkprefill` dispatcher with the FMHA prefill-with-KVcache AppendKV path.
- Route mixed/prefill batches through `prefill::mha_fwd`; keep pure paged decode on `decode::mha_fwd`.
- Wire existing Python `k` / `v` / `cu_seqlens_k_new` inputs through to native AppendKV params.
- Enable AppendKV coverage in `test_flash_attn_kvcache`.
- Keep FP8 e5m2 support on decode/split-decode; prefill/AppendKV remains unsupported for e5m2.
- Pull in the latest hd128 mixed-batch optimization from fmha-cri: remove the post-AppendKV device fence and add small/underutilized hd128 paged prefill tile dispatch.

## Validation
- `MAX_JOBS=4 CMAKE_BUILD_PARALLEL_LEVEL=4 python -m pip install -v .` passed.
- `pytest -q tests/test_flash_attention.py::test_flash_attn_kvcache`: 1200 passed, 1872 skipped.
- `pytest -q tests/test_flash_attention.py::test_flash_attn_decode_kvcache`: 640 passed, 384 skipped.
- `python -m pre_commit run --all-files --show-diff-on-failure` passed.

## Benchmark Notes
Baseline is the old chunk-prefill implementation: the previous `chunkprefill` dispatcher using separate decode/prefill launches. Current is the new single-kernel prefill path with AppendKV enabled.

Both sides are timed through one `flash_attn_with_kvcache(...)` callable with `new_k/new_v` inputs. For the old baseline, any append/copy done by the old double-launch path is inside the measured callable interval.

Benchmarks use bf16 KV, heads q/kv = 16/4, head dim = 128, and `triton.testing.do_bench(warmup=100, rep=500, return_mode="mean")` unless otherwise noted. Speedup ratio is `old double-launch ms / AppendKV ms`, shown as a percentage.

## AppendKV Size Sweep
Cache old length is 4096, page size is 64, causal/local are both false.

| batch | new_k/v per row | total new_k/v | new_k/v shape | old double-launch ms | AppendKV ms | speedup ratio |
|---:|---:|---:|:---|---:|---:|---:|
| 8 | 16 | 128 | `[8,16,4,128]` | 1.2790 | 0.4296 | 297.7% |
| 8 | 64 | 512 | `[8,64,4,128]` | 1.2343 | 0.5515 | 223.8% |
| 8 | 128 | 1024 | `[8,128,4,128]` | 1.2030 | 1.1659 | 103.2% |
| 8 | 256 | 2048 | `[8,256,4,128]` | 1.2698 | 1.2187 | 104.2% |
| 16 | 16 | 256 | `[16,16,4,128]` | 2.2723 | 0.6967 | 326.1% |
| 16 | 64 | 1024 | `[16,64,4,128]` | 2.1865 | 0.9060 | 241.3% |
| 16 | 128 | 2048 | `[16,128,4,128]` | 2.1778 | 2.1274 | 102.4% |
| 16 | 256 | 4096 | `[16,256,4,128]` | 2.3459 | 2.2693 | 103.4% |

## Mixed Varlen Chunk-Prefill
The first row mirrors the standalone window-3 style shape. The hd128 mixed-batch tile added here is selected for max new_k/v <= 256, so the q1/q512 row is listed separately from the <=256 mixed sweep.

| pattern | rows decode/prefill | q_lens | old_lens | total new_k/v | max new_k/v | new_k/v shape | page | mask | old double-launch ms | AppendKV ms | speedup ratio |
|:---|---:|:---|:---|---:|---:|:---|---:|:---|---:|---:|---:|
| window3_q1_q512 | 1/1 | `1/512` | `8191/7680` | 513 | 512 | `[513,4,128]` | 128 | causal | 1.0000 | 1.0740 | 93.1% |
| decode_heavy | 10/6 | `1/1/1/1/1/1/1/1/16/32/64/128/1/1/8/256` | `4096 x16` | 514 | 256 | `[514,4,128]` | 64 | none | 2.2387 | 0.9746 | 229.7% |
| decode_heavy | 10/6 | `1/1/1/1/1/1/1/1/16/32/64/128/1/1/8/256` | `4096 x16` | 514 | 256 | `[514,4,128]` | 64 | causal | 2.1849 | 0.9735 | 224.5% |
| balanced | 8/8 | `1/16/1/32/1/64/1/128/1/256/8/1/64/1/32/1` | `4096 x16` | 608 | 256 | `[608,4,128]` | 64 | none | 2.2321 | 0.9994 | 223.3% |
| balanced | 8/8 | `1/16/1/32/1/64/1/128/1/256/8/1/64/1/32/1` | `4096 x16` | 608 | 256 | `[608,4,128]` | 64 | causal | 2.1863 | 0.9982 | 219.0% |
| balanced | 8/8 | `1/16/1/32/1/64/1/128/1/256/8/1/64/1/32/1` | `4096 x16` | 608 | 256 | `[608,4,128]` | 64 | local | 1.2182 | 0.5050 | 241.2% |
| prefill_heavy | 3/13 | `64/128/256/128/64/32/16/8/1/1/64/128/256/32/1/16` | `4096 x16` | 1195 | 256 | `[1195,4,128]` | 64 | none | 2.2224 | 1.3131 | 169.2% |
| prefill_heavy | 3/13 | `64/128/256/128/64/32/16/8/1/1/64/128/256/32/1/16` | `4096 x16` | 1195 | 256 | `[1195,4,128]` | 64 | causal | 2.1688 | 1.3169 | 164.7% |
