### PR TITLE
add sycl kernel: plan_compress_prefill

### DIFF
--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -615,6 +615,19 @@ void fast_topk_transform_ragged_interface(
  */
 namespace at::native::xpu {
 
+std::tuple<torch::Tensor, torch::Tensor> plan_compress_prefill(
+    torch::Tensor req_pool_indices,
+    torch::Tensor req_to_token,
+    torch::Tensor full_to_state,
+    torch::Tensor seq_lens,
+    torch::Tensor extend_lens,
+    torch::Tensor pin_buffer,
+    int64_t num_q_tokens,
+    int64_t compress_ratio,
+    int64_t swa_page_size,
+    int64_t ring_size,
+    bool use_cuda_graph);
+
 torch::Tensor plan_compress_decode(
     torch::Tensor req_pool_indices,
     torch::Tensor req_to_token,

--- a/python/sgl_kernel/compress_plan.py
+++ b/python/sgl_kernel/compress_plan.py
@@ -76,7 +76,7 @@ def _prefill_buffer_len(j: int, compress_ratio: int) -> int:
 def plan_compress_prefill(
     req_pool_indices: torch.Tensor,
     req_to_token: torch.Tensor,
-    full_to_swa: torch.Tensor,
+    full_to_state: torch.Tensor,
     seq_lens: torch.Tensor,
     extend_lens: torch.Tensor,
     pin_buffer: torch.Tensor,
@@ -86,151 +86,19 @@ def plan_compress_prefill(
     ring_size: int,
     use_cuda_graph: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    assert (
-        req_pool_indices.device.type != "cpu" and req_pool_indices.dtype == torch.int64
+    return torch.ops.sgl_kernel.plan_compress_prefill(
+        req_pool_indices,
+        req_to_token,
+        full_to_state,
+        seq_lens,
+        extend_lens,
+        pin_buffer,
+        num_q_tokens,
+        compress_ratio,
+        swa_page_size,
+        ring_size,
+        use_cuda_graph,
     )
-    assert req_to_token.device.type != "cpu" and req_to_token.dtype == torch.int32
-    assert full_to_swa.device.type != "cpu" and full_to_swa.dtype == torch.int64
-    assert (
-        pin_buffer.device.type == "cpu"
-        and pin_buffer.dtype == torch.uint8
-        and pin_buffer.is_contiguous()
-    )
-    assert pin_buffer.numel() >= num_q_tokens * (16 + 8)
-
-    device = req_pool_indices.device
-    is_overlap = compress_ratio == 4
-    mtp_pad = min(ring_size - compress_ratio, 4)
-
-    seq_list = seq_lens.cpu().tolist()
-    ext_list = extend_lens.cpu().tolist()
-
-    c_seq: List[int] = []
-    c_rid16: List[int] = []
-    c_buf16: List[int] = []
-    c_bid: List[int] = []
-    w_packed32: List[int] = []
-    w_pos1: List[int] = []
-
-    counter = 0
-    for b, (sl, el) in enumerate(zip(seq_list, ext_list)):
-        sl = int(sl)
-        el = int(el)
-        prefix_len = sl - el
-
-        last_c_pos = (sl // compress_ratio) * compress_ratio
-        first_w_pos = min(
-            last_c_pos - (compress_ratio if is_overlap else 0), sl - mtp_pad
-        )
-
-        for j in range(el):
-            position = prefix_len + j
-            ragged_id = counter + j
-
-            if (position + 1) % compress_ratio == 0:
-                buffer_len = _prefill_buffer_len(j, compress_ratio)
-
-                c_seq.append(position + 1)
-                c_rid16.append(ragged_id & 0xFFFF)
-                c_buf16.append(int(buffer_len) & 0xFFFF)
-                c_bid.append(b)
-
-            do_write = position >= first_w_pos
-            if not do_write and is_overlap:
-                do_write = (position % swa_page_size) >= (
-                    swa_page_size - compress_ratio
-                )
-            if do_write:
-                w_packed32.append(((b & 0xFFFF) << 16) | (ragged_id & 0xFFFF))
-                w_pos1.append(position + 1)
-
-        counter += el
-
-    num_c = len(c_seq)
-    num_w = len(w_packed32)
-
-    c_bytes = pin_buffer[: num_q_tokens * 16].reshape(num_q_tokens, 16)
-    w_bytes = pin_buffer[num_q_tokens * 16 : num_q_tokens * 24].reshape(num_q_tokens, 8)
-    plan_c_i32 = c_bytes.view(torch.int32).reshape(num_q_tokens, 4)
-    plan_w_i32 = w_bytes.view(torch.int32).reshape(num_q_tokens, 2)
-
-    plan_c_i32[:, 0] = -1
-    plan_c_i32[:, 1] = 0
-    plan_c_i32[:, 2] = -1
-    plan_c_i32[:, 3] = -1
-    plan_w_i32[:, 0] = -1
-    plan_w_i32[:, 1] = -1
-
-    if num_c:
-        seq_t = torch.tensor(c_seq, dtype=torch.int32)
-        rid16_t = torch.tensor(c_rid16, dtype=torch.int32)
-        buf16_t = torch.tensor(c_buf16, dtype=torch.int32)
-        bid_t = torch.tensor(c_bid, dtype=torch.int32)
-
-        plan_c_i32[:num_c, 0] = seq_t
-        plan_c_i32[:num_c, 1] = ((buf16_t & 0xFFFF) << 16) | (rid16_t & 0xFFFF)
-        plan_c_i32[:num_c, 2] = -1
-        plan_c_i32[:num_c, 3] = bid_t
-
-    if num_w:
-        plan_w_i32[:num_w, 0] = torch.tensor(w_packed32, dtype=torch.int32)
-        plan_w_i32[:num_w, 1] = torch.tensor(w_pos1, dtype=torch.int32)
-
-    plan_c = c_bytes[:num_c].to(device, non_blocking=True).clone()
-    plan_w = w_bytes[:num_w].to(device, non_blocking=True).clone()
-
-    # stage1 (kernel_1 semantics)
-    if num_c:
-        Ci32 = plan_c.view(torch.int32).reshape(num_c, 4)
-
-        batch_id = Ci32[:, 3].long()
-        pos1 = Ci32[:, 0].long() - 1
-        pos0 = (pos1 - compress_ratio).clamp(min=0)
-
-        buf_len = ((Ci32[:, 1] >> 16) & 0xFFFF).long()
-        has_buf = buf_len > 0
-
-        rid = req_pool_indices.index_select(0, batch_id).long()
-        if compress_ratio == 128:
-            rp1 = (_compute_c128_loc(rid, pos1, ring_size) // compress_ratio).to(
-                torch.int32
-            )
-            rp0 = (_compute_c128_loc(rid, pos0, ring_size) // compress_ratio).to(
-                torch.int32
-            )
-        else:
-            raw1 = req_to_token[rid, pos1].long()
-            raw0 = req_to_token[rid, pos0].long()
-            swa1 = full_to_swa.index_select(0, raw1).long()
-            swa0 = full_to_swa.index_select(0, raw0).long()
-
-            rp1 = (_compute_loc(swa1, swa_page_size, ring_size) // compress_ratio).to(
-                torch.int32
-            )
-            rp0 = (_compute_loc(swa0, swa_page_size, ring_size) // compress_ratio).to(
-                torch.int32
-            )
-
-        Ci32[:, 2] = torch.where(has_buf, rp0, torch.full_like(rp0, -1))
-        Ci32[:, 3] = torch.where(has_buf, rp1, batch_id.to(torch.int32))
-
-    if num_w:
-        Wi32 = plan_w.view(torch.int32).reshape(num_w, 2)
-        batch_id = (Wi32[:, 0] >> 16).long()
-        pos = Wi32[:, 1].long() - 1
-
-        rid = req_pool_indices.index_select(0, batch_id).long()
-        if compress_ratio == 128:
-            loc = _compute_c128_loc(rid, pos, ring_size).to(torch.int32)
-        else:
-            raw = req_to_token[rid, pos].long()
-            swa = full_to_swa.index_select(0, raw).long()
-            loc = _compute_loc(swa, swa_page_size, ring_size).to(torch.int32)
-
-        Wi32[:, 0] = (Wi32[:, 0] & 0xFFFF).to(torch.int32)
-        Wi32[:, 1] = loc
-
-    return plan_c, plan_w
 
 
 def plan_compress_decode(

--- a/src/sycl/CompressPlan.cpp
+++ b/src/sycl/CompressPlan.cpp
@@ -2,6 +2,8 @@
 #include <c10/xpu/XPUStream.h>
 #include <torch/all.h>
 
+#include <algorithm>
+#include <limits>
 #include <sycl/sycl.hpp>
 
 #include "SYCLHelpers.h"
@@ -83,7 +85,157 @@ struct CompressDecodeKernel {
   uint32_t batch_size;
 };
 
+// Kernel for plan_compress_prefill stage 0
+struct CompressPrefillStage0Kernel {
+  void operator()(sycl::nd_item<1> item) const {
+    if (item.get_global_id(0) != 0) {
+      return;
+    }
+
+    const bool is_overlap = (compress_ratio_ == 4);
+    const int32_t window_size = compress_ratio_ * (is_overlap ? 2 : 1);
+
+    uint32_t counter = 0;
+    uint32_t counter_c = 0;
+    uint32_t counter_w = 0;
+
+    for (uint32_t batch_id = 0; batch_id < batch_size_; ++batch_id) {
+      const int32_t seq_len = static_cast<int32_t>(seq_lens_ptr_[batch_id]);
+      const int32_t extend_len = static_cast<int32_t>(extend_lens_ptr_[batch_id]);
+      const int32_t prefix_len = seq_len - extend_len;
+      const int32_t last_c_pos = (seq_len / compress_ratio_) * compress_ratio_;
+      const int32_t first_w_pos = sycl::min(last_c_pos - (is_overlap ? compress_ratio_ : 0), seq_len - mtp_pad_);
+
+      for (int32_t j = 0; j < extend_len; ++j) {
+        const int32_t position = prefix_len + j;
+        const uint32_t ragged_id = counter + static_cast<uint32_t>(j);
+
+        if (((position + 1) % compress_ratio_) == 0) {
+          const int32_t buffer_len = window_size - sycl::min(j + 1, window_size);
+          int32_t* plan = plan_c_i32_ + static_cast<int32_t>(counter_c) * 4;
+          plan[0] = position + 1;
+          plan[1] = ((buffer_len & 0xFFFF) << 16) | (static_cast<int32_t>(ragged_id) & 0xFFFF);
+          plan[2] = -1;
+          plan[3] = static_cast<int32_t>(batch_id);
+          ++counter_c;
+        }
+
+        bool do_write = position >= first_w_pos;
+        if (!do_write && is_overlap) {
+          do_write = (position % swa_page_size_) >= (swa_page_size_ - compress_ratio_);
+        }
+        if (do_write) {
+          int32_t* plan = plan_w_i32_ + static_cast<int32_t>(counter_w) * 2;
+          plan[0] = ((static_cast<int32_t>(batch_id) & 0xFFFF) << 16) | (static_cast<int32_t>(ragged_id) & 0xFFFF);
+          plan[1] = position + 1;
+          ++counter_w;
+        }
+      }
+      counter += static_cast<uint32_t>(extend_len);
+    }
+
+    for (uint32_t k = counter_c; k < num_q_tokens_; ++k) {
+      int32_t* plan = plan_c_i32_ + static_cast<int32_t>(k) * 4;
+      plan[0] = -1;
+      plan[1] = 0;
+      plan[2] = -1;
+      plan[3] = -1;
+    }
+    for (uint32_t k = counter_w; k < num_q_tokens_; ++k) {
+      int32_t* plan = plan_w_i32_ + static_cast<int32_t>(k) * 2;
+      plan[0] = -1;
+      plan[1] = -1;
+    }
+  }
+
+  int32_t* plan_c_i32_;
+  int32_t* plan_w_i32_;
+  const int64_t* seq_lens_ptr_;
+  const int64_t* extend_lens_ptr_;
+  uint32_t batch_size_;
+  uint32_t num_q_tokens_;
+  int32_t compress_ratio_;
+  int32_t swa_page_size_;
+  int32_t mtp_pad_;
+};
+
+// Kernel for plan_compress_prefill stage 1
+struct CompressPrefillStage1Kernel {
+  void operator()(sycl::nd_item<1> item) const {
+    uint32_t idx = static_cast<uint32_t>(item.get_global_id(0));
+    if (idx >= num_work_) return;
+
+    int32_t* plan_c = plan_c_i32_ + idx * 4;
+    if (plan_c[0] != -1) {
+      int32_t batch_id = plan_c[3];
+      int32_t position_1 = plan_c[0] - 1;
+      int32_t position_0 = sycl::max(position_1 - compress_ratio_, 0);
+      int32_t buffer_len = (plan_c[1] >> 16) & 0xFFFF;
+      bool has_buffer = buffer_len > 0;
+
+      int64_t rid = rid_ptr_[batch_id];
+
+      int64_t read_page_1;
+      int64_t read_page_0;
+      if (compress_ratio_ == 128) {
+        read_page_1 = rid * ring_size_div_ratio_ + ((static_cast<int64_t>(position_1) % ring_size_) / compress_ratio_);
+        read_page_0 = rid * ring_size_div_ratio_ + ((static_cast<int64_t>(position_0) % ring_size_) / compress_ratio_);
+      } else {
+        const int32_t* mapping = r2t_ptr_ + rid * stride_r2t_;
+        int64_t raw_loc_1 = static_cast<int64_t>(mapping[position_1]);
+        int64_t raw_loc_0 = static_cast<int64_t>(mapping[position_0]);
+        int64_t state_loc_1 = f2s_ptr_[raw_loc_1];
+        int64_t state_loc_0 = f2s_ptr_[raw_loc_0];
+        int64_t write_loc = (state_loc_1 / swa_page_size_) * ring_size_ + (state_loc_1 % ring_size_);
+        int64_t read_loc_0 = (state_loc_0 / swa_page_size_) * ring_size_ + (state_loc_0 % ring_size_);
+        read_page_1 = write_loc / static_cast<int64_t>(compress_ratio_);
+        read_page_0 = read_loc_0 / static_cast<int64_t>(compress_ratio_);
+      }
+
+      plan_c[2] = has_buffer ? static_cast<int32_t>(read_page_0) : -1;
+      plan_c[3] = has_buffer ? static_cast<int32_t>(read_page_1) : batch_id;
+    }
+
+    int32_t* plan_w = plan_w_i32_ + idx * 2;
+    if (plan_w[0] != -1) {
+      int32_t packed = plan_w[0];
+      int32_t batch_id = (packed >> 16) & 0xFFFF;
+      int32_t position = plan_w[1] - 1;
+      int64_t rid = rid_ptr_[batch_id];
+
+      int64_t write_loc;
+      if (compress_ratio_ == 128) {
+        write_loc = rid * ring_size_ + (static_cast<int64_t>(position) % ring_size_);
+      } else {
+        const int32_t* mapping = r2t_ptr_ + rid * stride_r2t_;
+        int64_t raw_loc = static_cast<int64_t>(mapping[position]);
+        int64_t state_loc = f2s_ptr_[raw_loc];
+        write_loc = (state_loc / swa_page_size_) * ring_size_ + (state_loc % ring_size_);
+      }
+
+      plan_w[0] = packed & 0xFFFF;
+      plan_w[1] = static_cast<int32_t>(write_loc);
+    }
+  }
+
+  int32_t* plan_c_i32_;
+  int32_t* plan_w_i32_;
+  const int64_t* rid_ptr_;
+  const int32_t* r2t_ptr_;
+  const int64_t* f2s_ptr_;
+  int32_t swa_page_size_;
+  int32_t ring_size_;
+  int32_t ring_size_div_ratio_;
+  int32_t compress_ratio_;
+  int64_t stride_r2t_;
+  uint32_t num_work_;
+};
+
 }  // namespace CompressPlanImpl
+
+constexpr int64_t kPlanCBytes = sizeof(int32_t) * 4;
+constexpr int64_t kPlanWBytes = sizeof(int32_t) * 2;
+constexpr int64_t kPlanDBytes = sizeof(int32_t) * 4;
 
 // SYCL helper to launch kernels
 inline sycl::nd_range<1> get_1d_range(int32_t size) {
@@ -139,6 +291,114 @@ torch::Tensor plan_compress_decode(
   });
 
   return output;
+}
+
+std::tuple<torch::Tensor, torch::Tensor> plan_compress_prefill(
+    torch::Tensor req_pool_indices,
+    torch::Tensor req_to_token,
+    torch::Tensor full_to_state,
+    torch::Tensor seq_lens,
+    torch::Tensor extend_lens,
+    torch::Tensor pin_buffer,
+    int64_t num_q_tokens,
+    int64_t compress_ratio,
+    int64_t swa_page_size,
+    int64_t ring_size,
+    bool use_cuda_graph) {
+  (void)pin_buffer;
+
+  TORCH_CHECK(
+      req_pool_indices.is_xpu() && req_pool_indices.dtype() == torch::kInt64 && req_pool_indices.dim() == 1,
+      "req_pool_indices must be a 1D int64 XPU tensor");
+  TORCH_CHECK(
+      req_to_token.is_xpu() && req_to_token.dtype() == torch::kInt32 && req_to_token.dim() == 2,
+      "req_to_token must be a 2D int32 XPU tensor");
+  TORCH_CHECK(
+      full_to_state.is_xpu() && full_to_state.dtype() == torch::kInt64, "full_to_state must be an int64 XPU tensor");
+  TORCH_CHECK(
+      (seq_lens.is_xpu() || seq_lens.device().is_cpu()) && seq_lens.dtype() == torch::kInt64 && seq_lens.dim() == 1,
+      "seq_lens must be a 1D int64 tensor on XPU or CPU");
+  TORCH_CHECK(
+      (extend_lens.is_xpu() || extend_lens.device().is_cpu()) && extend_lens.dtype() == torch::kInt64 &&
+          extend_lens.dim() == 1,
+      "extend_lens must be a 1D int64 tensor on XPU or CPU");
+  TORCH_CHECK(seq_lens.numel() == extend_lens.numel(), "seq_lens and extend_lens must have the same length");
+  TORCH_CHECK(req_pool_indices.numel() == seq_lens.numel(), "req_pool_indices and seq_lens must have the same length");
+  TORCH_CHECK(!use_cuda_graph, "plan_compress_prefill only supports use_cuda_graph=False on XPU");
+
+  auto seq_lens_xpu = seq_lens;
+  if (!seq_lens_xpu.is_xpu()) {
+    seq_lens_xpu = seq_lens.to(req_pool_indices.options().dtype(torch::kInt64));
+  }
+  auto extend_lens_xpu = extend_lens;
+  if (!extend_lens_xpu.is_xpu()) {
+    extend_lens_xpu = extend_lens.to(req_pool_indices.options().dtype(torch::kInt64));
+  }
+
+  const uint32_t num_q_tokens_u32 = static_cast<uint32_t>(num_q_tokens);
+  const int32_t compress_ratio_i32 = static_cast<int32_t>(compress_ratio);
+  const int32_t swa_page_size_i32 = static_cast<int32_t>(swa_page_size);
+  const int32_t ring_size_i32 = static_cast<int32_t>(ring_size);
+
+  const uint32_t batch_size = static_cast<uint32_t>(seq_lens_xpu.numel());
+  constexpr uint32_t kMaxTokens = static_cast<uint32_t>(std::numeric_limits<uint16_t>::max());
+  constexpr uint32_t kMaxPrefillBatchSize = 1024;
+  TORCH_CHECK(compress_ratio_i32 == 4 || compress_ratio_i32 == 128, "compress_ratio must be 4 or 128");
+  TORCH_CHECK(
+      num_q_tokens_u32 >= batch_size && num_q_tokens_u32 <= kMaxTokens, "num_q_tokens must be in [batch_size, 65535]");
+  TORCH_CHECK(
+      swa_page_size_i32 % ring_size_i32 == 0 && ring_size_i32 % compress_ratio_i32 == 0,
+      "swa_page_size must be divisible by ring_size and ring_size must be divisible by compress_ratio");
+  TORCH_CHECK(batch_size <= kMaxPrefillBatchSize, "XPU plan only supports batch size up to 1024");
+
+  auto options_u8 = req_pool_indices.options().dtype(torch::kUInt8);
+  if (num_q_tokens_u32 == 0) {
+    return {
+        torch::empty({0, kPlanCBytes}, options_u8),
+        torch::empty({0, kPlanWBytes}, options_u8),
+    };
+  }
+
+  auto plan_c = torch::empty({num_q_tokens_u32, kPlanCBytes}, options_u8);
+  auto plan_w = torch::empty({num_q_tokens_u32, kPlanWBytes}, options_u8);
+  constexpr int32_t kMaxMTPDraftTokens = 4;
+  const int32_t mtp_pad = std::min(ring_size_i32 - compress_ratio_i32, kMaxMTPDraftTokens);
+
+  auto queue = c10::xpu::getCurrentXPUStream().queue();
+  queue.submit([&](sycl::handler& cgh) {
+    CompressPlanImpl::CompressPrefillStage0Kernel kernel{
+        reinterpret_cast<int32_t*>(plan_c.data_ptr<uint8_t>()),
+        reinterpret_cast<int32_t*>(plan_w.data_ptr<uint8_t>()),
+        seq_lens_xpu.data_ptr<int64_t>(),
+        extend_lens_xpu.data_ptr<int64_t>(),
+        batch_size,
+        num_q_tokens_u32,
+        compress_ratio_i32,
+        swa_page_size_i32,
+        mtp_pad};
+    cgh.parallel_for(get_1d_range(1), kernel);
+  });
+
+  int64_t stride_r2t = req_to_token.stride(0);
+  if (num_q_tokens_u32 > 0) {
+    queue.submit([&](sycl::handler& cgh) {
+      CompressPlanImpl::CompressPrefillStage1Kernel kernel{
+          reinterpret_cast<int32_t*>(plan_c.data_ptr<uint8_t>()),
+          reinterpret_cast<int32_t*>(plan_w.data_ptr<uint8_t>()),
+          req_pool_indices.data_ptr<int64_t>(),
+          req_to_token.data_ptr<int32_t>(),
+          full_to_state.data_ptr<int64_t>(),
+          swa_page_size_i32,
+          ring_size_i32,
+          ring_size_i32 / compress_ratio_i32,
+          compress_ratio_i32,
+          stride_r2t,
+          num_q_tokens_u32};
+      cgh.parallel_for(get_1d_range(static_cast<int32_t>(num_q_tokens_u32)), kernel);
+    });
+  }
+
+  return {plan_c, plan_w};
 }
 
 }  // namespace at::native::xpu

--- a/src/sycl/CompressPlan.cpp
+++ b/src/sycl/CompressPlan.cpp
@@ -440,13 +440,6 @@ struct CompressPrefillStage1Kernel {
 
 }  // namespace CompressPlanImpl
 
-// SYCL helper to launch kernels
-inline sycl::nd_range<1> get_1d_range(int32_t size) {
-  constexpr int32_t local_size = 256;
-  return sycl::nd_range<1>(
-      sycl::range<1>((size + local_size - 1) / local_size * local_size), sycl::range<1>(local_size));
-}
-
 // XPU wrapper for plan_compress_decode
 torch::Tensor plan_compress_decode(
     torch::Tensor req_pool_indices,
@@ -457,15 +450,21 @@ torch::Tensor plan_compress_decode(
     int64_t swa_page_size,
     int64_t ring_size) {
   TORCH_CHECK(
-      req_pool_indices.is_xpu() && req_pool_indices.dtype() == torch::kInt64,
-      "req_pool_indices must be an int64 XPU tensor");
+      req_pool_indices.is_xpu() && req_pool_indices.dtype() == torch::kInt64 && req_pool_indices.dim() == 1 &&
+          req_pool_indices.is_contiguous(),
+      "req_pool_indices must be a contiguous 1D int64 XPU tensor");
   TORCH_CHECK(
-      req_to_token.is_xpu() && req_to_token.dtype() == torch::kInt32, "req_to_token must be an int32 XPU tensor");
+      req_to_token.is_xpu() && req_to_token.dtype() == torch::kInt32 && req_to_token.dim() == 2 &&
+          req_to_token.is_contiguous(),
+      "req_to_token must be a contiguous 2D int32 XPU tensor");
   TORCH_CHECK(
-      full_to_state.is_xpu() && full_to_state.dtype() == torch::kInt64, "full_to_state must be an int64 XPU tensor");
-  TORCH_CHECK(seq_lens.is_xpu() && seq_lens.dtype() == torch::kInt64, "seq_lens must be an int64 XPU tensor");
-  TORCH_CHECK(req_to_token.dim() == 2, "req_to_token must be a 2D tensor");
-  TORCH_CHECK(req_to_token.stride(1) == 1, "req_to_token must be contiguous in the last dim");
+      full_to_state.is_xpu() && full_to_state.dtype() == torch::kInt64 && full_to_state.dim() == 1 &&
+          full_to_state.is_contiguous(),
+      "full_to_state must be a contiguous 1D int64 XPU tensor");
+  TORCH_CHECK(
+      seq_lens.is_xpu() && seq_lens.dtype() == torch::kInt64 && seq_lens.dim() == 1 && seq_lens.is_contiguous(),
+      "seq_lens must be a contiguous 1D int64 XPU tensor");
+  TORCH_CHECK(req_pool_indices.numel() == seq_lens.numel(), "req_pool_indices and seq_lens must have the same length");
   TORCH_CHECK(compress_ratio > 0, "compress_ratio must be > 0");
 
   uint32_t batch_size = static_cast<uint32_t>(seq_lens.numel());
@@ -479,6 +478,8 @@ torch::Tensor plan_compress_decode(
 
   auto queue = c10::xpu::getCurrentXPUStream().queue();
   queue.submit([&](sycl::handler& cgh) {
+    constexpr uint32_t kLocalSize = 256;
+    const uint32_t global_size = ((batch_size + kLocalSize - 1) / kLocalSize) * kLocalSize;
     CompressPlanImpl::CompressDecodeKernel kernel{
         req_pool_indices.data_ptr<int64_t>(),
         seq_lens.data_ptr<int64_t>(),
@@ -490,7 +491,7 @@ torch::Tensor plan_compress_decode(
         static_cast<int32_t>(compress_ratio),
         req_to_token.size(1),
         batch_size};
-    cgh.parallel_for(get_1d_range(batch_size), kernel);
+    cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
   });
 
   return output;
@@ -512,20 +513,29 @@ std::tuple<torch::Tensor, torch::Tensor> plan_compress_prefill(
   (void)use_cuda_graph;
 
   TORCH_CHECK(
-      req_pool_indices.is_xpu() && req_pool_indices.dtype() == torch::kInt64 && req_pool_indices.dim() == 1,
-      "req_pool_indices must be a 1D int64 XPU tensor");
+      req_pool_indices.is_xpu() && req_pool_indices.dtype() == torch::kInt64 && req_pool_indices.dim() == 1 &&
+          req_pool_indices.is_contiguous(),
+      "req_pool_indices must be a contiguous 1D int64 XPU tensor");
   TORCH_CHECK(
-      req_to_token.is_xpu() && req_to_token.dtype() == torch::kInt32 && req_to_token.dim() == 2,
-      "req_to_token must be a 2D int32 XPU tensor");
+      req_to_token.is_xpu() && req_to_token.dtype() == torch::kInt32 && req_to_token.dim() == 2 &&
+          req_to_token.is_contiguous(),
+      "req_to_token must be a contiguous 2D int32 XPU tensor");
   TORCH_CHECK(
-      full_to_state.is_xpu() && full_to_state.dtype() == torch::kInt64, "full_to_state must be an int64 XPU tensor");
+      full_to_state.is_xpu() && full_to_state.dtype() == torch::kInt64 && full_to_state.dim() == 1 &&
+          full_to_state.is_contiguous(),
+      "full_to_state must be a contiguous 1D int64 XPU tensor");
   TORCH_CHECK(
-      (seq_lens.is_xpu() || seq_lens.device().is_cpu()) && seq_lens.dtype() == torch::kInt64 && seq_lens.dim() == 1,
-      "seq_lens must be a 1D int64 tensor on XPU or CPU");
+      (seq_lens.is_xpu() || seq_lens.device().is_cpu()) && seq_lens.dtype() == torch::kInt64 && seq_lens.dim() == 1 &&
+          seq_lens.is_contiguous(),
+      "seq_lens must be a contiguous 1D int64 tensor on XPU or CPU");
   TORCH_CHECK(
       (extend_lens.is_xpu() || extend_lens.device().is_cpu()) && extend_lens.dtype() == torch::kInt64 &&
-          extend_lens.dim() == 1,
-      "extend_lens must be a 1D int64 tensor on XPU or CPU");
+          extend_lens.dim() == 1 && extend_lens.is_contiguous(),
+      "extend_lens must be a contiguous 1D int64 tensor on XPU or CPU");
+  TORCH_CHECK(
+      pin_buffer.device().is_cpu() && pin_buffer.dtype() == torch::kUInt8 && pin_buffer.dim() == 1 &&
+          pin_buffer.is_contiguous(),
+      "pin_buffer must be a contiguous 1D uint8 CPU tensor");
   TORCH_CHECK(seq_lens.numel() == extend_lens.numel(), "seq_lens and extend_lens must have the same length");
   TORCH_CHECK(req_pool_indices.numel() == seq_lens.numel(), "req_pool_indices and seq_lens must have the same length");
 
@@ -608,6 +618,8 @@ std::tuple<torch::Tensor, torch::Tensor> plan_compress_prefill(
   const uint32_t num_work = std::max(num_c_padded, num_w_padded);
   if (num_q_tokens_u32 > 0) {
     queue.submit([&](sycl::handler& cgh) {
+      constexpr uint32_t kLocalSize = 256;
+      const uint32_t global_size = ((num_work + kLocalSize - 1) / kLocalSize) * kLocalSize;
       CompressPlanImpl::CompressPrefillStage1Kernel kernel{
           reinterpret_cast<CompressPlan*>(plan_c.data_ptr<uint8_t>()),
           reinterpret_cast<WritePlan*>(plan_w.data_ptr<uint8_t>()),
@@ -623,7 +635,7 @@ std::tuple<torch::Tensor, torch::Tensor> plan_compress_prefill(
           num_c_padded,
           num_w_padded,
           num_work};
-      cgh.parallel_for(get_1d_range(static_cast<int32_t>(num_work)), kernel);
+      cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
     });
   }
 

--- a/src/sycl/CompressPlan.cpp
+++ b/src/sycl/CompressPlan.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <limits>
 #include <sycl/sycl.hpp>
+#include <utility>
 
 #include "SYCLHelpers.h"
 #include "Utils.h"
@@ -17,7 +18,68 @@ struct alignas(16) DecodePlan {
   int32_t read_page_0;
   int32_t read_page_1;
 };
+
+struct alignas(16) CompressPlan {
+  uint32_t seq_len;
+  uint16_t ragged_id;
+  uint16_t buffer_len;
+  int32_t read_page_0;
+  int32_t read_page_1;
+
+  static constexpr CompressPlan invalid() {
+    return CompressPlan{-1u, 0, 0, -1, -1};
+  }
+
+  constexpr bool is_invalid() const {
+    return seq_len == -1u;
+  }
+};
+
+struct alignas(8) WritePlan {
+  uint32_t ragged_id;
+  int32_t write_loc;
+
+  static constexpr WritePlan invalid() {
+    return WritePlan{-1u, -1};
+  }
+
+  constexpr bool is_invalid() const {
+    return ragged_id == -1u;
+  }
+};
+
+inline WritePlan pack_w(uint32_t ragged_id, uint32_t batch_id, int32_t seq_len) {
+  return {static_cast<uint32_t>(ragged_id | (batch_id << 16)), seq_len};
+}
+
+inline std::pair<uint16_t, uint16_t> unpack_w(WritePlan plan) {
+  return {static_cast<uint16_t>(plan.ragged_id), static_cast<uint16_t>(plan.ragged_id >> 16)};
+}
+
 static_assert(sizeof(DecodePlan) == 16, "DecodePlan must be 16 bytes");
+static_assert(sizeof(CompressPlan) == 16, "CompressPlan must be 16 bytes");
+static_assert(sizeof(WritePlan) == 8, "WritePlan must be 8 bytes");
+constexpr uint32_t kStage0BlockSize = 256;
+constexpr uint32_t kStage0SubGroupSize = 32;
+constexpr uint32_t kStage0NumSubGroups = kStage0BlockSize / kStage0SubGroupSize;
+
+using Stage0LocalAtomic = sycl::atomic_ref<
+    uint32_t,
+    sycl::memory_order::relaxed,
+    sycl::memory_scope::work_group,
+    sycl::access::address_space::local_space>;
+
+inline uint32_t wg_reserve_u32(sycl::nd_item<1>& item, uint32_t& counter, uint32_t want) {
+  auto g = item.get_group();
+  const uint32_t my_off = sycl::exclusive_scan_over_group(g, want, sycl::plus<uint32_t>());
+  const uint32_t wg_total = sycl::reduce_over_group(g, want, sycl::plus<uint32_t>());
+  uint32_t wg_base = 0;
+  if (item.get_local_id(0) == 0 && wg_total > 0) {
+    wg_base = Stage0LocalAtomic(counter).fetch_add(wg_total);
+  }
+  wg_base = sycl::group_broadcast(g, wg_base, 0);
+  return wg_base + my_off;
+}
 
 namespace CompressPlanImpl {
 
@@ -87,69 +149,195 @@ struct CompressDecodeKernel {
 
 // Kernel for plan_compress_prefill stage 0
 struct CompressPrefillStage0Kernel {
+  [[sycl::reqd_sub_group_size(kStage0SubGroupSize)]]
   void operator()(sycl::nd_item<1> item) const {
-    if (item.get_global_id(0) != 0) {
-      return;
-    }
-
+    const auto tx = static_cast<uint32_t>(item.get_local_id(0));
+    const auto block_size = static_cast<uint32_t>(item.get_local_range(0));
+    auto sg = item.get_sub_group();
+    const auto lane_id = tx % kStage0SubGroupSize;
+    const auto sg_id = tx / kStage0SubGroupSize;
     const bool is_overlap = (compress_ratio_ == 4);
     const int32_t window_size = compress_ratio_ * (is_overlap ? 2 : 1);
 
-    uint32_t counter = 0;
-    uint32_t counter_c = 0;
-    uint32_t counter_w = 0;
+    // === Stage A: load per-batch fields, init shared scratch ===
+    if (tx == 0) {
+      counter_c_local_[0] = 0;
+      counter_w_local_[0] = 0;
+    }
 
-    for (uint32_t batch_id = 0; batch_id < batch_size_; ++batch_id) {
+    if (tx < kStage0NumSubGroups) {
+      warp_max_[tx] = 0;
+      warp_min_[tx] = 0xFFFFFFFFu;
+    }
+
+    uint32_t local_max_extend = 0;
+    uint32_t local_min_extend = 0xFFFFFFFFu;
+    for (uint32_t batch_id = tx; batch_id < batch_size_; batch_id += block_size) {
       const int32_t seq_len = static_cast<int32_t>(seq_lens_ptr_[batch_id]);
       const int32_t extend_len = static_cast<int32_t>(extend_lens_ptr_[batch_id]);
-      const int32_t prefix_len = seq_len - extend_len;
-      const int32_t last_c_pos = (seq_len / compress_ratio_) * compress_ratio_;
-      const int32_t first_w_pos = sycl::min(last_c_pos - (is_overlap ? compress_ratio_ : 0), seq_len - mtp_pad_);
+      s_seq_len_[batch_id] = seq_len;
+      s_prefix_len_[batch_id] = seq_len - extend_len;
+      const uint32_t extend_len_u32 = static_cast<uint32_t>(extend_len);
+      local_max_extend = sycl::max(local_max_extend, extend_len_u32);
+      local_min_extend = sycl::min(local_min_extend, extend_len_u32);
+    }
 
-      for (int32_t j = 0; j < extend_len; ++j) {
-        const int32_t position = prefix_len + j;
-        const uint32_t ragged_id = counter + static_cast<uint32_t>(j);
+    // === Stage B: min/max(extend_len) for MTP-uniform detection ===
+    // Level 1: reduce inside each subgroup.
+    uint32_t sg_max = sycl::reduce_over_group(sg, local_max_extend, sycl::maximum<uint32_t>());
+    uint32_t sg_min = sycl::reduce_over_group(sg, local_min_extend, sycl::minimum<uint32_t>());
+    if (lane_id == 0) {
+      warp_max_[sg_id] = sg_max;
+      warp_min_[sg_id] = sg_min;
+    }
+    item.barrier(sycl::access::fence_space::local_space);
 
-        if (((position + 1) % compress_ratio_) == 0) {
-          const int32_t buffer_len = window_size - sycl::min(j + 1, window_size);
-          int32_t* plan = plan_c_i32_ + static_cast<int32_t>(counter_c) * 4;
-          plan[0] = position + 1;
-          plan[1] = ((buffer_len & 0xFFFF) << 16) | (static_cast<int32_t>(ragged_id) & 0xFFFF);
-          plan[2] = -1;
-          plan[3] = static_cast<int32_t>(batch_id);
-          ++counter_c;
-        }
-
-        bool do_write = position >= first_w_pos;
-        if (!do_write && is_overlap) {
-          do_write = (position % swa_page_size_) >= (swa_page_size_ - compress_ratio_);
-        }
-        if (do_write) {
-          int32_t* plan = plan_w_i32_ + static_cast<int32_t>(counter_w) * 2;
-          plan[0] = ((static_cast<int32_t>(batch_id) & 0xFFFF) << 16) | (static_cast<int32_t>(ragged_id) & 0xFFFF);
-          plan[1] = position + 1;
-          ++counter_w;
-        }
+    // Level 2: subgroup 0 reduces subgroup outputs to block-wide min/max.
+    if (sg_id == 0) {
+      uint32_t v_max = (lane_id < kStage0NumSubGroups) ? warp_max_[lane_id] : 0u;
+      uint32_t v_min = (lane_id < kStage0NumSubGroups) ? warp_min_[lane_id] : 0xFFFFFFFFu;
+      uint32_t block_max = sycl::reduce_over_group(sg, v_max, sycl::maximum<uint32_t>());
+      uint32_t block_min = sycl::reduce_over_group(sg, v_min, sycl::minimum<uint32_t>());
+      if (lane_id == 0) {
+        s_max_extend_[0] = block_max;
+        s_min_extend_[0] = block_min;
       }
-      counter += static_cast<uint32_t>(extend_len);
+    }
+    item.barrier(sycl::access::fence_space::local_space);
+
+    // MTP-uniform means each request shares the same small extend length E.
+    const bool is_mtp_extend =
+        (s_min_extend_[0] == s_max_extend_[0]) && (s_max_extend_[0] > 0) && (s_max_extend_[0] <= 32);
+
+    // === Stage C: emit valid plans ===
+    if (is_mtp_extend) {
+      // Path 1 (token-driven): map k -> (batch_id, j) via E.
+      const uint32_t e = s_max_extend_[0];
+      // num_q_tokens_ is padded capacity; cap work at real tokens for safety.
+      const uint32_t num_real_q = batch_size_ * e;
+      for (uint32_t k_base = 0; k_base < num_real_q; k_base += block_size) {
+        const uint32_t k = k_base + tx;
+        uint32_t batch_id = 0;
+        uint32_t ragged_id = 0;
+        int32_t position = 0;
+        int32_t buffer_len = 0;
+        uint32_t do_compress_flag = 0;
+        uint32_t do_write_flag = 0;
+
+        if (k < num_real_q) {
+          batch_id = k / e;
+          const uint32_t j = k % e;
+          const int32_t prefix_len = s_prefix_len_[batch_id];
+          const int32_t seq_len = s_seq_len_[batch_id];
+          position = prefix_len + static_cast<int32_t>(j);
+          ragged_id = k;
+
+          if (((position + 1) % compress_ratio_) == 0) {
+            do_compress_flag = 1u;
+            buffer_len = window_size - sycl::min(static_cast<int32_t>(j) + 1, window_size);
+          }
+
+          const int32_t last_c_pos = (seq_len / compress_ratio_) * compress_ratio_;
+          const int32_t first_w_pos = sycl::min(last_c_pos - (is_overlap ? compress_ratio_ : 0), seq_len - mtp_pad_);
+          bool do_write = position >= first_w_pos;
+          if (!do_write && is_overlap) {
+            do_write = (position % swa_page_size_) >= (swa_page_size_ - compress_ratio_);
+          }
+          do_write_flag = do_write ? 1u : 0u;
+        }
+
+        const uint32_t c_out_idx = wg_reserve_u32(item, counter_c_local_[0], do_compress_flag);
+        if (k < num_real_q && do_compress_flag != 0u) {
+          plan_c_[c_out_idx] = CompressPlan{
+              .seq_len = static_cast<uint32_t>(position + 1),
+              .ragged_id = static_cast<uint16_t>(ragged_id),
+              .buffer_len = static_cast<uint16_t>(buffer_len),
+              .read_page_0 = -1,
+              .read_page_1 = static_cast<int32_t>(batch_id),
+          };
+        }
+        item.barrier(sycl::access::fence_space::local_space);
+
+        const uint32_t w_out_idx = wg_reserve_u32(item, counter_w_local_[0], do_write_flag);
+        if (k < num_real_q && do_write_flag != 0u) {
+          plan_w_[w_out_idx] = pack_w(ragged_id, batch_id, position + 1);
+        }
+        item.barrier(sycl::access::fence_space::local_space);
+      }
+    } else {
+      // Path 2: general prefill (long extend_len). Iterate batches in an outer loop;
+      // the whole block sweeps each batch's tokens in parallel.
+      uint32_t base_e = 0;
+      for (uint32_t batch_id = 0; batch_id < batch_size_; ++batch_id) {
+        const int32_t prefix_len = s_prefix_len_[batch_id];
+        const int32_t seq_len = s_seq_len_[batch_id];
+        const int32_t extend_len = seq_len - prefix_len;
+        const int32_t last_c_pos = (seq_len / compress_ratio_) * compress_ratio_;
+        const int32_t first_w_pos = sycl::min(last_c_pos - (is_overlap ? compress_ratio_ : 0), seq_len - mtp_pad_);
+
+        // Chunk by block_size to avoid cross-chunk interleaving when extend_len is large.
+        for (int32_t j_base = 0; j_base < extend_len; j_base += static_cast<int32_t>(block_size)) {
+          const int32_t j = j_base + static_cast<int32_t>(tx);
+          int32_t position = 0;
+          uint32_t ragged_id = 0;
+          int32_t buffer_len = 0;
+          uint32_t do_compress_flag = 0;
+          uint32_t do_write_flag = 0;
+          if (j < extend_len) {
+            position = prefix_len + j;
+            ragged_id = base_e + static_cast<uint32_t>(j);
+
+            if (((position + 1) % compress_ratio_) == 0) {
+              do_compress_flag = 1u;
+              buffer_len = window_size - sycl::min(j + 1, window_size);
+            }
+
+            bool do_write = position >= first_w_pos;
+            if (!do_write && is_overlap) {
+              do_write = (position % swa_page_size_) >= (swa_page_size_ - compress_ratio_);
+            }
+            do_write_flag = do_write ? 1u : 0u;
+          }
+
+          const uint32_t c_out_idx = wg_reserve_u32(item, counter_c_local_[0], do_compress_flag);
+          if (j < extend_len && do_compress_flag != 0u) {
+            plan_c_[c_out_idx] = CompressPlan{
+                .seq_len = static_cast<uint32_t>(position + 1),
+                .ragged_id = static_cast<uint16_t>(ragged_id),
+                .buffer_len = static_cast<uint16_t>(buffer_len),
+                .read_page_0 = -1,
+                .read_page_1 = static_cast<int32_t>(batch_id),
+            };
+          }
+          item.barrier(sycl::access::fence_space::local_space);
+
+          const uint32_t w_out_idx = wg_reserve_u32(item, counter_w_local_[0], do_write_flag);
+          if (j < extend_len && do_write_flag != 0u) {
+            plan_w_[w_out_idx] = pack_w(ragged_id, batch_id, position + 1);
+          }
+
+          item.barrier(sycl::access::fence_space::local_space);
+        }
+
+        base_e += static_cast<uint32_t>(extend_len);
+        item.barrier(sycl::access::fence_space::local_space);
+      }
     }
 
-    for (uint32_t k = counter_c; k < num_q_tokens_; ++k) {
-      int32_t* plan = plan_c_i32_ + static_cast<int32_t>(k) * 4;
-      plan[0] = -1;
-      plan[1] = 0;
-      plan[2] = -1;
-      plan[3] = -1;
+    // === Stage D: pad [counter_c, num_q) / [counter_w, num_q) with invalid ===
+    item.barrier(sycl::access::fence_space::local_space);
+    const uint32_t total_c = counter_c_local_[0];
+    const uint32_t total_w = counter_w_local_[0];
+    for (uint32_t k = total_c + tx; k < num_q_tokens_; k += block_size) {
+      plan_c_[k] = CompressPlan::invalid();
     }
-    for (uint32_t k = counter_w; k < num_q_tokens_; ++k) {
-      int32_t* plan = plan_w_i32_ + static_cast<int32_t>(k) * 2;
-      plan[0] = -1;
-      plan[1] = -1;
+    for (uint32_t k = total_w + tx; k < num_q_tokens_; k += block_size) {
+      plan_w_[k] = WritePlan::invalid();
     }
   }
 
-  int32_t* plan_c_i32_;
-  int32_t* plan_w_i32_;
+  CompressPlan* plan_c_;
+  WritePlan* plan_w_;
   const int64_t* seq_lens_ptr_;
   const int64_t* extend_lens_ptr_;
   uint32_t batch_size_;
@@ -157,85 +345,95 @@ struct CompressPrefillStage0Kernel {
   int32_t compress_ratio_;
   int32_t swa_page_size_;
   int32_t mtp_pad_;
+  sycl::local_accessor<uint32_t, 1> counter_c_local_;
+  sycl::local_accessor<uint32_t, 1> counter_w_local_;
+  sycl::local_accessor<int32_t, 1> s_seq_len_;
+  sycl::local_accessor<int32_t, 1> s_prefix_len_;
+  sycl::local_accessor<uint32_t, 1> warp_max_;
+  sycl::local_accessor<uint32_t, 1> warp_min_;
+  sycl::local_accessor<uint32_t, 1> s_max_extend_;
+  sycl::local_accessor<uint32_t, 1> s_min_extend_;
 };
 
 // Kernel for plan_compress_prefill stage 1
 struct CompressPrefillStage1Kernel {
   void operator()(sycl::nd_item<1> item) const {
-    uint32_t idx = static_cast<uint32_t>(item.get_global_id(0));
+    const auto idx = static_cast<uint32_t>(item.get_global_id(0));
     if (idx >= num_work_) return;
 
-    int32_t* plan_c = plan_c_i32_ + idx * 4;
-    if (plan_c[0] != -1) {
-      int32_t batch_id = plan_c[3];
-      int32_t position_1 = plan_c[0] - 1;
-      int32_t position_0 = sycl::max(position_1 - compress_ratio_, 0);
-      int32_t buffer_len = (plan_c[1] >> 16) & 0xFFFF;
-      bool has_buffer = buffer_len > 0;
+    const auto compute_loc = [&](int32_t swa_loc) {
+      const auto swa_page = swa_loc / swa_page_size_;
+      const auto ring_offset = swa_loc % ring_size_;
+      return swa_page * ring_size_ + ring_offset;
+    };
+    const auto compute_c128_loc = [&](int64_t rid, int32_t position) {
+      return static_cast<int32_t>(rid * ring_size_ + position % ring_size_);
+    };
 
-      int64_t rid = rid_ptr_[batch_id];
+    auto plan_c = idx < num_c_ ? plan_c_[idx] : CompressPlan::invalid();
+    if (!plan_c.is_invalid()) {
+      if (plan_c.buffer_len > 0) {
+        const auto batch_id = plan_c.read_page_1;
+        const auto rid = rid_ptr_[batch_id];
+        const auto position_1 = static_cast<int32_t>(plan_c.seq_len - 1);
+        const auto position_0 = sycl::max(position_1 - compress_ratio_, 0);
 
-      int64_t read_page_1;
-      int64_t read_page_0;
-      if (compress_ratio_ == 128) {
-        read_page_1 = rid * ring_size_div_ratio_ + ((static_cast<int64_t>(position_1) % ring_size_) / compress_ratio_);
-        read_page_0 = rid * ring_size_div_ratio_ + ((static_cast<int64_t>(position_0) % ring_size_) / compress_ratio_);
-      } else {
-        const int32_t* mapping = r2t_ptr_ + rid * stride_r2t_;
-        int64_t raw_loc_1 = static_cast<int64_t>(mapping[position_1]);
-        int64_t raw_loc_0 = static_cast<int64_t>(mapping[position_0]);
-        int64_t state_loc_1 = f2s_ptr_[raw_loc_1];
-        int64_t state_loc_0 = f2s_ptr_[raw_loc_0];
-        int64_t write_loc = (state_loc_1 / swa_page_size_) * ring_size_ + (state_loc_1 % ring_size_);
-        int64_t read_loc_0 = (state_loc_0 / swa_page_size_) * ring_size_ + (state_loc_0 % ring_size_);
-        read_page_1 = write_loc / static_cast<int64_t>(compress_ratio_);
-        read_page_0 = read_loc_0 / static_cast<int64_t>(compress_ratio_);
+        if (compress_ratio_ == 128) {
+          plan_c.read_page_0 = compute_c128_loc(rid, position_0) / 128;
+          plan_c.read_page_1 = compute_c128_loc(rid, position_1) / 128;
+        } else {
+          const auto mapping = r2t_ptr_ + rid * stride_r2t_;
+          const auto raw_loc_1 = mapping[position_1];
+          const auto raw_loc_0 = mapping[position_0];
+          const auto state_loc_1 = f2s_ptr_[raw_loc_1];
+          const auto state_loc_0 = f2s_ptr_[raw_loc_0];
+          plan_c.read_page_0 = compute_loc(state_loc_0) / compress_ratio_;
+          plan_c.read_page_1 = compute_loc(state_loc_1) / compress_ratio_;
+        }
+        plan_c_[idx] = plan_c;
       }
-
-      plan_c[2] = has_buffer ? static_cast<int32_t>(read_page_0) : -1;
-      plan_c[3] = has_buffer ? static_cast<int32_t>(read_page_1) : batch_id;
+    } else if (idx < num_c_padded_) {
+      plan_c_[idx] = CompressPlan::invalid();
     }
 
-    int32_t* plan_w = plan_w_i32_ + idx * 2;
-    if (plan_w[0] != -1) {
-      int32_t packed = plan_w[0];
-      int32_t batch_id = (packed >> 16) & 0xFFFF;
-      int32_t position = plan_w[1] - 1;
-      int64_t rid = rid_ptr_[batch_id];
+    auto plan_w = idx < num_w_ ? plan_w_[idx] : WritePlan::invalid();
+    if (!plan_w.is_invalid()) {
+      const auto [ragged_id, batch_id] = unpack_w(plan_w);
+      const auto rid = rid_ptr_[batch_id];
+      const auto position = static_cast<int32_t>(plan_w.write_loc - 1);
 
-      int64_t write_loc;
       if (compress_ratio_ == 128) {
-        write_loc = rid * ring_size_ + (static_cast<int64_t>(position) % ring_size_);
+        plan_w.write_loc = compute_c128_loc(rid, position);
       } else {
-        const int32_t* mapping = r2t_ptr_ + rid * stride_r2t_;
-        int64_t raw_loc = static_cast<int64_t>(mapping[position]);
-        int64_t state_loc = f2s_ptr_[raw_loc];
-        write_loc = (state_loc / swa_page_size_) * ring_size_ + (state_loc % ring_size_);
+        const auto mapping = r2t_ptr_ + rid * stride_r2t_;
+        const auto raw_loc = mapping[position];
+        plan_w.write_loc = compute_loc(f2s_ptr_[raw_loc]);
       }
 
-      plan_w[0] = packed & 0xFFFF;
-      plan_w[1] = static_cast<int32_t>(write_loc);
+      plan_w.ragged_id = ragged_id;
+      plan_w_[idx] = plan_w;
+    } else if (idx < num_w_padded_) {
+      plan_w_[idx] = WritePlan::invalid();
     }
   }
 
-  int32_t* plan_c_i32_;
-  int32_t* plan_w_i32_;
+  CompressPlan* plan_c_;
+  WritePlan* plan_w_;
   const int64_t* rid_ptr_;
   const int32_t* r2t_ptr_;
   const int64_t* f2s_ptr_;
   int32_t swa_page_size_;
   int32_t ring_size_;
-  int32_t ring_size_div_ratio_;
   int32_t compress_ratio_;
   int64_t stride_r2t_;
+  uint32_t num_c_;
+  uint32_t num_w_;
+  uint32_t num_c_padded_;
+  uint32_t num_w_padded_;
   uint32_t num_work_;
 };
 
 }  // namespace CompressPlanImpl
-
-constexpr int64_t kPlanCBytes = sizeof(int32_t) * 4;
-constexpr int64_t kPlanWBytes = sizeof(int32_t) * 2;
-constexpr int64_t kPlanDBytes = sizeof(int32_t) * 4;
 
 // SYCL helper to launch kernels
 inline sycl::nd_range<1> get_1d_range(int32_t size) {
@@ -306,6 +504,7 @@ std::tuple<torch::Tensor, torch::Tensor> plan_compress_prefill(
     int64_t ring_size,
     bool use_cuda_graph) {
   (void)pin_buffer;
+  (void)use_cuda_graph;
 
   TORCH_CHECK(
       req_pool_indices.is_xpu() && req_pool_indices.dtype() == torch::kInt64 && req_pool_indices.dim() == 1,
@@ -324,7 +523,6 @@ std::tuple<torch::Tensor, torch::Tensor> plan_compress_prefill(
       "extend_lens must be a 1D int64 tensor on XPU or CPU");
   TORCH_CHECK(seq_lens.numel() == extend_lens.numel(), "seq_lens and extend_lens must have the same length");
   TORCH_CHECK(req_pool_indices.numel() == seq_lens.numel(), "req_pool_indices and seq_lens must have the same length");
-  TORCH_CHECK(!use_cuda_graph, "plan_compress_prefill only supports use_cuda_graph=False on XPU");
 
   auto seq_lens_xpu = seq_lens;
   if (!seq_lens_xpu.is_xpu()) {
@@ -354,47 +552,72 @@ std::tuple<torch::Tensor, torch::Tensor> plan_compress_prefill(
   auto options_u8 = req_pool_indices.options().dtype(torch::kUInt8);
   if (num_q_tokens_u32 == 0) {
     return {
-        torch::empty({0, kPlanCBytes}, options_u8),
-        torch::empty({0, kPlanWBytes}, options_u8),
+        torch::empty({0, static_cast<int64_t>(sizeof(CompressPlan))}, options_u8),
+        torch::empty({0, static_cast<int64_t>(sizeof(WritePlan))}, options_u8),
     };
   }
 
-  auto plan_c = torch::empty({num_q_tokens_u32, kPlanCBytes}, options_u8);
-  auto plan_w = torch::empty({num_q_tokens_u32, kPlanWBytes}, options_u8);
+  auto plan_c = torch::empty({num_q_tokens_u32, static_cast<int64_t>(sizeof(CompressPlan))}, options_u8);
+  auto plan_w = torch::empty({num_q_tokens_u32, static_cast<int64_t>(sizeof(WritePlan))}, options_u8);
   constexpr int32_t kMaxMTPDraftTokens = 4;
   const int32_t mtp_pad = std::min(ring_size_i32 - compress_ratio_i32, kMaxMTPDraftTokens);
 
   auto queue = c10::xpu::getCurrentXPUStream().queue();
   queue.submit([&](sycl::handler& cgh) {
+    sycl::local_accessor<uint32_t, 1> counter_c_local(sycl::range<1>(1), cgh);
+    sycl::local_accessor<uint32_t, 1> counter_w_local(sycl::range<1>(1), cgh);
+    sycl::local_accessor<int32_t, 1> s_seq_len(sycl::range<1>(kMaxPrefillBatchSize), cgh);
+    sycl::local_accessor<int32_t, 1> s_prefix_len(sycl::range<1>(kMaxPrefillBatchSize), cgh);
+    sycl::local_accessor<uint32_t, 1> warp_max(sycl::range<1>(kStage0NumSubGroups), cgh);
+    sycl::local_accessor<uint32_t, 1> warp_min(sycl::range<1>(kStage0NumSubGroups), cgh);
+    sycl::local_accessor<uint32_t, 1> s_max_extend(sycl::range<1>(1), cgh);
+    sycl::local_accessor<uint32_t, 1> s_min_extend(sycl::range<1>(1), cgh);
+
     CompressPlanImpl::CompressPrefillStage0Kernel kernel{
-        reinterpret_cast<int32_t*>(plan_c.data_ptr<uint8_t>()),
-        reinterpret_cast<int32_t*>(plan_w.data_ptr<uint8_t>()),
+        reinterpret_cast<CompressPlan*>(plan_c.data_ptr<uint8_t>()),
+        reinterpret_cast<WritePlan*>(plan_w.data_ptr<uint8_t>()),
         seq_lens_xpu.data_ptr<int64_t>(),
         extend_lens_xpu.data_ptr<int64_t>(),
         batch_size,
         num_q_tokens_u32,
         compress_ratio_i32,
         swa_page_size_i32,
-        mtp_pad};
-    cgh.parallel_for(get_1d_range(1), kernel);
+        mtp_pad,
+        counter_c_local,
+        counter_w_local,
+        s_seq_len,
+        s_prefix_len,
+        warp_max,
+        warp_min,
+        s_max_extend,
+        s_min_extend};
+    cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(kStage0BlockSize), sycl::range<1>(kStage0BlockSize)), kernel);
   });
 
   int64_t stride_r2t = req_to_token.stride(0);
+  const uint32_t num_c = num_q_tokens_u32;
+  const uint32_t num_w = num_q_tokens_u32;
+  const uint32_t num_c_padded = num_q_tokens_u32;
+  const uint32_t num_w_padded = num_q_tokens_u32;
+  const uint32_t num_work = std::max(num_c_padded, num_w_padded);
   if (num_q_tokens_u32 > 0) {
     queue.submit([&](sycl::handler& cgh) {
       CompressPlanImpl::CompressPrefillStage1Kernel kernel{
-          reinterpret_cast<int32_t*>(plan_c.data_ptr<uint8_t>()),
-          reinterpret_cast<int32_t*>(plan_w.data_ptr<uint8_t>()),
+          reinterpret_cast<CompressPlan*>(plan_c.data_ptr<uint8_t>()),
+          reinterpret_cast<WritePlan*>(plan_w.data_ptr<uint8_t>()),
           req_pool_indices.data_ptr<int64_t>(),
           req_to_token.data_ptr<int32_t>(),
           full_to_state.data_ptr<int64_t>(),
           swa_page_size_i32,
           ring_size_i32,
-          ring_size_i32 / compress_ratio_i32,
           compress_ratio_i32,
           stride_r2t,
-          num_q_tokens_u32};
-      cgh.parallel_for(get_1d_range(static_cast<int32_t>(num_q_tokens_u32)), kernel);
+          num_c,
+          num_w,
+          num_c_padded,
+          num_w_padded,
+          num_work};
+      cgh.parallel_for(get_1d_range(static_cast<int32_t>(num_work)), kernel);
     });
   }
 

--- a/src/sycl/CompressPlan.cpp
+++ b/src/sycl/CompressPlan.cpp
@@ -205,13 +205,14 @@ struct CompressPrefillStage0Kernel {
     }
     item.barrier(sycl::access::fence_space::local_space);
 
-    // MTP-uniform means each request shares the same small extend length E.
+    // MTP-uniform: every batch shares the same small extend_len `E`, so we can decompose
+    // a global token id `k` into (batch_id, j) = (k / E, k % E) and skip the per-batch loop.
     const bool is_mtp_extend =
         (s_min_extend_[0] == s_max_extend_[0]) && (s_max_extend_[0] > 0) && (s_max_extend_[0] <= 32);
 
     // === Stage C: emit valid plans ===
     if (is_mtp_extend) {
-      // Path 1 (token-driven): map k -> (batch_id, j) via E.
+      // Path 1: token-driven. Each global token id maps to exactly one (batch_id, j).
       const uint32_t e = s_max_extend_[0];
       // num_q_tokens_ is padded capacity; cap work at real tokens for safety.
       const uint32_t num_real_q = batch_size_ * e;
@@ -370,6 +371,8 @@ struct CompressPrefillStage1Kernel {
       return static_cast<int32_t>(rid * ring_size_ + position % ring_size_);
     };
 
+    // Stage0 writes a compact/intermediate CompressPlan. Stage1 resolves it to
+    // final ring pages by looking up req->token and token->state mappings.
     auto plan_c = idx < num_c_ ? plan_c_[idx] : CompressPlan::invalid();
     if (!plan_c.is_invalid()) {
       if (plan_c.buffer_len > 0) {
@@ -396,6 +399,8 @@ struct CompressPrefillStage1Kernel {
       plan_c_[idx] = CompressPlan::invalid();
     }
 
+    // Stage0 packs (ragged_id, batch_id) into ragged_id and stores (position+1)
+    // in write_loc. Stage1 unpacks and resolves write_loc to final ring address.
     auto plan_w = idx < num_w_ ? plan_w_[idx] : WritePlan::invalid();
     if (!plan_w.is_invalid()) {
       const auto [ragged_id, batch_id] = unpack_w(plan_w);
@@ -524,6 +529,7 @@ std::tuple<torch::Tensor, torch::Tensor> plan_compress_prefill(
   TORCH_CHECK(seq_lens.numel() == extend_lens.numel(), "seq_lens and extend_lens must have the same length");
   TORCH_CHECK(req_pool_indices.numel() == seq_lens.numel(), "req_pool_indices and seq_lens must have the same length");
 
+  // Accept CPU metadata tensors and move them to the current XPU stream device.
   auto seq_lens_xpu = seq_lens;
   if (!seq_lens_xpu.is_xpu()) {
     seq_lens_xpu = seq_lens.to(req_pool_indices.options().dtype(torch::kInt64));

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -341,6 +341,13 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
    * Compress plan kernels
    */
   m.def(
+      "plan_compress_prefill(Tensor req_pool_indices, Tensor req_to_token, Tensor full_to_state, "
+      "Tensor seq_lens, Tensor extend_lens, Tensor pin_buffer, int num_q_tokens, int compress_ratio, int "
+      "swa_page_size, "
+      "int ring_size, bool use_cuda_graph=False) -> (Tensor, Tensor)");
+  m.impl("plan_compress_prefill", torch::kXPU, &at::native::xpu::plan_compress_prefill);
+
+  m.def(
       "plan_compress_decode(Tensor req_pool_indices, Tensor req_to_token, Tensor full_to_state, "
       "Tensor seq_lens, int compress_ratio, int swa_page_size, int ring_size) -> Tensor");
   m.impl("plan_compress_decode", torch::kXPU, &at::native::xpu::plan_compress_decode);


### PR DESCRIPTION
### Motivation
Adds an SYCL implementation of the plan_compress_prefill planner and wires it into the Torch extension so Python can call the SYCL kernel instead of the previous pure-PyTorch implementation.

### Modifications
Register plan_compress_prefill in TORCH_LIBRARY_FRAGMENT(sgl_kernel, ...) for XPU dispatch.
Add SYCL kernel + C++ wrapper implementation for at::native::xpu::plan_compress_prefill.
Update the Python wrapper to call torch.ops.sgl_kernel.plan_compress_prefill instead of computing the plan via PyTorch ops.

### Performance
The SYCL implementation significantly improves the performance of plan_compress_prefill on XPU.
case | ratio | bs | seq_lens | extend_lens | num_q_tokens | sycl implementation time (us) | pure-PyTorch implementation time (us)
-- | -- | -- | -- | -- | -- | -- | --
c4_prefill_seq8_ext8_paged | 4 | 1 | 8 | 8 | 8 | 9.765 | 1185.589
c4_prefill_seq32_ext32_paged | 4 | 1 | 32 | 32 | 32 | 10.223 | 1173.261
c4_prefill_seq256_ext256_paged | 4 | 1 | 256 | 256 | 256 | 10.498 | 1221.63
c4_prefill_seq1024_ext1024_paged | 4 | 1 | 1024 | 1024 | 1024 | 17.304 | 1416.887
c128_prefill_seq128_ext128_paged | 128 | 1 | 128 | 128 | 128 | 7.471 | 857.95
c128_prefill_seq256_ext256_paged | 128 | 1 | 256 | 256 | 256 | 7.729 | 860.995
c128_prefill_seq512_ext512_paged | 128 | 1 | 512 | 512 | 512 | 9.198 | 887.474
