### PR TITLE
[XPU] Add fused MXFP8 W8A16 GEMM (moe_grouped_mm_nt_xe20_mxfp8_w8a16)

### DIFF
--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -388,6 +388,15 @@ void moe_grouped_mm_nt_xe20_mxfp4_w4a16(
     double gemm1_alpha = 1.702,
     double gemm1_limit = 7.0);
 
+void moe_grouped_mm_nt_xe20_mxfp8_w8a16(
+    torch::Tensor& output,
+    const torch::Tensor& activations,
+    const torch::Tensor& packed_weights,
+    const torch::Tensor& scales,
+    const std::optional<at::Tensor>& bias,
+    const torch::Tensor& total_rows_for_experts,
+    const int64_t n_experts);
+
 void prepare_moe_input(
     const torch::Tensor& topk_ids,
     torch::Tensor& expert_offsets,

--- a/python/sgl_kernel/__init__.py
+++ b/python/sgl_kernel/__init__.py
@@ -65,6 +65,7 @@ from sgl_kernel.gemm import (
     fp8_blockwise_scaled_mm,
     fp8_scaled_mm,
     int8_scaled_mm,
+    mxfp8_w8a16_gemm,
     qserve_w4a8_per_chn_gemm,
     qserve_w4a8_per_group_gemm,
     scaled_fp4_experts_quant,

--- a/python/sgl_kernel/gemm.py
+++ b/python/sgl_kernel/gemm.py
@@ -42,6 +42,57 @@ def fp8_scaled_mm(mat_a, mat_b, scales_a, scales_b, out_dtype, bias=None):
     )
 
 
+def mxfp8_w8a16_gemm(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Dense MXFP8 W8A16 GEMM: out[M, N] = input[M, K] @ weight[N, K]^T.
+
+    - input: bf16 activations, shape [M, K] (or [*, K]; flattened here).
+    - weight: float8_e4m3fn MXFP8 weights, shape [N, K] (one byte per element).
+    - weight_scale: fp32 per-32-K-block "direct multiplier" scales, shape
+      [N, K/32] (UE8M0 already decoded to 2**(e-127) by the caller).
+    - bias: optional fp32 bias, shape [N].
+
+    Wraps the grouped kernel with a single logical expert (dense case).
+    """
+    assert input.dim() >= 2, "input must be at least 2D [.., K]"
+    assert weight.dim() == 2, "weight must be 2D [N, K]"
+    assert weight.dtype == torch.float8_e4m3fn, "weight must be float8_e4m3fn"
+    assert weight_scale.dtype == torch.float32, "weight_scale must be float32 (direct multiplier)"
+
+    out_shape = (*input.shape[:-1], weight.shape[0])
+    input_2d = input.reshape(-1, input.shape[-1])
+    input_2d = input_2d.contiguous() if not input_2d.is_contiguous() else input_2d
+    m = input_2d.shape[0]
+    n, k = weight.shape
+
+    # Grouped kernel expects [E, N, K] weights, [E, N, K/32] scales and a
+    # per-expert row count; the dense case is a single expert covering all M rows.
+    packed_weights = weight.unsqueeze(0)
+    scales = weight_scale.unsqueeze(0)
+    total_rows_for_experts = torch.tensor([m], dtype=torch.int32, device=input.device)
+
+    bias_arg = None
+    if bias is not None:
+        # Kernel expects fp32 bias shaped [E, N].
+        bias_arg = bias.to(torch.float32).reshape(1, n).contiguous()
+
+    output = torch.empty((m, n), dtype=torch.bfloat16, device=input.device)
+    torch.ops.sgl_kernel.moe_grouped_mm_nt_xe20_mxfp8_w8a16.default(
+        output,
+        input_2d,
+        packed_weights,
+        scales,
+        bias_arg,
+        total_rows_for_experts,
+        1,
+    )
+    return output.reshape(out_shape)
+
+
 def _bmm_fp8_internal(
     workspace_buffer: torch.Tensor,
     A: torch.Tensor,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,7 @@ list(APPEND ATen_XPU_SYCL_XE20 ${device_cpp_xe20})
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/GroupGemmXe20.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/GroupGemmMxfp4W4A16Xe20.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/GroupGemmMxfp8W8A16Xe20.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/SGEMMLoraAFwdXe20.cmake)
 
 set(ATen_XPU_CPP_SRCS ${ATen_XPU_CPP_SRCS} PARENT_SCOPE)

--- a/src/GroupGemmMxfp8W8A16Xe20.cmake
+++ b/src/GroupGemmMxfp8W8A16Xe20.cmake
@@ -1,0 +1,31 @@
+set(GROUP_GEMM_MXFP8_W8A16_XE20_TEMPLATE "${CMAKE_CURRENT_SOURCE_DIR}/sycl/GroupGemmMxfp8W8A16Xe20LauncherInstance.cpp.in")
+set(GROUP_GEMM_MXFP8_W8A16_XE20_GEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated/group_gemm_mxfp8_w8a16_xe20")
+set(GROUP_GEMM_MXFP8_W8A16_XE20_INST_SRCS)
+file(MAKE_DIRECTORY ${GROUP_GEMM_MXFP8_W8A16_XE20_GEN_DIR})
+
+function(add_group_gemm_mxfp8_w8a16_xe20_inst TILE_M TILE_N TILE_K SG_SHAPE SG_STRIDE ACT_TYPE FUSE_ACT WITH_BIAS)
+    set(TILE "Shape<${TILE_M}, ${TILE_N}, ${TILE_K}>")
+    set(SGLAYOUT "Layout<Shape<${SG_SHAPE}>, Stride<${SG_STRIDE}>>")
+    set(GEN_SRC
+        "${GROUP_GEMM_MXFP8_W8A16_XE20_GEN_DIR}/GroupGemmMxfp8W8A16Xe20_inst_${TILE_M}_${TILE_N}_${TILE_K}_a${ACT_TYPE}_f${FUSE_ACT}_b${WITH_BIAS}.cpp")
+
+    configure_file(${GROUP_GEMM_MXFP8_W8A16_XE20_TEMPLATE} ${GEN_SRC} @ONLY)
+    list(APPEND GROUP_GEMM_MXFP8_W8A16_XE20_INST_SRCS ${GEN_SRC})
+    set(GROUP_GEMM_MXFP8_W8A16_XE20_INST_SRCS ${GROUP_GEMM_MXFP8_W8A16_XE20_INST_SRCS} PARENT_SCOPE)
+endfunction()
+
+# Dense MXFP8 W8A16 linear only needs the non-fused, silu(act=0) slice, with and
+# without bias, across the three non-fused tile shapes keyed on avg_m (matching
+# the mxfp4 non-fused tiles):
+#   <_8,   _64,  _32> / SG_1_4_1   — avg_m ≤ 8
+#   <_128, _128, _32> / SG_4_2_1   — avg_m ≤ 128 (small weight)
+#   <_256, _256, _32> / SG_8_4_1   — avg_m > 128
+# 3 tiles × {no-bias, bias} = 6 TUs. The dispatch-side declarations in
+# src/sycl/GroupGemmMxfp8W8A16Xe20.cpp must match this matrix exactly.
+foreach(with_bias false true)
+    add_group_gemm_mxfp8_w8a16_xe20_inst("_8" "_64" "_32" "_1, _4, _1" "_4, _1, _0" 0 false ${with_bias})
+    add_group_gemm_mxfp8_w8a16_xe20_inst("_128" "_128" "_32" "_4, _2, _1" "_2, _1, _0" 0 false ${with_bias})
+    add_group_gemm_mxfp8_w8a16_xe20_inst("_256" "_256" "_32" "_8, _4, _1" "_4, _1, _0" 0 false ${with_bias})
+endforeach()
+
+list(APPEND ATen_XPU_SYCL_XE20 ${GROUP_GEMM_MXFP8_W8A16_XE20_INST_SRCS})

--- a/src/sycl/GroupGemmMxfp8W8A16Xe20.cpp
+++ b/src/sycl/GroupGemmMxfp8W8A16Xe20.cpp
@@ -1,0 +1,162 @@
+#define SYCL_INTEL_TARGET 20
+
+#include <ATen/ATen.h>
+#include <c10/xpu/XPUStream.h>
+#include <torch/all.h>
+
+#include <cute/tensor.hpp>
+
+#include "Utils.h"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/group_array_problem_shape.hpp"
+#include "kernels/moe/xe20/mxfp8_w8a16/moe_kernel.hpp"
+
+using namespace cute;
+
+template <typename Tile, typename SGLayout, int ActType, bool FuseAct, bool WithBias>
+void Xe20MoEGEMMMxfp8W8A16Launcher(
+    sycl::queue q,
+    const void* activations,
+    const void* packed_weights,
+    const void* scales,
+    const void* bias,
+    void* outputs,
+    const int gemm_n,
+    const int gemm_k,
+    const int* num_rows_per_expert_device,
+    const int num_experts,
+    int* workspace,
+    float gemm1_alpha,
+    float gemm1_limit);
+
+// Tile menu (see GroupGemmMxfp8W8A16Xe20.cmake for the instantiation matrix).
+// The dense mxfp8 W8A16 linear path is non-fused (ActType=0, FuseAct=false),
+// so only that slice is instantiated -- with and without bias. Tile selection
+// mirrors the mxfp4 non-fused tiles keyed on avg_m.
+using Tile_8_64_32 = Shape<_8, _64, _32>;
+using Tile_128_128_32 = Shape<_128, _128, _32>;
+using Tile_256_256_32 = Shape<_256, _256, _32>;
+
+using SG_1_4_1 = Layout<Shape<_1, _4, _1>, Stride<_4, _1, _0>>;
+using SG_4_2_1 = Layout<Shape<_4, _2, _1>, Stride<_2, _1, _0>>;
+using SG_8_4_1 = Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>;
+
+#define DECLARE_XE20_MOE_MXFP8_EXTERN(Tile, SGLayout, WithBias)                             \
+  extern template void Xe20MoEGEMMMxfp8W8A16Launcher<Tile, SGLayout, 0, false, WithBias>(   \
+      sycl::queue,                                                                          \
+      const void*,                                                                          \
+      const void*,                                                                          \
+      const void*,                                                                          \
+      const void*,                                                                          \
+      void*,                                                                                \
+      const int,                                                                            \
+      const int,                                                                            \
+      const int*,                                                                           \
+      const int,                                                                            \
+      int*,                                                                                 \
+      float,                                                                                \
+      float);
+
+#define DECLARE_XE20_MOE_MXFP8_TILES(WithBias)              \
+  DECLARE_XE20_MOE_MXFP8_EXTERN(Tile_8_64_32, SG_1_4_1, WithBias)     \
+  DECLARE_XE20_MOE_MXFP8_EXTERN(Tile_128_128_32, SG_4_2_1, WithBias)  \
+  DECLARE_XE20_MOE_MXFP8_EXTERN(Tile_256_256_32, SG_8_4_1, WithBias)
+
+DECLARE_XE20_MOE_MXFP8_TILES(false)
+DECLARE_XE20_MOE_MXFP8_TILES(true)
+
+#undef DECLARE_XE20_MOE_MXFP8_TILES
+#undef DECLARE_XE20_MOE_MXFP8_EXTERN
+
+#define LAUNCH_MOE_MXFP8(...)                 \
+  Xe20MoEGEMMMxfp8W8A16Launcher<__VA_ARGS__>( \
+      queue,                                  \
+      activations.data_ptr(),                 \
+      packed_weights.data_ptr(),              \
+      scales.data_ptr(),                      \
+      bias_ptr,                               \
+      output.data_ptr(),                      \
+      gemm_n,                                 \
+      gemm_k,                                 \
+      total_rows_for_experts.data_ptr<int>(), \
+      n_experts,                              \
+      atomic_buffer.data_ptr<int>(),          \
+      1.0f,                                   \
+      7.0f)
+
+#define DISPATCH_MOE_MXFP8(WithBias, ...)          \
+  do {                                             \
+    if (WithBias) {                                \
+      LAUNCH_MOE_MXFP8(__VA_ARGS__, 0, false, true);  \
+    } else {                                       \
+      LAUNCH_MOE_MXFP8(__VA_ARGS__, 0, false, false); \
+    }                                              \
+  } while (0)
+
+// Dense/grouped MXFP8 W8A16 GEMM: output[M,N] = activations[M,K] @ B[N,K]^T
+// with per-32-K-block fp32 (direct-multiplier) scales. Non-fused, N-outer.
+// For a dense linear the caller passes n_experts == 1 and total_rows == [M].
+void moe_grouped_mm_nt_xe20_mxfp8_w8a16(
+    torch::Tensor& output,
+    const torch::Tensor& activations,
+    const torch::Tensor& packed_weights,  // [E, N, K] float8_e4m3fn (one byte/elem)
+    const torch::Tensor& scales,          // [E, N, K/32] float32 direct multiplier (N-outer)
+    const std::optional<at::Tensor>& bias,
+    const torch::Tensor& total_rows_for_experts,
+    const int64_t n_experts) {
+  int total_m = activations.sizes()[0];
+  int gemm_k = activations.sizes()[1];
+  auto pw_shape = packed_weights.sizes().vec();
+  int gemm_n = pw_shape[1];
+
+  TORCH_CHECK(pw_shape.size() == 3, "packed_weights must be 3D [E, N, K]");
+  TORCH_CHECK(pw_shape[0] == n_experts, "packed_weights first dim must equal n_experts");
+  TORCH_CHECK(pw_shape[1] == gemm_n, "packed_weights second dim must equal N");
+  TORCH_CHECK(pw_shape[2] == gemm_k, "packed_weights last dim must equal K (one e4m3 byte per element)");
+  TORCH_CHECK(
+      packed_weights.scalar_type() == at::ScalarType::Float8_e4m3fn, "packed_weights must be float8_e4m3fn");
+
+  auto sc_shape = scales.sizes().vec();
+  TORCH_CHECK(sc_shape.size() == 3, "scales must be 3D [E, N, K/32]");
+  TORCH_CHECK(sc_shape[0] == n_experts, "scales first dim must equal n_experts");
+  TORCH_CHECK(sc_shape[1] == gemm_n, "scales second dim must equal N");
+  TORCH_CHECK(
+      sc_shape[2] == gemm_k / MoE_MXFP8_W8A16::MXFP8_GROUP_SIZE, "scales last dim must equal K/32");
+  TORCH_CHECK(scales.scalar_type() == at::ScalarType::Float, "scales must be float32 (direct multiplier)");
+
+  TORCH_CHECK(
+      n_experts == total_rows_for_experts.size(0),
+      "total_rows_for_experts must have the same size as packed_weights.size(0)");
+  TORCH_CHECK(output.sizes()[0] == total_m, "output rows must match activations rows");
+  TORCH_CHECK(output.sizes()[1] == gemm_n, "output must have N columns");
+
+  TORCH_CHECK(activations.scalar_type() == at::ScalarType::BFloat16, "activations must be bfloat16");
+  TORCH_CHECK(output.scalar_type() == at::ScalarType::BFloat16, "output must be bfloat16");
+  TORCH_CHECK(
+      gemm_k % MoE_MXFP8_W8A16::MXFP8_GROUP_SIZE == 0, "K must be a multiple of GROUP_SIZE=32");
+
+  if (bias.has_value()) {
+    TORCH_CHECK(bias->scalar_type() == at::kFloat, "bias must be float32");
+    TORCH_CHECK(bias->dim() == 2, "bias must be 2D [E, N]");
+    TORCH_CHECK(bias->size(0) == n_experts && bias->size(1) == gemm_n, "bias shape mismatch");
+  }
+
+  auto stream = at::xpu::getCurrentXPUStream();
+  auto queue = stream.queue();
+  at::Tensor atomic_buffer = at::empty({static_cast<long>(1)}, activations.options().dtype(at::kInt));
+  bool with_bias = bias.has_value();
+  void* bias_ptr = with_bias ? bias->data_ptr() : nullptr;
+
+  int avg_m = total_m / n_experts;
+  bool small_weight = (int64_t)gemm_k * gemm_n <= MOE_GROUPED_GEMM_SMALL_WEIGHT_THRESHOLD;
+
+  if (avg_m <= 8) {
+    DISPATCH_MOE_MXFP8(with_bias, Shape<_8, _64, _32>, Layout<Shape<_1, _4, _1>, Stride<_4, _1, _0>>);
+  } else if (avg_m <= 128 && small_weight) {
+    DISPATCH_MOE_MXFP8(with_bias, Shape<_128, _128, _32>, Layout<Shape<_4, _2, _1>, Stride<_2, _1, _0>>);
+  } else {
+    DISPATCH_MOE_MXFP8(with_bias, Shape<_256, _256, _32>, Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>);
+  }
+}
+
+#undef SYCL_INTEL_TARGET

--- a/src/sycl/GroupGemmMxfp8W8A16Xe20LauncherInstance.cpp.in
+++ b/src/sycl/GroupGemmMxfp8W8A16Xe20LauncherInstance.cpp.in
@@ -1,0 +1,147 @@
+#define SYCL_INTEL_TARGET 20
+
+#include <ATen/ATen.h>
+#include <c10/xpu/XPUStream.h>
+#include <torch/all.h>
+
+#include <cute/tensor.hpp>
+
+#include "sycl/Utils.h"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/group_array_problem_shape.hpp"
+#include "sycl/kernels/moe/xe20/mxfp8_w8a16/moe_kernel.hpp"
+
+using namespace cute;
+
+template <typename, typename, typename, typename, typename, typename, int, bool, bool>
+class GemmXe20Mxfp8Name;
+
+template <typename Tile, typename SGLayout, int ActType, bool FuseAct, bool WithBias>
+void Xe20MoEGEMMMxfp8W8A16Launcher(
+    sycl::queue q,
+    const void* activations,
+    const void* packed_weights,
+    const void* scales,
+    const void* bias,
+    void* outputs,
+    const int gemm_n,
+    const int gemm_k,
+    const int* num_rows_per_expert_device,
+    const int num_experts,
+    int* workspace,
+    float gemm1_alpha,
+    float gemm1_limit) {
+  using ElementA = cutlass::bfloat16_t;
+
+  auto make_dummy_tensor_bf16 = [&](auto val, auto stride) {
+    return make_tensor(make_gmem_ptr(&val), make_layout(repeat<rank_v<decltype(stride)>>(1), stride));
+  };
+  auto make_dummy_tensor_u8 = [&](auto val, auto stride) {
+    return make_tensor(make_gmem_ptr(&val), make_layout(repeat<rank_v<decltype(stride)>>(1), stride));
+  };
+  auto make_dummy_bias = [&](auto val) {
+    if constexpr (FuseAct && ActType == 2) {
+      return make_tensor(make_gmem_ptr(&val), make_layout(Shape<int>{}, Stride<_2>{}));
+    } else {
+      return make_tensor(make_gmem_ptr(&val), make_layout(Shape<int>{}, Stride<_1>{}));
+    }
+  };
+
+  using StrideA = Stride<int, _1>;
+  using StrideB = Stride<int, _1>;
+  using StrideS = Stride<int, _1>;
+  using StrideD = Stride<int, _1>;
+
+  using TensorA = decltype(make_dummy_tensor_bf16(ElementA{}, StrideA{}));
+  // TensorBPacked uses cutlass::float_e4m3_t: one byte per element (no sub-byte
+  // packing). The underlying GMEM is uint8 bytes reinterpreted as e4m3.
+  using TensorBPacked = decltype(make_dummy_tensor_u8(cutlass::float_e4m3_t{}, StrideB{}));
+  using TensorD = decltype(make_dummy_tensor_bf16(ElementA{}, StrideD{}));
+  using TensorBias = decltype(make_dummy_bias(float{}));
+
+  using ElementA_non_CV = cutlass::platform::remove_cv_t<ElementA>;
+  // BF16 × BF16 DPAS: same MMA as the non-quantized path, because our B
+  // gets dequantized to bf16 in registers before cute::gemm is called.
+  using MMA =
+      typename TiledMMAHelper<MMA_Atom<XE_DPAS_TT<8, float, ElementA_non_CV>>, Layout<Tile>, SGLayout>::TiledMMA;
+  auto mma = MMA{};
+
+  int sm_count = cutlass::KernelHardwareInfo::query_device_multiprocessor_count(0);
+  auto MaxThreadsPerWorkgroup = size(mma);
+
+  static constexpr int MaxThreadsPerSM = 512;
+  TORCH_CHECK(
+      MaxThreadsPerSM % MaxThreadsPerWorkgroup == 0, "MaxThreadsPerSM must be divisible by MaxThreadsPerWorkgroup");
+
+  sycl::range<3> local(1, 1, MaxThreadsPerWorkgroup);
+  sycl::range<3> global(1, sm_count * MaxThreadsPerSM / MaxThreadsPerWorkgroup, 1);
+
+  namespace syclex = sycl::ext::oneapi::experimental;
+  namespace intelex = sycl::ext::intel::experimental;
+
+  syclex::properties kernel_props{syclex::sub_group_size<16>, intelex::grf_size<256>};
+
+  using Kernel = MoE_MXFP8_W8A16::MoEGEMMMxfp8W8A16<
+      Tile,
+      SGLayout,
+      TensorA,
+      TensorBPacked,
+      TensorD,
+      TensorBias,
+      MMA,
+      ActType,
+      FuseAct,
+      WithBias,
+      ElementA>;
+  typename Kernel::Params params{
+      static_cast<const ElementA*>(activations),
+      static_cast<const uint8_t*>(packed_weights),
+      static_cast<const float*>(scales),
+      static_cast<const float*>(bias),
+      static_cast<ElementA*>(outputs),
+      num_rows_per_expert_device,
+      gemm_n,
+      gemm_k,
+      num_experts,
+      workspace,
+      mma,
+      static_cast<float>(gemm1_alpha),
+      static_cast<float>(gemm1_limit),
+  };
+
+  q.submit([&](sycl::handler& h) {
+    sycl::local_accessor<int32_t, 1> local_mem(sycl::range<1>(1), h);
+    h.parallel_for<GemmXe20Mxfp8Name<
+        Tile,
+        SGLayout,
+        TensorA,
+        TensorBPacked,
+        TensorD,
+        ElementA,
+        ActType,
+        FuseAct,
+        WithBias>>(
+        sycl::nd_range<3>(global * local, local), kernel_props, [=](sycl::nd_item<3> item) {
+          int32_t* slm_mem =
+              static_cast<int32_t*>(local_mem.template get_multi_ptr<sycl::access::decorated::no>().get());
+          Kernel{}(params, item, slm_mem);
+        });
+  });
+}
+
+template void Xe20MoEGEMMMxfp8W8A16Launcher<@TILE@, @SGLAYOUT@, @ACT_TYPE@, @FUSE_ACT@, @WITH_BIAS@>(
+    sycl::queue,
+    const void*,
+    const void*,
+    const void*,
+    const void*,
+    void*,
+    const int,
+    const int,
+    const int*,
+    const int,
+    int*,
+    float,
+    float);
+
+#undef SYCL_INTEL_TARGET

--- a/src/sycl/kernels/moe/xe20/mxfp8_w8a16/moe_kernel.hpp
+++ b/src/sycl/kernels/moe/xe20/mxfp8_w8a16/moe_kernel.hpp
@@ -1,0 +1,310 @@
+/***************************************************************************************************
+ * Copyright (C) 2025 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ **************************************************************************************************/
+
+// MXFP8-B × BF16-A grouped-GEMM kernel for Xe2 (BMG).
+//
+// Fork of src/sycl/kernels/moe/xe20/mxfp4_w4a16/moe_kernel.hpp. Identical
+// per-expert tile-scheduler loop; the differences from the MXFP4 fork are:
+//   - B is float8_e4m3_t with row stride K (one byte per element, NOT K/2 --
+//     there is no nibble packing).
+//   - The per-expert B byte offset is N*K (not N*K/2).
+//   - Everything else (fp32 direct-multiplier scales with stride K/32, the
+//     mainloop call shape) is unchanged.
+//
+// The dense mxfp8 linear path invokes this with num_experts == 1 and
+// FuseAct == false: the scheduler loop then degenerates to a single dense
+// C[M,N] = A[M,K] @ B[N,K]^T problem.
+
+#pragma once
+
+#include "cute/tensor.hpp"
+#include "cutlass/cutlass.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/group_array_problem_shape.hpp"
+#include "cutlass/gemm/kernel/tile_scheduler.hpp"
+#include "cutlass/kernel_hardware_info.hpp"
+#include "cutlass/platform/platform.h"
+#include "cutlass/util/packed_stride.hpp"
+#include "moe_mainloop.hpp"
+
+#pragma clang diagnostic ignored "-Wpass-failed"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+namespace MoE_MXFP8_W8A16 {
+using namespace cute;
+
+template <
+    typename TileShape,
+    typename SubgroupLayout,
+    typename TensorA,
+    typename TensorBPacked,
+    typename TensorD,
+    typename TensorBias,
+    typename TiledMMA,
+    int ActType,
+    bool FuseAct,
+    bool WithBias,
+    typename ElementA,
+    typename ElementD = ElementA>
+class MoEGEMMMxfp8W8A16 {
+ public:
+  using TiledCopyA = decltype(make_block_2d_copy_A(TiledMMA{}, TensorA{}));
+  using TiledCopyBPacked = decltype(make_block_2d_copy_B(TiledMMA{}, TensorBPacked{}));
+  using TiledCopyD = decltype(make_block_2d_copy_D(TiledMMA{}, TensorD{}));
+  using SGPerWG = decltype(product(take<1, 4>(shape(typename TiledMMA::ThrLayoutVMNK{}))));
+
+  constexpr static int Stages = 3;
+  using MainloopDispatchPolicy = MoE_MXFP8_W8A16::XeDefault<Stages>;
+  using CollectiveMainloop = MoEMainloopMxfp8W8A16<
+      MainloopDispatchPolicy,
+      TiledCopyA,
+      TiledCopyBPacked,
+      TiledCopyD,
+      TensorA,
+      TensorBPacked,
+      TensorD,
+      TensorBias,
+      TiledMMA,
+      WithBias,
+      ActType>;
+
+  struct Params {
+    const ElementA* Activations;
+    // MXFP8 weights stored as a raw byte buffer of shape
+    // [num_experts, N, K] uint8, one float_e4m3_t element per byte. Pointer is
+    // kept in byte address space for per-expert offsetting (offset N*K bytes);
+    // wrapped into a float_e4m3_t CuTe tensor per-expert below.
+    const uint8_t* PackedWeights;
+    const float* Scales;  // [num_experts, N, K/GROUP_SIZE] fp32 direct multiplier
+    const float* Bias;
+    ElementD* Outputs;
+    const int32_t* M_per_group;
+    const int32_t N;
+    const int32_t K;
+    const int32_t num_experts;
+    int32_t* workspace;
+    TiledMMA mma;
+    float gemm1_alpha = 1.702f;
+    float gemm1_limit = 7.0f;
+  };
+
+  // Build B tensor(s) from a byte buffer. Inside CuTe, B's element type is
+  // cutlass::float_e4m3_t (1 byte). We reinterpret the uint8 byte pointer to
+  // float_e4m3_t* and wrap with make_gmem_ptr(raw_ptr) so the resulting type
+  // matches the launcher dummy tensor type: gmem_ptr<float_e4m3_t*>. Row
+  // stride is K (one byte per element -- no /2 halving as in MXFP4).
+  auto make_B_tensors(uint8_t* ptr_B, int N, int K) {
+    auto* e4m3_ptr = reinterpret_cast<cutlass::float_e4m3_t*>(ptr_B);
+    if constexpr (FuseAct) {
+      if constexpr (ActType == SWIGLU_GPT_OSS) {
+        // Interleaved [g0, u0, g1, u1, ...] → gate at byte offset 0,
+        // up at byte offset K (one row = K bytes).
+        auto B0 = make_tensor(make_gmem_ptr(e4m3_ptr), make_layout(make_shape(N / 2, K), make_stride(2 * K, _1{})));
+        auto B1 = make_tensor(
+            make_gmem_ptr(reinterpret_cast<cutlass::float_e4m3_t*>(ptr_B + K)),
+            make_layout(make_shape(N / 2, K), make_stride(2 * K, _1{})));
+        return cute::make_tuple(B0, B1);
+      } else {
+        // Block-split: first N/2 rows = gate, last N/2 rows = up.
+        // up rows start at byte offset (N/2) * K.
+        auto B0 = make_tensor(make_gmem_ptr(e4m3_ptr), make_layout(make_shape(N / 2, K), make_stride(K, _1{})));
+        auto B1 = make_tensor(
+            make_gmem_ptr(reinterpret_cast<cutlass::float_e4m3_t*>(ptr_B + (N / 2) * K)),
+            make_layout(make_shape(N / 2, K), make_stride(K, _1{})));
+        return cute::make_tuple(B0, B1);
+      }
+    } else {
+      auto B = make_tensor(make_gmem_ptr(e4m3_ptr), make_layout(make_shape(N, K), make_stride(K, _1{})));
+      return cute::make_tuple(B);
+    }
+  }
+
+  // Per-expert scale pointers + row stride. Returns a struct that matches
+  // the split-B pattern: gate/up base pointers for the fused-act path, or
+  // a single pointer for the non-fused path. Row stride is the N-row fp32
+  // element stride (= K/GROUP_SIZE for block-split and non-fused,
+  // 2*K/GROUP_SIZE for GPT-OSS interleaved layout).
+  struct ScalePtrs {
+    const float* ptr0;
+    const float* ptr1;
+    int row_stride;
+  };
+
+  ScalePtrs make_scale_ptrs(const float* ptr_S, int N, int K) {
+    const int K_scale = K / MXFP8_GROUP_SIZE;
+    if constexpr (FuseAct) {
+      if constexpr (ActType == SWIGLU_GPT_OSS) {
+        // Interleaved [g0, u0, g1, u1, ...] scales: gate rows at element
+        // offset 0, up rows at element offset K_scale; row stride = 2*K_scale.
+        return ScalePtrs{ptr_S, ptr_S + K_scale, 2 * K_scale};
+      } else {
+        // Block-split: up rows start after (N/2) gate rows.
+        return ScalePtrs{ptr_S, ptr_S + (N / 2) * K_scale, K_scale};
+      }
+    } else {
+      return ScalePtrs{ptr_S, nullptr, K_scale};
+    }
+  }
+
+  auto make_Bias_tensors(float* ptr_Bias, int N) {
+    if constexpr (WithBias) {
+      if constexpr (FuseAct) {
+        if constexpr (ActType == SWIGLU_GPT_OSS) {
+          auto Bias0 = make_tensor(make_gmem_ptr<float>(ptr_Bias), make_layout(make_shape(N / 2), make_stride(_2{})));
+          auto Bias1 =
+              make_tensor(make_gmem_ptr<float>(ptr_Bias + 1), make_layout(make_shape(N / 2), make_stride(_2{})));
+          return cute::make_tuple(Bias0, Bias1);
+        } else {
+          auto Bias0 = make_tensor(make_gmem_ptr<float>(ptr_Bias), make_layout(make_shape(N / 2), make_stride(_1{})));
+          float* ptr_Bias1 = ptr_Bias + (N / 2);
+          auto Bias1 = make_tensor(make_gmem_ptr<float>(ptr_Bias1), make_layout(make_shape(N / 2), make_stride(_1{})));
+          return cute::make_tuple(Bias0, Bias1);
+        }
+      } else {
+        auto Bias = make_tensor(make_gmem_ptr<float>(ptr_Bias), make_layout(make_shape(N), make_stride(_1{})));
+        return cute::make_tuple(Bias);
+      }
+    } else {
+      if constexpr (FuseAct && ActType == SWIGLU_GPT_OSS) {
+        return cute::make_tuple(
+            make_tensor(make_gmem_ptr<float>(nullptr), make_layout(make_shape(0), make_stride(_2{}))),
+            make_tensor(make_gmem_ptr<float>(nullptr), make_layout(make_shape(0), make_stride(_2{}))));
+      } else {
+        return cute::make_tuple(
+            make_tensor(make_gmem_ptr<float>(nullptr), make_layout(make_shape(0), make_stride(_1{}))),
+            make_tensor(make_gmem_ptr<float>(nullptr), make_layout(make_shape(0), make_stride(_1{}))));
+      }
+    }
+  }
+
+  auto make_D_tensors(ElementD* ptr_D, int pre_rows, int M, int N) {
+    if constexpr (FuseAct) {
+      auto D_tensor = make_tensor(
+          make_gmem_ptr<ElementD>(ptr_D + pre_rows * N / 2),
+          make_layout(make_shape(M, N / 2), make_stride(N / 2, _1{})));
+      return D_tensor;
+    } else {
+      auto D_tensor = make_tensor(
+          make_gmem_ptr<ElementD>(ptr_D + pre_rows * N), make_layout(make_shape(M, N), make_stride(N, _1{})));
+      return D_tensor;
+    }
+  }
+
+  void operator()(Params const& params, sycl::nd_item<3> item, int32_t* slm_mem) {
+    auto N = params.N;
+    auto K = params.K;
+    auto M_per_group = params.M_per_group;
+    auto num_experts = params.num_experts;
+    auto mma = params.mma;
+    auto workspace = params.workspace;
+
+    auto wg_tile = mma.tile_mnk();
+    auto wg_tile_m = get<0>(wg_tile);
+    auto wg_tile_n = get<1>(wg_tile);
+
+    int group_id = item.get_group_linear_id();
+    int N_pad;
+    if constexpr (FuseAct) {
+      N_pad = ceil_div(N / 2, wg_tile_n) * wg_tile_n;
+    } else {
+      N_pad = ceil_div(N, wg_tile_n) * wg_tile_n;
+    }
+    int group_m_id = (group_id * wg_tile_n) / N_pad;
+    int group_range = item.get_group_range(1);
+    int32_t thr_id = int32_t(item.get_local_linear_id());
+
+    if (group_id == 0 && thr_id == 0) {
+      auto atm = sycl::atomic_ref<
+          int,
+          sycl::memory_order::relaxed,
+          sycl::memory_scope::device,
+          sycl::access::address_space::global_space>(workspace[0]);
+      atm.store(0);
+    }
+
+    // E4M3: one byte per element, so the packed K stride equals K.
+    const int64_t K_packed = K;
+    const int64_t K_scale = K / MXFP8_GROUP_SIZE;
+
+    int pre_rows = 0;
+    int pre_tiles = 0;
+    for (int i = 0; i < num_experts; ++i) {
+      int M = M_per_group[i];
+      int cumsum_rows_for_experts = M + pre_rows;
+      int cumsum_tiles_for_experts = (M + wg_tile_m - 1) / wg_tile_m + pre_tiles;
+
+      if (group_m_id >= cumsum_tiles_for_experts) {
+        pre_rows = cumsum_rows_for_experts;
+        pre_tiles = cumsum_tiles_for_experts;
+        continue;
+      }
+
+      int expert_id = i;
+      int64_t B_offset = static_cast<int64_t>(expert_id) * static_cast<int64_t>(N) * K_packed;
+      int64_t S_offset = static_cast<int64_t>(expert_id) * static_cast<int64_t>(N) * K_scale;
+
+      ElementA* ptr_A_curr_batch = const_cast<ElementA*>(params.Activations) + pre_rows * K;
+      uint8_t* ptr_B_curr_batch = const_cast<uint8_t*>(params.PackedWeights) + B_offset;
+      float* ptr_S_curr_batch = const_cast<float*>(params.Scales) + S_offset;
+      float* ptr_Bias_curr_batch = nullptr;
+      if constexpr (WithBias) {
+        ptr_Bias_curr_batch = const_cast<float*>(params.Bias) + expert_id * N;
+      }
+
+      auto A_tensor =
+          make_tensor(make_gmem_ptr<ElementA>(ptr_A_curr_batch), make_layout(make_shape(M, K), make_stride(K, _1{})));
+      auto B_tensor = make_B_tensors(ptr_B_curr_batch, N, K);
+      auto scale_ptrs = make_scale_ptrs(ptr_S_curr_batch, N, K);
+      auto D_tensor = make_D_tensors(params.Outputs, pre_rows, M, N);
+      auto Bias_tensor = make_Bias_tensors(ptr_Bias_curr_batch, N);
+
+      while (group_m_id < cumsum_tiles_for_experts) {
+        int n_coord = (group_id * wg_tile_n) % N_pad / wg_tile_n;
+        int m_coord = (group_m_id - pre_tiles);
+
+        CollectiveMainloop mainloop;
+        if constexpr (FuseAct) {
+          auto tile_coord = make_coord(m_coord, n_coord, n_coord);
+          mainloop(
+              A_tensor,
+              get<0>(B_tensor),
+              get<1>(B_tensor),
+              scale_ptrs.ptr0,
+              scale_ptrs.ptr1,
+              scale_ptrs.row_stride,
+              D_tensor,
+              tile_coord,
+              mma,
+              thr_id,
+              get<0>(Bias_tensor),
+              get<1>(Bias_tensor),
+              params.gemm1_alpha,
+              params.gemm1_limit);
+        } else {
+          auto tile_coord = make_coord(m_coord, n_coord, _, 0);
+          mainloop(
+              A_tensor,
+              get<0>(B_tensor),
+              scale_ptrs.ptr0,
+              scale_ptrs.row_stride,
+              D_tensor,
+              tile_coord,
+              mma,
+              thr_id,
+              get<0>(Bias_tensor));
+        }
+        if (thr_id == 0) {
+          slm_mem[0] = cutlass::atomicAdd(workspace, 1);
+        }
+        item.barrier(sycl::access::fence_space::local_space);
+        group_id = group_range + slm_mem[0];
+        group_m_id = (group_id * wg_tile_n) / N_pad;
+      }
+      pre_rows = cumsum_rows_for_experts;
+      pre_tiles = cumsum_tiles_for_experts;
+    }
+  };
+};
+}  // namespace MoE_MXFP8_W8A16

--- a/src/sycl/kernels/moe/xe20/mxfp8_w8a16/moe_mainloop.hpp
+++ b/src/sycl/kernels/moe/xe20/mxfp8_w8a16/moe_mainloop.hpp
@@ -1,0 +1,547 @@
+/***************************************************************************************************
+ * Copyright (C) 2025 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ **************************************************************************************************/
+
+// MXFP8-B × BF16-A grouped-GEMM mainloop for Xe2 (BMG).
+//
+// Fork of src/sycl/kernels/moe/xe20/mxfp4_w4a16/moe_mainloop.hpp. Structurally
+// identical; the only material difference from the MXFP4 fork is the B element
+// type: MXFP8 stores B as float8_e4m3_t (one byte per element) rather than
+// packed E2M1 nibbles. Consequences:
+//
+//   - B is stored in GMEM as MXFP8 (float_e4m3_t bytes, one element per byte,
+//     row stride K -- NOT K/2). No nibble unpacking.
+//   - Per-block UE8M0 scales are still one value per 32 consecutive K-elements.
+//     As with the MXFP4 path, the producer decodes UE8M0 -> fp32 direct
+//     multipliers ahead of the kernel, so this mainloop consumes fp32 scales.
+//   - In registers, cute::reorder converts the float_e4m3_t B fragment to bf16
+//     (Xe_Reorder<float_e4m3_t, bfloat16_t>, cute/arch/reorder_xe.hpp) and
+//     permutes into MMA-B layout in one call -- exactly like the E2M1 path,
+//     just a different source element type. The per-block scale multiply
+//     (apply_B_scales_mma) is unchanged.
+//
+// Everything else -- prefetch pipeline, collaborative scale load, bias, fused
+// activation, tile scheduler semantics -- is copied verbatim from the MXFP4
+// mainloop. BLK_K is hardcoded to the MX group size 32 so each k-tile sees one
+// scale element per N-row.
+
+#pragma once
+
+#include <cute/tensor.hpp>
+#include <cute/util/compat.hpp>
+#include <sycl/ext/intel/experimental/grf_size_properties.hpp>
+#include <sycl/sycl.hpp>
+
+#include "../common/activation.hpp"
+#include "cutlass/kernel_hardware_info.h"
+#include "cutlass/platform/platform.h"
+#include "cutlass/tensor_ref.h"
+#include "cutlass/util/GPU_Clock.hpp"
+#include "cutlass/util/reference/device/gemm_complex.h"
+#include "cutlass/util/reference/device/tensor_compare.h"
+#include "cutlass/util/reference/host/tensor_fill.h"
+#include "cutlass/util/sycl_event_manager.hpp"
+
+#pragma clang diagnostic ignored "-Wpass-failed"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+namespace MoE_MXFP8_W8A16 {
+
+using namespace cute;
+
+// Shared activation IDs / fused gate-and-mul live in common/activation.hpp.
+// Re-export under this namespace so existing call sites (moe_kernel.hpp,
+// the activation switch below) read the same identifiers as before.
+inline constexpr int SILU = moe_xe20::ACT_SILU;
+inline constexpr int GELU = moe_xe20::ACT_GELU;
+inline constexpr int SWIGLU_GPT_OSS = moe_xe20::ACT_SWIGLU_GPT_OSS;
+// DeepSeek-V4 swiglu uses the default block-split gate/up weight layout
+// (first N/2 rows = gate, last N/2 = up), same as SILU -- only the fused
+// epilogue formula differs (see common/activation.hpp).
+inline constexpr int SWIGLU_DEEPSEEK_V4 = moe_xe20::ACT_SWIGLU_DEEPSEEK_V4;
+
+// MXFP8 invariant: one scale value per 32 consecutive K-elements.
+static constexpr int MXFP8_GROUP_SIZE = 32;
+
+// Number of work-items per subgroup on Xe (SIMD lane count).
+static constexpr int SUBGROUP_SIZE = 16;
+
+// Collaborative scale load. Each WI in the SG reads SG_N / SUBGROUP_SIZE
+// fp32 elements from gmem, then the SG uses sycl::select_from_group to
+// broadcast each WI's local elements so every WI holds the full [SG_N]
+// scale array. Total gmem traffic per SG per k-tile: SG_N * 4 bytes vs.
+// 16*SG_N*4 with a naive "every WI reads all scales" approach.
+//
+// scales_gmem_ptr points at this expert's scale tile
+// ([N, K/GROUP_SIZE] fp32, row-stride = K/GROUP_SIZE). k_scale_idx is the
+// K-group index for this k-tile (= k_tile since BLK_K == GROUP_SIZE).
+// Per-WI N assignment matches the add_bias convention so apply_B_scales_mma
+// can index scales by the same N coord as the MMA-B fragment's N-loop.
+//
+// 2D-block-load doesn't fit a (BLK_N, 1) tile cleanly so we load with
+// plain pointer arithmetic; the latency is hidden under the A/B 2D-block
+// loads which are orders of magnitude bigger.
+template <int SG_N, int ATOM_N, int BLK_N>
+CUTLASS_DEVICE void load_scale_slice(
+    const float* scales_gmem_ptr,
+    int row_stride,
+    int wg_n,
+    int k_scale_idx,
+    int thr_id,
+    float* scale_out /* [SG_N] */) {
+  static constexpr int N_per_wi = SG_N / SUBGROUP_SIZE;
+  static_assert(SG_N % SUBGROUP_SIZE == 0, "SG_N must be a multiple of SUBGROUP_SIZE");
+
+  const int sg_n_coord = (thr_id / SUBGROUP_SIZE) % ATOM_N;
+  const int lane = thr_id % SUBGROUP_SIZE;
+  const int n_base = wg_n * BLK_N + sg_n_coord * SG_N;
+
+  // Each WI loads its own N_per_wi fp32 elements from gmem (its assigned
+  // rows interleaved by lane: WI `lane` owns rows
+  // { lane*N_per_wi + k : k<N_per_wi }). Matches the add_bias per-WI N
+  // mapping convention.
+  float wi_local[N_per_wi];
+  CUTE_UNROLL
+  for (int sn = 0; sn < N_per_wi; ++sn) {
+    const int n = n_base + lane * N_per_wi + sn;
+    wi_local[sn] = scales_gmem_ptr[n * row_stride + k_scale_idx];
+  }
+
+  // Broadcast each lane's elements to all SG lanes, materializing the full
+  // SG_N fp32 scale array in every WI's registers.
+  auto sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+  CUTE_UNROLL
+  for (int src_lane = 0; src_lane < SUBGROUP_SIZE; ++src_lane) {
+    CUTE_UNROLL
+    for (int sn = 0; sn < N_per_wi; ++sn) {
+      scale_out[src_lane * N_per_wi + sn] = sycl::select_from_group(sg, wi_local[sn], src_lane);
+    }
+  }
+}
+
+// Apply per-block MXFP8 scales to an already-upcasted bf16 MMA-B fragment.
+// Used after cute::reorder does the E4M3->bf16 conversion + layout permute.
+//
+// The N-row for each fragment element comes from the MMA-B coord companion:
+// get<0>(coord_frag(idx)) is the WG-tile-N coord. We subtract n_sg_base to
+// index into scale_bf16, which is the fp32->bf16-cast SG-local scale array.
+template <int SG_N_v, class FragBf16, class CoordFrag>
+CUTLASS_DEVICE void
+apply_B_scales_mma(FragBf16& frag, CoordFrag const& coord_frag, const float* scales_sg, int n_sg_base) {
+  using FragLayout = typename FragBf16::layout_type;
+  constexpr int frag_size = cute::size_v<FragLayout>;
+
+  // Cast SG_N fp32 scales -> bf16 multipliers once; amortized across every
+  // fragment element referencing the same N-row.
+  cutlass::bfloat16_t scale_bf16[SG_N_v];
+  CUTE_UNROLL
+  for (int i = 0; i < SG_N_v; ++i) {
+    scale_bf16[i] = cutlass::bfloat16_t(scales_sg[i]);
+  }
+
+  CUTE_UNROLL
+  for (int idx = 0; idx < frag_size; ++idx) {
+    auto coord = coord_frag(idx);
+    int n_in_sg = get<0>(coord) - n_sg_base;
+    cutlass::bfloat16_t s = scale_bf16[n_in_sg];
+    frag(idx) = frag(idx) * s;
+  }
+}
+
+template <int Stages>
+class XeDefault {};
+
+template <
+    class DispatchPolicy_,
+    class TiledCopyA_,
+    class TiledCopyBPacked_,
+    class TiledCopyD_,
+    class ATensor_,
+    class BPackedTensor_,
+    class DTensor_,
+    class BiasTensor_,
+    class TiledMMA_,
+    bool WithBias,
+    int ActType>
+struct MoEMainloopMxfp8W8A16 {
+  static_assert(cutlass::detail::dependent_false<DispatchPolicy_>, "Could not find a mainloop specialization.");
+};
+
+template <
+    int Stages,
+    class TiledCopyA_,
+    class TiledCopyBPacked_,
+    class TiledCopyD_,
+    class ATensor_,
+    class BPackedTensor_,
+    class DTensor_,
+    class BiasTensor_,
+    class TiledMMA_,
+    bool WithBias,
+    int ActType>
+struct MoEMainloopMxfp8W8A16<
+    XeDefault<Stages>,
+    TiledCopyA_,
+    TiledCopyBPacked_,
+    TiledCopyD_,
+    ATensor_,
+    BPackedTensor_,
+    DTensor_,
+    BiasTensor_,
+    TiledMMA_,
+    WithBias,
+    ActType> {
+  using TiledMMA = TiledMMA_;
+  using TiledCopyA = TiledCopyA_;
+  using TiledCopyBPacked = TiledCopyBPacked_;
+  using TiledCopyD = TiledCopyD_;
+  using ATensor = ATensor_;
+  using BPackedTensor = BPackedTensor_;
+  using DTensor = DTensor_;
+  using BiasTensor = BiasTensor_;
+
+  MoEMainloopMxfp8W8A16() {}
+
+  // -------------------------------------------------------------------------
+  // Non-fused-activation path: one B, one scale-B.
+  // -------------------------------------------------------------------------
+  template <typename Coord>
+  CUTLASS_DEVICE void operator()(
+      ATensor& A,                // (M,K)              bf16
+      BPackedTensor& Bp,         // (N, K)             float_e4m3_t (1 byte/elem)
+      const float* scales_gmem,  // fp32 scale buffer (rows span N via scale_row_stride)
+      int scale_row_stride,      // fp32 stride per scale N-row
+      DTensor& D,                // (M,N)              bf16
+      Coord blk_coord,
+      TiledMMA mma,
+      int thr_id,
+      BiasTensor Bias) {
+    auto wg_m = get<0>(blk_coord);
+    auto wg_n = get<1>(blk_coord);
+
+    Tensor cA = make_identity_tensor(A.shape());
+    Tensor cBp = make_identity_tensor(Bp.shape());
+    Tensor cD = make_identity_tensor(D.shape());
+
+    auto wg_tile = mma.tile_mnk();
+    auto wg_coord = make_coord(wg_m, wg_n, 0);
+
+    constexpr int BLK_N = get<1>(decltype(wg_tile){});
+    constexpr int BLK_K = get<2>(decltype(wg_tile){});
+    static_assert(
+        BLK_K == MXFP8_GROUP_SIZE,
+        "MXFP8 mainloop assumes BLK_K == GROUP_SIZE == 32 so each k-tile has one scale per N-row");
+
+    // Compute subgroup-local N dimensions for scale loading. ATOM_N is the
+    // SG replication along N (mode 2 of TiledMMA::ThrLayoutVMNK); SG_N is
+    // BLK_N / ATOM_N.
+    constexpr int ATOM_N_V = get<2>(typename TiledMMA::ThrLayoutVMNK{}.shape());
+    constexpr int SG_N = BLK_N / ATOM_N_V;
+    constexpr int N_per_wi = SG_N / SUBGROUP_SIZE;
+    static_assert(N_per_wi >= 1, "SG_N must be at least SUBGROUP_SIZE");
+
+    // B tile uses the full logical K stride. Unlike MXFP4 (K/2 byte footprint
+    // via sub-byte E2M1 arithmetic), E4M3 is one byte per element so the
+    // logical and byte K strides coincide.
+    Tensor gA = local_tile(cA, select<0, 2>(wg_tile), make_coord(wg_m, _));
+    Tensor gBp = local_tile(cBp, select<1, 2>(wg_tile), make_coord(wg_n, _));
+    Tensor gD = local_tile(cD, wg_tile, wg_coord, Step<_1, _1, X>{});
+
+    TiledCopyA tiled_copy_a{A};
+    TiledCopyBPacked tiled_copy_b{Bp};
+    TiledCopyD tiled_copy_d{D};
+
+    auto thr_copy_a = tiled_copy_a.get_slice(thr_id);
+    auto thr_copy_b = tiled_copy_b.get_slice(thr_id);
+    auto thr_copy_d = tiled_copy_d.get_slice(thr_id);
+    auto thr_mma = mma.get_slice(thr_id);
+
+    auto tAgA = thr_copy_a.partition_S(gA);
+    auto tBgBp = thr_copy_b.partition_S(gBp);
+
+    // A fragments.
+    auto tArA = thr_copy_a.partition_sg_fragment_D(gA(_, _, 0));
+    auto tSrA = thr_mma.partition_sg_fragment_A(gA(_, _, 0));
+
+    // tBrB_packed: float_e4m3_t COPY-layout fragment (2D-block-load target).
+    // tSrB:        bf16 MMA-B-layout fragment. cute::reorder's
+    //              ConvertRelayout path does E4M3->bf16 upcast + copy-layout
+    //              -> MMA-B layout permute in one call; scales are applied
+    //              in-place on tSrB after.
+    auto tBrB_packed = thr_copy_b.partition_sg_fragment_D(gBp(_, _, 0));
+    auto tSrB = thr_mma.partition_sg_fragment_B(gBp(_, _, 0));
+
+    // Coord companion in the MMA-B layout -- maps each tSrB element's
+    // linear index to its (n, k) coord for scale indexing.
+    auto cBp_coord_tile = make_identity_tensor(make_shape(Int<BLK_N>{}, Int<BLK_K>{}));
+    auto tCrB_coord = thr_mma.partition_B(cBp_coord_tile);
+
+    // Per-SG scale register array -- one fp32 value per N-row in this SG's slice.
+    float scale_sg[SG_N];
+
+    // Partition C/D.
+    SubgroupTensor tCrC = thr_mma.partition_sg_fragment_C(gD);
+
+    using TD = typename DTensor::element_type;
+    TD tCrD_final_frag[tCrC.size()];
+    Tensor tCrD_final_tensor = make_tensor(make_rmem_ptr(tCrD_final_frag), tCrC.layout());
+    SubgroupTensor tCrD_final_sg_tensor = make_subgroup_tensor(tCrD_final_tensor, tCrC.tv_layout());
+    Tensor tCgD = thr_mma.partition_C(gD);
+
+    // Prefetches for A and B (no prefetch for scales -- direct loads are
+    // small enough that the hit in the A/B-prefetch-hidden critical path
+    // is negligible).
+    auto prefetch_a = make_block_2d_prefetch(tiled_copy_a);
+    auto prefetch_b = make_block_2d_prefetch(tiled_copy_b);
+
+    auto pAgA = prefetch_a.get_slice(thr_id).partition_S(gA);
+    auto pBgBp = prefetch_b.get_slice(thr_id).partition_S(gBp);
+
+    constexpr SPIRVScope barrier_scope = ScopeWorkgroup;
+    int k_start_idx = 0;
+    int prefetch_k = k_start_idx;
+    const int prefetch_dist = Stages;
+    int k_tile_count = ceil_div(shape<1>(A), get<2>(wg_tile));
+
+    CUTE_UNROLL
+    for (; prefetch_k < prefetch_dist; ++prefetch_k) {
+      prefetch(prefetch_a, pAgA(_, _, _, prefetch_k));
+      prefetch(prefetch_b, pBgBp(_, _, _, prefetch_k));
+    }
+
+    // Loop-invariant N-base for this SG's slice in the WG tile -- used by
+    // apply_B_scales_mma to map each MMA-B fragment element to its N-row.
+    const int sg_n_coord = (thr_id / SUBGROUP_SIZE) % ATOM_N_V;
+    const int n_sg_base = sg_n_coord * SG_N;
+
+    for (int k_tile = k_start_idx; k_tile < k_tile_count; ++k_tile, ++prefetch_k) {
+      barrier_arrive(barrier_scope);
+
+      copy(tiled_copy_a, tAgA(_, _, _, k_tile), tArA);
+      // Standard copy -- copy-layout fragment as target (no retile_D).
+      copy(tiled_copy_b, tBgBp(_, _, _, k_tile), tBrB_packed);
+      load_scale_slice<SG_N, ATOM_N_V, BLK_N>(
+          scales_gmem, scale_row_stride, wg_n, /*k_scale_idx=*/k_tile, thr_id, scale_sg);
+
+      if (prefetch_k < k_tile_count) {
+        prefetch(prefetch_a, pAgA(_, _, _, prefetch_k));
+        prefetch(prefetch_b, pBgBp(_, _, _, prefetch_k));
+      }
+
+      reorder(tArA, tSrA);
+      // Fused type-conversion + layout-reorder. This picks the
+      // ConvertRelayout dispatch inside cute::reorder, which handles both
+      // E4M3 -> bf16 upcast and copy-layout -> MMA-B layout permutation.
+      reorder(tBrB_packed, tSrB);
+
+      // Apply per-block MXFP8 scales to tSrB in-place. Each element's
+      // N-coord is looked up in the MMA-B coord companion; scale_sg holds
+      // the per-SG fp32 scales are cast to bf16 in apply_B_scales_mma.
+      apply_B_scales_mma<SG_N>(tSrB, tCrB_coord, scale_sg, n_sg_base);
+
+      cute::gemm(mma, tSrA, tSrB, tCrC);
+      barrier_wait(barrier_scope);
+    }
+
+    if constexpr (WithBias) {
+      constexpr int BLK_M = get<0>(decltype(wg_tile){});
+      add_bias<decltype(tCrC), BLK_M, BLK_N>(Bias, tCrC, mma, wg_n, thr_id);
+    }
+
+    reorder(tCrC, tCrD_final_sg_tensor);
+    copy(tiled_copy_d, tCrD_final_sg_tensor, tCgD);
+  }
+
+  // -------------------------------------------------------------------------
+  // Fused-activation path: two Bs (gate + up), two scale-B pointers.
+  // Retained from the MXFP4 fork for parity; the dense mxfp8 linear path only
+  // instantiates the non-fused operator() above.
+  // -------------------------------------------------------------------------
+  template <typename Coord>
+  CUTLASS_DEVICE void operator()(
+      ATensor& A,                 // (M,K)
+      BPackedTensor& Bp0,         // (N/2, K)  float_e4m3_t
+      BPackedTensor& Bp1,         // (N/2, K)  float_e4m3_t
+      const float* scales0_gmem,  // fp32 gate scales
+      const float* scales1_gmem,  // fp32 up scales
+      int scale_row_stride,       // fp32 stride per scale N-row (same for both halves)
+      DTensor& D,
+      Coord blk_coord,
+      TiledMMA mma,
+      int thr_id,
+      BiasTensor Bias0,
+      BiasTensor Bias1,
+      float gemm1_alpha,
+      float gemm1_limit) {
+    auto wg_m = get<0>(blk_coord);
+    auto wg_n = get<1>(blk_coord);
+    auto wg_n1 = get<2>(blk_coord);
+
+    Tensor cA = make_identity_tensor(A.shape());
+    Tensor cBp0 = make_identity_tensor(Bp0.shape());
+    Tensor cBp1 = make_identity_tensor(Bp1.shape());
+    Tensor cC0 = make_identity_tensor(D.shape());
+    Tensor cC1 = make_identity_tensor(D.shape());
+
+    auto wg_tile = mma.tile_mnk();
+    auto wg_coord = make_coord(wg_m, wg_n, 0);
+
+    constexpr int BLK_M = get<0>(decltype(wg_tile){});
+    constexpr int BLK_N = get<1>(decltype(wg_tile){});
+    constexpr int BLK_K = get<2>(decltype(wg_tile){});
+    static_assert(BLK_K == MXFP8_GROUP_SIZE, "MXFP8 mainloop assumes BLK_K == GROUP_SIZE == 32");
+
+    constexpr int ATOM_N_V = get<2>(typename TiledMMA::ThrLayoutVMNK{}.shape());
+    constexpr int SG_N = BLK_N / ATOM_N_V;
+    constexpr int N_per_wi = SG_N / SUBGROUP_SIZE;
+    static_assert(N_per_wi >= 1, "SG_N must be at least SUBGROUP_SIZE");
+
+    Tensor gA = local_tile(cA, select<0, 2>(wg_tile), make_coord(wg_m, _));
+    Tensor gBp = local_tile(cBp0, select<1, 2>(wg_tile), make_coord(wg_n, _));
+    Tensor gC0 = local_tile(cC0, wg_tile, wg_coord, Step<_1, _1, X>{});
+    Tensor gC1 = local_tile(cC1, wg_tile, wg_coord, Step<_1, _1, X>{});
+
+    TiledCopyA tiled_copy_a{A};
+    TiledCopyBPacked tiled_copy_b0{Bp0};
+    TiledCopyBPacked tiled_copy_b1{Bp1};
+    TiledCopyD tiled_copy_d{D};
+
+    auto thr_copy_a = tiled_copy_a.get_slice(thr_id);
+    auto thr_copy_b0 = tiled_copy_b0.get_slice(thr_id);
+    auto thr_copy_b1 = tiled_copy_b1.get_slice(thr_id);
+    auto thr_copy_d = tiled_copy_d.get_slice(thr_id);
+    auto thr_mma = mma.get_slice(thr_id);
+
+    auto tAgA = thr_copy_a.partition_S(gA);
+    auto tBgBp0 = thr_copy_b0.partition_S(gBp);
+    auto tBgBp1 = thr_copy_b1.partition_S(gBp);
+
+    auto tArA = thr_copy_a.partition_sg_fragment_D(gA(_, _, 0));
+    auto tSrA = thr_mma.partition_sg_fragment_A(gA(_, _, 0));
+
+    // Two packed-B fragments (gate, up); tSrB is shared MMA-B-layout target
+    // (the two cute::gemm calls run in series).
+    auto tBrB_packed0 = thr_copy_b0.partition_sg_fragment_D(gBp(_, _, 0));
+    auto tBrB_packed1 = thr_copy_b1.partition_sg_fragment_D(gBp(_, _, 0));
+    auto tSrB = thr_mma.partition_sg_fragment_B(gBp(_, _, 0));
+
+    // Coord companion in the MMA-B layout for scale indexing on tSrB.
+    auto cBp_coord_tile = make_identity_tensor(make_shape(Int<BLK_N>{}, Int<BLK_K>{}));
+    auto tCrB_coord = thr_mma.partition_B(cBp_coord_tile);
+
+    // Per-SG scale register arrays (gate + up).
+    float scale0_sg[SG_N];
+    float scale1_sg[SG_N];
+
+    SubgroupTensor tCrC0 = thr_mma.partition_sg_fragment_C(gC0);
+    SubgroupTensor tCrC1 = thr_mma.partition_sg_fragment_C(gC1);
+
+    using TD = typename DTensor::element_type;
+    TD tCrD_final_frag0[tCrC0.size()];
+    Tensor tCrD_final_tensor0 = make_tensor(make_rmem_ptr(tCrD_final_frag0), tCrC0.layout());
+    SubgroupTensor tCrD_final_sg_tensor0 = make_subgroup_tensor(tCrD_final_tensor0, tCrC0.tv_layout());
+    TD tCrD_final_frag1[tCrC1.size()];
+    Tensor tCrD_final_tensor1 = make_tensor(make_rmem_ptr(tCrD_final_frag1), tCrC1.layout());
+    SubgroupTensor tCrD_final_sg_tensor1 = make_subgroup_tensor(tCrD_final_tensor1, tCrC1.tv_layout());
+
+    Tensor tCgD = thr_mma.partition_C(gC0);
+
+    auto prefetch_a = make_block_2d_prefetch(tiled_copy_a);
+    auto prefetch_b0 = make_block_2d_prefetch(tiled_copy_b0);
+    auto prefetch_b1 = make_block_2d_prefetch(tiled_copy_b1);
+
+    auto pAgA = prefetch_a.get_slice(thr_id).partition_S(gA);
+    auto pBgBp0 = prefetch_b0.get_slice(thr_id).partition_S(gBp);
+    auto pBgBp1 = prefetch_b1.get_slice(thr_id).partition_S(gBp);
+
+    constexpr SPIRVScope barrier_scope = ScopeWorkgroup;
+    int k_start_idx = 0;
+    int prefetch_k = k_start_idx;
+    const int prefetch_dist = Stages;
+    int k_tile_count = ceil_div(shape<1>(A), get<2>(wg_tile));
+
+    CUTE_UNROLL
+    for (; prefetch_k < prefetch_dist; ++prefetch_k) {
+      prefetch(prefetch_a, pAgA(_, _, _, prefetch_k));
+      prefetch(prefetch_b0, pBgBp0(_, _, _, prefetch_k));
+      prefetch(prefetch_b1, pBgBp1(_, _, _, prefetch_k));
+    }
+
+    // Loop-invariant N-base for this SG's slice in the WG tile -- used by
+    // apply_B_scales_mma to map each MMA-B fragment element to its N-row.
+    const int sg_n_coord = (thr_id / SUBGROUP_SIZE) % ATOM_N_V;
+    const int n_sg_base = sg_n_coord * SG_N;
+
+    for (int k_tile = k_start_idx; k_tile < k_tile_count; ++k_tile, ++prefetch_k) {
+      barrier_arrive(barrier_scope);
+
+      copy(tiled_copy_a, tAgA(_, _, _, k_tile), tArA);
+
+      // GEMM0 (gate)
+      copy(tiled_copy_b0, tBgBp0(_, _, _, k_tile), tBrB_packed0);
+      load_scale_slice<SG_N, ATOM_N_V, BLK_N>(scales0_gmem, scale_row_stride, wg_n, k_tile, thr_id, scale0_sg);
+      reorder(tArA, tSrA);
+      reorder(tBrB_packed0, tSrB);
+      apply_B_scales_mma<SG_N>(tSrB, tCrB_coord, scale0_sg, n_sg_base);
+      cute::gemm(mma, tSrA, tSrB, tCrC0);
+
+      // GEMM1 (up)
+      copy(tiled_copy_b1, tBgBp1(_, _, _, k_tile), tBrB_packed1);
+      load_scale_slice<SG_N, ATOM_N_V, BLK_N>(scales1_gmem, scale_row_stride, wg_n1, k_tile, thr_id, scale1_sg);
+      reorder(tBrB_packed1, tSrB);
+      apply_B_scales_mma<SG_N>(tSrB, tCrB_coord, scale1_sg, n_sg_base);
+      cute::gemm(mma, tSrA, tSrB, tCrC1);
+
+      if (prefetch_k < k_tile_count) {
+        prefetch(prefetch_a, pAgA(_, _, _, prefetch_k));
+        prefetch(prefetch_b0, pBgBp0(_, _, _, prefetch_k));
+        prefetch(prefetch_b1, pBgBp1(_, _, _, prefetch_k));
+      }
+
+      barrier_wait(barrier_scope);
+    }
+
+    if constexpr (WithBias) {
+      add_bias<decltype(tCrC0), BLK_M, BLK_N>(Bias0, tCrC0, mma, wg_n, thr_id);
+      add_bias<decltype(tCrC1), BLK_M, BLK_N>(Bias1, tCrC1, mma, wg_n1, thr_id);
+    }
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < tCrC0.size(); ++i) {
+      tCrC0(i) = moe_xe20::apply_fused_activation<ActType>(tCrC0(i), tCrC1(i), gemm1_alpha, gemm1_limit);
+    }
+
+    reorder(tCrC0, tCrD_final_sg_tensor0);
+    copy(tiled_copy_d, tCrD_final_sg_tensor0, tCgD);
+  }
+
+  // Bias helper (identical to BF16 mainloop).
+  template <typename tCrC_t, int tile_m, int tile_n>
+  void add_bias(const BiasTensor& Bias, tCrC_t& tCrC, const TiledMMA& mma, int wg_n, int thr_id) {
+    static constexpr auto ATOM_M = get<1>(typename TiledMMA::ThrLayoutVMNK{}.shape());
+    static constexpr auto ATOM_N = get<2>(typename TiledMMA::ThrLayoutVMNK{}.shape());
+
+    static constexpr int sg_local_range = 16;
+    int sg_local_n_coord = (thr_id / sg_local_range) % ATOM_N;
+    int sg_local_id = (thr_id % sg_local_range);
+
+    static constexpr auto SG_M = tile_m / ATOM_M;
+    static constexpr auto SG_N = tile_n / ATOM_N;
+
+    int n_tile_start = wg_n * tile_n;
+    int n_sg_start = sg_local_n_coord * SG_N;
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int sn = 0; sn < SG_N / sg_local_range; ++sn) {
+      int sg_local_n = sn * sg_local_range + sg_local_id;
+      float bias = static_cast<float>(Bias(n_tile_start + n_sg_start + sg_local_n));
+      CUTLASS_PRAGMA_UNROLL
+      for (int sm = 0; sm < SG_M; ++sm) {
+        tCrC(sn * SG_M + sm) += bias;
+      }
+    }
+  }
+};
+
+}  // namespace MoE_MXFP8_W8A16

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -120,6 +120,11 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("moe_grouped_mm_nt_xe20_mxfp4_w4a16", torch::kXPU, &moe_grouped_mm_nt_xe20_mxfp4_w4a16);
 
   m.def(
+      "moe_grouped_mm_nt_xe20_mxfp8_w8a16(Tensor! output, Tensor activations, Tensor packed_weights, Tensor scales, "
+      "Tensor? bias, Tensor total_rows_for_experts, int n_experts) -> ()");
+  m.impl("moe_grouped_mm_nt_xe20_mxfp8_w8a16", torch::kXPU, &moe_grouped_mm_nt_xe20_mxfp8_w8a16);
+
+  m.def(
       "prepare_moe_input(Tensor topk_ids, Tensor! expert_offsets, Tensor? blockscale_offsets, Tensor! problem_sizes1,"
       " Tensor! problem_sizes2, Tensor! input_permutation, Tensor! output_permutation, int num_experts, int n, int k)"
       " -> ()");


### PR DESCRIPTION
[XPU] Add fused MXFP8 W8A16 GEMM (moe_grouped_mm_nt_xe20_mxfp8_w8a16)

Fused bf16-activation x E4M3-weight GEMM with per-32-K-block fp32
direct-multiplier scales, dequantizing B to bf16 in registers before the
DPAS MMA. Fork of the MXFP4 W4A16 grouped GEMM: the B fragment element
type is cutlass::float_e4m3_t (one byte/elem, row stride K, no nibble
unpack), relying on Xe_Reorder<float_e4m3_t, bfloat16_t> for the
in-register upcast. The dense linear path calls it with n_experts=1.

- src/sycl/kernels/moe/xe20/mxfp8_w8a16/{moe_mainloop,moe_kernel}.hpp:
  forked mxfp8 kernel + mainloop.
- src/sycl/GroupGemmMxfp8W8A16Xe20.cpp + LauncherInstance.cpp.in +
  src/GroupGemmMxfp8W8A16Xe20.cmake: dispatcher, launcher template, and
  tile instantiation (non-fused/silu slice, 3 tiles x {bias,no-bias}).
- torch_extension_sycl.cc / sgl_kernel_ops.h: op def/impl + decl.
- python/sgl_kernel/gemm.py: mxfp8_w8a16_gemm wrapper (2D [N,K] weight,
  fp32 [N,K/32] scales) wrapping the single-expert grouped call;
  exported from __init__.py.

Build against oneAPI 2025.3 (libsycl.so.8) to match the py312 torch-xpu
runtime. Validated vs the sglang torch dequant reference: cosine sim
1.000000 across decode/prefill/MLP shapes, and identical greedy output
to the Phase A path on full Llama-3.3-70B-Instruct (tp=8).