### PR TITLE
[Attention] support softmax lse

### DIFF
--- a/include/sgl_flash_kernel_ops.h
+++ b/include/sgl_flash_kernel_ops.h
@@ -46,7 +46,7 @@ limitations under the License.
 // Defined in the FMHA/MLA SYCL shared libraries (built with -fvisibility=hidden)
 // and called from common_ops; keep them exported with default visibility.
 #pragma GCC visibility push(default)
-std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
+void mha_fwd(
     const at::Tensor& q,  // (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_q
     const at::Tensor& k,  // (b_k, s_k, h_k, d) or (total_k, h_k, d) if there is cu_seqlens_k or (num_pages, page_size,
                           // h_k, d) if there is page_table.
@@ -77,8 +77,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    std::optional<at::Tensor>& out_,
-    bool return_softmax_lse);
+    at::Tensor& out,
+    at::Tensor& softmax_lse);
 
 void flash_mla_decode(
     torch::Tensor& out,

--- a/include/sgl_flash_kernel_ops.h
+++ b/include/sgl_flash_kernel_ops.h
@@ -78,7 +78,7 @@ void mha_fwd(
     std::optional<bool> pack_gqa_,
     int const sm_margin,
     at::Tensor& out,
-    at::Tensor& softmax_lse);
+    std::optional<at::Tensor>& softmax_lse);
 
 void flash_mla_decode(
     torch::Tensor& out,

--- a/include/sgl_flash_kernel_ops.h
+++ b/include/sgl_flash_kernel_ops.h
@@ -77,7 +77,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    std::optional<at::Tensor>& out_);
+    std::optional<at::Tensor>& out_,
+    bool return_softmax_lse);
 
 void flash_mla_decode(
     torch::Tensor& out,

--- a/python/sgl_kernel/flash_attn.py
+++ b/python/sgl_kernel/flash_attn.py
@@ -264,7 +264,22 @@ def flash_attn_with_kvcache(
     if cache_seqlens is not None:
         assert cache_seqlens.size(0) + 1 == cu_seqlens_q.size(0)
         cu_seqlens_k = cache_seqlens
-    out, softmax_lse, *rest = torch.ops.sgl_kernel.fwd.default(
+
+    # Pre-construct the output buffers and let the kernel write into them in
+    # place (passed by reference); nothing is returned by the op. Whether the
+    # logsumexp is computed is signalled by passing a non-empty ``softmax_lse``
+    # buffer (an empty tensor skips the LSE computation).
+    total_q = q.size(0)
+    num_heads = q.size(-2)
+    head_size_v = v_cache.size(-1)
+    if out is None:
+        out = q.new_empty(total_q, num_heads, head_size_v)
+    softmax_lse = (
+        q.new_empty(num_heads, total_q, dtype=torch.float32)
+        if return_softmax_lse
+        else q.new_empty(0, dtype=torch.float32)
+    )
+    torch.ops.sgl_kernel.fwd.default(
         q,
         k_cache,
         v_cache,
@@ -294,9 +309,9 @@ def flash_attn_with_kvcache(
         pack_gqa,
         sm_margin,
         out,
-        return_softmax_lse,
+        softmax_lse,
     )
-    return (out, softmax_lse, *rest) if return_softmax_lse else out
+    return (out, softmax_lse) if return_softmax_lse else out
 
 
 def flash_attn_varlen_func(
@@ -339,7 +354,20 @@ def flash_attn_varlen_func(
         max_seqlen_q = q.size(1)
         q = q.view(-1, q.size(-2), q.size(-1)).contiguous()
 
-    out, softmax_lse, *rest = torch.ops.sgl_kernel.fwd.default(
+    # Pre-construct the output buffers and let the kernel write into them in
+    # place (passed by reference); nothing is returned by the op. Whether the
+    # logsumexp is computed is signalled by passing a non-empty ``softmax_lse``
+    # buffer (an empty tensor skips the LSE computation).
+    total_q = q.size(0)
+    num_heads = q.size(-2)
+    head_size_v = v.size(-1)
+    out = q.new_empty(total_q, num_heads, head_size_v)
+    softmax_lse = (
+        q.new_empty(num_heads, total_q, dtype=torch.float32)
+        if return_softmax_lse
+        else q.new_empty(0, dtype=torch.float32)
+    )
+    torch.ops.sgl_kernel.fwd.default(
         q,
         k,
         v,
@@ -368,8 +396,8 @@ def flash_attn_varlen_func(
         num_splits,
         pack_gqa,
         sm_margin,
-        None,  # out
-        return_softmax_lse,
+        out,
+        softmax_lse,
     )
 
-    return (out, softmax_lse, *rest) if return_softmax_lse else out
+    return (out, softmax_lse) if return_softmax_lse else out

--- a/python/sgl_kernel/flash_attn.py
+++ b/python/sgl_kernel/flash_attn.py
@@ -294,6 +294,7 @@ def flash_attn_with_kvcache(
         pack_gqa,
         sm_margin,
         out,
+        return_softmax_lse,
     )
     return (out, softmax_lse, *rest) if return_softmax_lse else out
 
@@ -367,6 +368,8 @@ def flash_attn_varlen_func(
         num_splits,
         pack_gqa,
         sm_margin,
+        None,  # out
+        return_softmax_lse,
     )
 
     return (out, softmax_lse, *rest) if return_softmax_lse else out

--- a/python/sgl_kernel/flash_attn.py
+++ b/python/sgl_kernel/flash_attn.py
@@ -267,8 +267,8 @@ def flash_attn_with_kvcache(
 
     # Pre-construct the output buffers and let the kernel write into them in
     # place (passed by reference); nothing is returned by the op. Whether the
-    # logsumexp is computed is signalled by passing a non-empty ``softmax_lse``
-    # buffer (an empty tensor skips the LSE computation).
+    # logsumexp is computed is signalled by passing ``softmax_lse``: a real
+    # tensor requests it, ``None`` skips the LSE computation.
     total_q = q.size(0)
     num_heads = q.size(-2)
     head_size_v = v_cache.size(-1)
@@ -277,7 +277,7 @@ def flash_attn_with_kvcache(
     softmax_lse = (
         q.new_empty(num_heads, total_q, dtype=torch.float32)
         if return_softmax_lse
-        else q.new_empty(0, dtype=torch.float32)
+        else None
     )
     torch.ops.sgl_kernel.fwd.default(
         q,
@@ -356,8 +356,8 @@ def flash_attn_varlen_func(
 
     # Pre-construct the output buffers and let the kernel write into them in
     # place (passed by reference); nothing is returned by the op. Whether the
-    # logsumexp is computed is signalled by passing a non-empty ``softmax_lse``
-    # buffer (an empty tensor skips the LSE computation).
+    # logsumexp is computed is signalled by passing ``softmax_lse``: a real
+    # tensor requests it, ``None`` skips the LSE computation.
     total_q = q.size(0)
     num_heads = q.size(-2)
     head_size_v = v.size(-1)
@@ -365,7 +365,7 @@ def flash_attn_varlen_func(
     softmax_lse = (
         q.new_empty(num_heads, total_q, dtype=torch.float32)
         if return_softmax_lse
-        else q.new_empty(0, dtype=torch.float32)
+        else None
     )
     torch.ops.sgl_kernel.fwd.default(
         q,

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -94,6 +94,7 @@ std::vector<at::Tensor> mha_fwd_nopage(
     int window_size_left,
     int window_size_right,
     float const softcap,
+    bool return_softmax_lse,
     std::optional<at::Tensor> out_opt,
     std::optional<at::Tensor> skip_batch_mask_opt) {
   auto q_type = q.scalar_type();
@@ -191,6 +192,7 @@ std::vector<at::Tensor> mha_fwd_nopage(
   params.total_knew = 0;
 
   params.softmax_lse_ptr = softmax_lse.data_ptr();
+  params.return_softmax_lse = return_softmax_lse;
 
   params.b = batch_size;
   params.h = num_heads;
@@ -302,6 +304,7 @@ std::vector<at::Tensor> mha_fwd(
     // chunkprefill two-launch path: pre-allocated shared output, and a per-batch
     // bool mask (length = batch) whose true entries are skipped by the kernel.
     std::optional<at::Tensor> out_opt = std::nullopt,
+    bool return_softmax_lse = false,
     std::optional<at::Tensor> skip_batch_mask_opt = std::nullopt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -347,6 +350,7 @@ std::vector<at::Tensor> mha_fwd(
         window_size_left,
         window_size_right,
         softcap,
+        return_softmax_lse,
         std::move(out_opt),
         std::move(skip_batch_mask_opt));
   }
@@ -479,8 +483,12 @@ std::vector<at::Tensor> mha_fwd(
   // Cast to char to avoid compiler warning about narrowing
   c10::DeviceGuard device_guard(q.device());
 
+  // Only allocate the (num_heads, total_q) LSE tensor when the caller asked for
+  // it; otherwise a zero-element placeholder keeps the return ABI stable while
+  // the kernel (LSE=false) skips every LSE write.
   at::Tensor softmax_lse;
-  softmax_lse = torch::empty({num_heads, total_q}, opts.dtype(at::kFloat));
+  softmax_lse = return_softmax_lse ? torch::empty({num_heads, total_q}, opts.dtype(at::kFloat))
+                                   : torch::empty({0}, opts.dtype(at::kFloat));
 
   // align with FA3
 
@@ -520,8 +528,10 @@ std::vector<at::Tensor> mha_fwd(
   params.cu_seqlens_k = cu_seqlens_k.data_ptr<int>();
   params.num_kv_splits = num_kv_splits;
 
-  // Softmax sum
-  params.softmax_lse_ptr = softmax_lse.data_ptr();
+  // Softmax sum (null when the caller does not request it, matching the empty
+  // placeholder tensor above).
+  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse.data_ptr() : nullptr;
+  params.return_softmax_lse = return_softmax_lse;
 
   // Set the dimensions.
   params.b = batch_size;
@@ -891,6 +901,7 @@ std::vector<at::Tensor> mha_fwd(
     // chunkprefill two-launch path: pre-allocated shared output, and a per-batch
     // bool mask (length = batch) whose true entries are skipped by the kernel.
     std::optional<at::Tensor> out_opt = std::nullopt,
+    bool return_softmax_lse = false,
     std::optional<at::Tensor> skip_batch_mask_opt = std::nullopt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -1011,8 +1022,12 @@ std::vector<at::Tensor> mha_fwd(
   // Cast to char to avoid compiler warning about narrowing
   c10::DeviceGuard device_guard(q.device());
 
+  // Only allocate the (num_heads, total_q) LSE tensor when the caller asked for
+  // it; otherwise a zero-element placeholder keeps the return ABI stable while
+  // the kernel (LSE=false) skips every LSE write.
   at::Tensor softmax_lse;
-  softmax_lse = torch::empty({num_heads, total_q}, opts.dtype(at::kFloat));
+  softmax_lse = return_softmax_lse ? torch::empty({num_heads, total_q}, opts.dtype(at::kFloat))
+                                   : torch::empty({0}, opts.dtype(at::kFloat));
 
   // align with FA3
   Arguments params;
@@ -1040,8 +1055,10 @@ std::vector<at::Tensor> mha_fwd(
   params.cu_seqlens_q = cu_seqlens_q.data_ptr<int>();
   params.cu_seqlens_k = cu_seqlens_k.data_ptr<int>();
 
-  // Softmax sum
-  params.softmax_lse_ptr = softmax_lse.data_ptr();
+  // Softmax sum (null when the caller does not request it, matching the empty
+  // placeholder tensor above).
+  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse.data_ptr() : nullptr;
+  params.return_softmax_lse = return_softmax_lse;
 
   // Set the dimensions.
   params.b = batch_size;
@@ -1236,7 +1253,8 @@ std::vector<at::Tensor> mha_fwd(
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    std::optional<at::Tensor> out_ = std::nullopt) {
+    std::optional<at::Tensor> out_ = std::nullopt,
+    bool return_softmax_lse = false) {
   // Supports both paged (page_table != None) and non-paged (contiguous ragged
   // KV, page_table == None) layouts.
   // ``seqlens_rotary_`` is intentionally not checked here: callers pass it
@@ -1293,12 +1311,14 @@ std::vector<at::Tensor> mha_fwd(
         pack_gqa_,
         sm_margin,
         std::move(out_opt),
+        return_softmax_lse,
         std::move(skip_mask));
   };
 
   // Launch 1: decode allocates the shared output (or reuses the caller-provided
-  // out_ buffer) and skips prefill batches. It also allocates a full
-  // (num_heads, total_q) softmax_lse and fills only the decode rows.
+  // out_ buffer) and skips prefill batches. When return_softmax_lse is set it
+  // also allocates a full (num_heads, total_q) softmax_lse and fills only the
+  // decode rows (otherwise an empty placeholder).
   auto decode_ret = launch(decode::mha_fwd, std::move(out_), is_prefill);
   auto out = decode_ret[0];
   auto lse_decode = decode_ret[1];  // (num_heads, total_q), valid only on decode rows
@@ -1312,9 +1332,16 @@ std::vector<at::Tensor> mha_fwd(
   // launch that actually computed it. Columns are query tokens (total_q); a token
   // belongs to a prefill batch iff its batch has seqlen_q > 1. at::where is a pure
   // element-wise select, so the uninitialized rows are never read out. This runs
-  // entirely on device (no D2H sync).
-  auto token_is_prefill = is_prefill.repeat_interleave(seqlens_q.to(at::kLong));         // (total_q,)
-  auto softmax_lse = at::where(token_is_prefill.unsqueeze(0), lse_prefill, lse_decode);  // (num_heads, total_q)
+  // entirely on device (no D2H sync). When return_softmax_lse is false the two
+  // sub-launches allocated empty LSE placeholders (no LSE compute), so skip the
+  // stitch and return an empty placeholder as well.
+  at::Tensor softmax_lse;
+  if (return_softmax_lse) {
+    auto token_is_prefill = is_prefill.repeat_interleave(seqlens_q.to(at::kLong));    // (total_q,)
+    softmax_lse = at::where(token_is_prefill.unsqueeze(0), lse_prefill, lse_decode);  // (num_heads, total_q)
+  } else {
+    softmax_lse = at::empty({0}, q.options().dtype(at::kFloat));
+  }
 
   // accum tensors are internal to split-KV reduction and unused by the Python
   // caller; return empty placeholders to keep the ABI stable.
@@ -1353,7 +1380,8 @@ SGL_KERNEL_EXPORT std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    std::optional<at::Tensor>& out_) {
+    std::optional<at::Tensor>& out_,
+    bool return_softmax_lse = false) {
   TORCH_CHECK(q.dim() == 3, "query must be in ragged format (total_q, h, d)");
   // k and v may be 3D (total_k, h_k, d) for non-paged or 4D (num_pages, page_size, h_k, d)
   // for paged KV cache; sub-functions validate their own shapes.
@@ -1408,6 +1436,7 @@ SGL_KERNEL_EXPORT std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha
            pack_gqa_,
            sm_margin,
            out_,
+           return_softmax_lse,
            std::forward<decltype(tail)>(tail)...));
   };
 

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -80,7 +80,7 @@ namespace decode {
 // chunkprefill dispatcher run on the decode-optimized kernel. The non-paged
 // decode kernel carries its own tile configuration (FMHA_DECODE_TILED_KV_NP_*)
 // so it can be tuned independently of both the paged decode and prefill paths.
-std::vector<at::Tensor> mha_fwd_nopage(
+void mha_fwd_nopage(
     const at::Tensor& q,             // (total_q, h, d)
     const at::Tensor& k,             // (total_k, h_k, d)
     const at::Tensor& v,             // (total_k, h_k, dv)
@@ -94,8 +94,8 @@ std::vector<at::Tensor> mha_fwd_nopage(
     int window_size_left,
     int window_size_right,
     float const softcap,
-    bool return_softmax_lse,
-    std::optional<at::Tensor> out_opt,
+    at::Tensor& out,
+    at::Tensor& softmax_lse,
     std::optional<at::Tensor> skip_batch_mask_opt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -149,17 +149,14 @@ std::vector<at::Tensor> mha_fwd_nopage(
   TORCH_CHECK(head_size % alignment == 0, "head_size should be a multiple of " + std::to_string(alignment));
   TORCH_CHECK(head_size_v % alignment == 0, "head_size_v should be a multiple of " + std::to_string(alignment));
 
-  auto opts = q.options();
-  // Use the caller-provided shared output when present (two-launch path); the
-  // first launch zero-initializes so that rows of batches with zero KV length
-  // (never written by the kernel) read back their correct value of 0.
-  at::Tensor out = out_opt.has_value() ? *out_opt : torch::zeros({total_q, num_heads, head_size_v}, opts);
+  // ``out`` is caller-provided and written in place. Whether to compute the
+  // softmax logsumexp is derived from the caller-provided ``softmax_lse`` buffer
+  // (a non-empty tensor requests it; an empty one skips the LSE computation).
+  bool const return_softmax_lse = softmax_lse.numel() > 0;
 
   int const head_size_rounded = round_up_headdim(head_size);
 
   c10::DeviceGuard device_guard(q.device());
-
-  at::Tensor softmax_lse = torch::empty({num_heads, total_q}, opts.dtype(at::kFloat));
 
   Arguments params;
   params.is_bf16 = q.dtype() == torch::kBFloat16;
@@ -192,7 +189,7 @@ std::vector<at::Tensor> mha_fwd_nopage(
   params.seqlen_knew = 0;
   params.total_knew = 0;
 
-  params.softmax_lse_ptr = softmax_lse.data_ptr();
+  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse.data_ptr() : nullptr;
   params.return_softmax_lse = return_softmax_lse;
 
   params.b = batch_size;
@@ -255,8 +252,6 @@ std::vector<at::Tensor> mha_fwd_nopage(
 
   params.tensor_opts = torch::TensorOptions().dtype(torch::kUInt8).device(q.device());
 
-  at::Tensor out_accum, softmax_lse_accum;
-
   int qg_sz = nextPowerOf2(params.q_group_size);
   TORCH_CHECK(qg_sz >= 1 && qg_sz <= 16, "Unsupported q_group_size for decode attention: ", params.q_group_size);
   // Non-paged decode supports its own (independent) set of head dims; see
@@ -268,11 +263,9 @@ std::vector<at::Tensor> mha_fwd_nopage(
       params.d);
 
   DISPATCH_DECODE_NOPAGE(qg_sz);
-
-  return {out, softmax_lse, out_accum, softmax_lse_accum};
 }
 
-std::vector<at::Tensor> mha_fwd(
+void mha_fwd(
     const at::Tensor& q,  // (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_q
     const at::Tensor& k,  // (b_k, s_k, h_k, d) or (total_k, h_k, d) if there is cu_seqlens_k or (num_pages, page_size,
                           // h_k, d) if there is page_table.
@@ -303,10 +296,12 @@ std::vector<at::Tensor> mha_fwd(
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    // chunkprefill two-launch path: pre-allocated shared output, and a per-batch
-    // bool mask (length = batch) whose true entries are skipped by the kernel.
-    std::optional<at::Tensor> out_opt = std::nullopt,
-    bool return_softmax_lse = false,
+    // Caller-provided output buffers written in place: ``out`` receives the
+    // attention result and ``softmax_lse`` the logsumexp when non-empty. A
+    // per-batch skip mask (length = batch, chunkprefill two-launch path) selects
+    // which batches this launch processes.
+    at::Tensor& out,
+    at::Tensor& softmax_lse,
     std::optional<at::Tensor> skip_batch_mask_opt = std::nullopt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -338,7 +333,7 @@ std::vector<at::Tensor> mha_fwd(
   // the decode-specific non-paged entry (decode::mha_fwd_nopage) so it can carry
   // its own parameter configuration independently of the prefill path.
   if (!page_table.has_value()) {
-    return mha_fwd_nopage(
+    mha_fwd_nopage(
         q,
         k,
         v,
@@ -352,9 +347,10 @@ std::vector<at::Tensor> mha_fwd(
         window_size_left,
         window_size_right,
         softcap,
-        return_softmax_lse,
-        std::move(out_opt),
+        out,
+        softmax_lse,
         std::move(skip_batch_mask_opt));
+    return;
   }
 
   TORCH_CHECK(page_table.value().dtype() == torch::kInt32, "page_table must have dtype torch.int32");
@@ -420,12 +416,13 @@ std::vector<at::Tensor> mha_fwd(
   TORCH_CHECK(head_size % alignment == 0, "head_size should be a multiple of " + std::to_string(alignment));
   TORCH_CHECK(head_size_v % alignment == 0, "head_size_v should be a multiple of " + std::to_string(alignment));
 
-  auto opts = q.options();
-  at::Tensor out;
+  // ``out`` is caller-provided and written in place. Whether to compute the
+  // softmax logsumexp is derived from the caller-provided ``softmax_lse`` buffer
+  // (a non-empty tensor requests it; an empty one skips the LSE computation).
+  bool const return_softmax_lse = softmax_lse.numel() > 0;
   at::Tensor temp_out;    // [batch, num_kv_splits, num_head_q, seq_q, head_size]
   at::Tensor exp_sums;    // [batch, num_head_q, seq_q, num_kv_splits]
   at::Tensor max_logits;  // [batch, num_head_q, seq_q, num_kv_splits]
-  out = out_opt.has_value() ? *out_opt : torch::empty({total_q, num_heads, head_size_v}, opts);
   Arguments params;
   // num_kv_splits semantics (host-side scalar, no D2H sync):
   //   -1 or 1 -> split-KV disabled, use the non-split FmhaDecodeRunner
@@ -494,12 +491,8 @@ std::vector<at::Tensor> mha_fwd(
   // Cast to char to avoid compiler warning about narrowing
   c10::DeviceGuard device_guard(q.device());
 
-  // Only allocate the (num_heads, total_q) LSE tensor when the caller asked for
-  // it; otherwise a zero-element placeholder keeps the return ABI stable while
-  // the kernel (LSE=false) skips every LSE write.
-  at::Tensor softmax_lse;
-  softmax_lse = return_softmax_lse ? torch::empty({num_heads, total_q}, opts.dtype(at::kFloat))
-                                   : torch::empty({0}, opts.dtype(at::kFloat));
+  // ``softmax_lse`` is caller-provided; empty (numel == 0) when the LSE was not
+  // requested, in which case the kernel skips every LSE write.
 
   // align with FA3
 
@@ -665,8 +658,6 @@ std::vector<at::Tensor> mha_fwd(
 
   params.tensor_opts = torch::TensorOptions().dtype(torch::kUInt8).device(q.device());
 
-  at::Tensor out_accum, softmax_lse_accum;
-
   int qg_sz = nextPowerOf2(params.q_group_size);
   TORCH_CHECK(qg_sz >= 1 && qg_sz <= 16, "Unsupported q_group_size for decode attention: ", params.q_group_size);
   // Paged decode supports its own (independent) set of head dims; see
@@ -681,8 +672,6 @@ std::vector<at::Tensor> mha_fwd(
       params.page_size);
 
   DISPATCH_DECODE(qg_sz);
-
-  return {out, softmax_lse, out_accum, softmax_lse_accum};
 }
 
 }  // namespace decode
@@ -691,9 +680,10 @@ namespace prefill {
 
 // Non-paged (contiguous ragged KV) prefill entry. Drives both the prefill and
 // the decode sub-launches of the no-page chunkprefill two-launch path: the
-// caller passes a shared output (out_opt) and a per-batch skip mask
-// (skip_batch_mask_opt) selecting which batches this launch processes.
-std::vector<at::Tensor> mha_fwd_nopage(
+// caller passes shared ``out`` / ``softmax_lse`` buffers (written in place) and
+// a per-batch skip mask (skip_batch_mask_opt) selecting which batches this
+// launch processes.
+void mha_fwd_nopage(
     const at::Tensor& q,             // (total_q, h, d)
     const at::Tensor& k,             // (total_k, h_k, d)
     const at::Tensor& v,             // (total_k, h_k, dv)
@@ -707,7 +697,8 @@ std::vector<at::Tensor> mha_fwd_nopage(
     int window_size_left,
     int window_size_right,
     float const softcap,
-    std::optional<at::Tensor> out_opt,
+    at::Tensor& out,
+    at::Tensor& softmax_lse,
     std::optional<at::Tensor> skip_batch_mask_opt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -761,17 +752,12 @@ std::vector<at::Tensor> mha_fwd_nopage(
   TORCH_CHECK(head_size % alignment == 0, "head_size should be a multiple of " + std::to_string(alignment));
   TORCH_CHECK(head_size_v % alignment == 0, "head_size_v should be a multiple of " + std::to_string(alignment));
 
-  auto opts = q.options();
-  // Use the caller-provided shared output when present (two-launch path); the
-  // first launch zero-initializes so that rows of batches with zero KV length
-  // (never written by the kernel) read back their correct value of 0.
-  at::Tensor out = out_opt.has_value() ? *out_opt : torch::zeros({total_q, num_heads, head_size_v}, opts);
+  // ``out`` is caller-provided and written in place. Non-paged prefill does not
+  // currently compute the softmax logsumexp (``softmax_lse`` is left untouched).
 
   int const head_size_rounded = round_up_headdim(head_size);
 
   c10::DeviceGuard device_guard(q.device());
-
-  at::Tensor softmax_lse = torch::empty({num_heads, total_q}, opts.dtype(at::kFloat));
 
   Arguments params;
   params.is_bf16 = q.dtype() == torch::kBFloat16;
@@ -797,7 +783,7 @@ std::vector<at::Tensor> mha_fwd_nopage(
   params.cu_seqlens_q = cu_seqlens_q.data_ptr<int>();
   params.cu_seqlens_k = cu_seqlens_k.data_ptr<int>();
 
-  params.softmax_lse_ptr = softmax_lse.data_ptr();
+  params.softmax_lse_ptr = softmax_lse.numel() > 0 ? softmax_lse.data_ptr() : nullptr;
 
   params.b = batch_size;
   params.h = num_heads;
@@ -844,8 +830,6 @@ std::vector<at::Tensor> mha_fwd_nopage(
 
   params.tensor_opts = torch::TensorOptions().dtype(torch::kUInt8).device(q.device());
 
-  at::Tensor out_accum, softmax_lse_accum;
-
   // Non-paged prefill supports its own (independent) set of head dims; see
   // FMHA_PREFILL_NP_HEAD_DIMS in FMHAPrefillXe20.cmake.
   TORCH_CHECK(
@@ -884,10 +868,9 @@ std::vector<at::Tensor> mha_fwd_nopage(
   }
 
   // TODO: Support prefill softmax_lse, now is 0
-  return {out, softmax_lse, out_accum, softmax_lse_accum};
 }
 
-std::vector<at::Tensor> mha_fwd(
+void mha_fwd(
     const at::Tensor& q,  // (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_q
     const at::Tensor& k,  // (b_k, s_k, h_k, d) or (total_k, h_k, d) if there is cu_seqlens_k or (num_pages, page_size,
                           // h_k, d) if there is page_table.
@@ -918,10 +901,12 @@ std::vector<at::Tensor> mha_fwd(
     int num_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    // chunkprefill two-launch path: pre-allocated shared output, and a per-batch
-    // bool mask (length = batch) whose true entries are skipped by the kernel.
-    std::optional<at::Tensor> out_opt = std::nullopt,
-    bool return_softmax_lse = false,
+    // Caller-provided output buffers written in place: ``out`` receives the
+    // attention result and ``softmax_lse`` the logsumexp when non-empty. A
+    // per-batch skip mask (length = batch, chunkprefill two-launch path) selects
+    // which batches this launch processes.
+    at::Tensor& out,
+    at::Tensor& softmax_lse,
     std::optional<at::Tensor> skip_batch_mask_opt = std::nullopt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -950,7 +935,7 @@ std::vector<at::Tensor> mha_fwd(
 
   // Non-paged (page_table == nullopt) prefill: contiguous ragged KV cache.
   if (!page_table.has_value()) {
-    return mha_fwd_nopage(
+    mha_fwd_nopage(
         q,
         k,
         v,
@@ -964,8 +949,10 @@ std::vector<at::Tensor> mha_fwd(
         window_size_left,
         window_size_right,
         softcap,
-        std::move(out_opt),
+        out,
+        softmax_lse,
         std::move(skip_batch_mask_opt));
+    return;
   }
 
   TORCH_CHECK(page_table.value().dtype() == torch::kInt32, "page_table must have dtype torch.int32");
@@ -1031,9 +1018,10 @@ std::vector<at::Tensor> mha_fwd(
   TORCH_CHECK(head_size % alignment == 0, "head_size should be a multiple of " + std::to_string(alignment));
   TORCH_CHECK(head_size_v % alignment == 0, "head_size_v should be a multiple of " + std::to_string(alignment));
 
-  auto opts = q.options();
-  at::Tensor out;
-  out = out_opt.has_value() ? *out_opt : torch::empty({total_q, num_heads, head_size_v}, opts);
+  // ``out`` is caller-provided and written in place. Whether to compute the
+  // softmax logsumexp is derived from the caller-provided ``softmax_lse`` buffer
+  // (a non-empty tensor requests it; an empty one skips the LSE computation).
+  bool const return_softmax_lse = softmax_lse.numel() > 0;
 
   int const head_size_rounded = round_up_headdim(head_size);
   int const head_size_v_rounded = head_size_v == head_size ? head_size_rounded : round_up_headdim(head_size_v);
@@ -1042,12 +1030,8 @@ std::vector<at::Tensor> mha_fwd(
   // Cast to char to avoid compiler warning about narrowing
   c10::DeviceGuard device_guard(q.device());
 
-  // Only allocate the (num_heads, total_q) LSE tensor when the caller asked for
-  // it; otherwise a zero-element placeholder keeps the return ABI stable while
-  // the kernel (LSE=false) skips every LSE write.
-  at::Tensor softmax_lse;
-  softmax_lse = return_softmax_lse ? torch::empty({num_heads, total_q}, opts.dtype(at::kFloat))
-                                   : torch::empty({0}, opts.dtype(at::kFloat));
+  // ``softmax_lse`` is caller-provided; empty (numel == 0) when the LSE was not
+  // requested, in which case the kernel skips every LSE write.
 
   // align with FA3
   Arguments params;
@@ -1196,8 +1180,6 @@ std::vector<at::Tensor> mha_fwd(
 
   params.tensor_opts = torch::TensorOptions().dtype(torch::kUInt8).device(q.device());
 
-  at::Tensor out_accum, softmax_lse_accum;
-
   // Paged prefill supports its own (independent) set of head dims; see
   // FMHA_PREFILL_PAGED_HEAD_DIMS in FMHAPrefillXe20.cmake.
   TORCH_CHECK(
@@ -1229,7 +1211,6 @@ std::vector<at::Tensor> mha_fwd(
   }
 
   // TODO: Support prefill softmax_lse, now is 0
-  return {out, softmax_lse, out_accum, softmax_lse_accum};
 }
 
 }  // namespace prefill
@@ -1245,7 +1226,7 @@ namespace chunkprefill {
 // Limitations: paged KV cache required; rotary / q_v / descale / scheduler
 // metadata are not supported on this path. Sliding window and attention sinks
 // are forwarded to both sub-kernels, which support them.
-std::vector<at::Tensor> mha_fwd(
+void mha_fwd(
     const at::Tensor& q,
     const at::Tensor& k,
     const at::Tensor& v,
@@ -1274,8 +1255,8 @@ std::vector<at::Tensor> mha_fwd(
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    std::optional<at::Tensor> out_ = std::nullopt,
-    bool return_softmax_lse = false) {
+    at::Tensor& out,
+    at::Tensor& softmax_lse) {
   // Supports both paged (page_table != None) and non-paged (contiguous ragged
   // KV, page_table == None) layouts.
   // ``seqlens_rotary_`` is intentionally not checked here: callers pass it
@@ -1286,12 +1267,10 @@ std::vector<at::Tensor> mha_fwd(
           !scheduler_metadata_.has_value(),
       "chunkprefill two-launch path does not yet support q_v / rotary / q_descale / scheduler_metadata.");
   TORCH_CHECK(cu_seqlens_q.scalar_type() == at::kInt, "cu_seqlens_q must be int32.");
-  // Pre-allocated out requires paged KV: on the non-paged path zero-KV-length
-  // rows are never written by the kernel, so a caller buffer would retain stale
-  // values on graph replay. SGLang always provides page_table (paged KV cache),
-  // so this check should never fire in practice.
-  TORCH_CHECK(
-      !out_.has_value() || page_table.has_value(), "chunkprefill: out buffer requires page_table (paged KV cache).");
+  // chunkprefill is only reached for paged KV (the public dispatcher routes the
+  // non-paged and single-batch cases to the pure prefill path), so the
+  // caller-provided ``out`` buffer is always backed by a page table.
+  TORCH_CHECK(page_table.has_value(), "chunkprefill: requires page_table (paged KV cache).");
 
   int64_t batch_size = cu_seqlens_q.size(0) - 1;
   TORCH_CHECK(batch_size >= 0, "cu_seqlens_q must have at least 1 element.");
@@ -1299,80 +1278,56 @@ std::vector<at::Tensor> mha_fwd(
   auto seqlens_q = cu_seqlens_q.slice(0, 1, batch_size + 1).sub(cu_seqlens_q.slice(0, 0, batch_size));
   auto is_prefill = seqlens_q.gt(1).contiguous();  // true for prefill batches
 
-  // Forward every shared argument to a sub-kernel, overriding only the output
-  // tensor (out_opt) and the per-batch skip mask.
-  auto launch = [&](auto&& fn, std::optional<at::Tensor> out_opt, std::optional<at::Tensor> skip_mask) {
-    return fn(
-        q,
-        k,
-        v,
-        q_v_,
-        cu_seqlens_q,
-        cu_seqlens_k,
-        max_seqlen_q,
-        max_seqlen_k,
-        page_table,
-        kv_batch_idx_,
-        leftpad_k_,
-        rotary_cos_,
-        rotary_sin_,
-        seqlens_rotary_,
-        q_descale_,
-        k_descale_,
-        v_descale_,
-        softmax_scale_,
-        sinks_,
-        is_causal,
-        window_size_left,
-        window_size_right,
-        softcap,
-        is_rotary_interleaved,
-        scheduler_metadata_,
-        num_kv_splits,
-        pack_gqa_,
-        sm_margin,
-        std::move(out_opt),
-        return_softmax_lse,
-        std::move(skip_mask));
+  // Forward every shared argument to a sub-kernel, overriding only the per-batch
+  // skip mask. Both launches write into the same caller-provided ``out`` and
+  // ``softmax_lse`` buffers.
+  auto launch = [&](auto&& fn, std::optional<at::Tensor> skip_mask) {
+    fn(q,
+       k,
+       v,
+       q_v_,
+       cu_seqlens_q,
+       cu_seqlens_k,
+       max_seqlen_q,
+       max_seqlen_k,
+       page_table,
+       kv_batch_idx_,
+       leftpad_k_,
+       rotary_cos_,
+       rotary_sin_,
+       seqlens_rotary_,
+       q_descale_,
+       k_descale_,
+       v_descale_,
+       softmax_scale_,
+       sinks_,
+       is_causal,
+       window_size_left,
+       window_size_right,
+       softcap,
+       is_rotary_interleaved,
+       scheduler_metadata_,
+       num_kv_splits,
+       pack_gqa_,
+       sm_margin,
+       out,
+       softmax_lse,
+       std::move(skip_mask));
   };
 
-  // Launch 1: decode allocates the shared output (or reuses the caller-provided
-  // out_ buffer) and skips prefill batches. When return_softmax_lse is set it
-  // also allocates a full (num_heads, total_q) softmax_lse and fills only the
-  // decode rows (otherwise an empty placeholder).
-  auto decode_ret = launch(decode::mha_fwd, std::move(out_), is_prefill);
-  auto out = decode_ret[0];
-  auto lse_decode = decode_ret[1];  // (num_heads, total_q), valid only on decode rows
-  // Launch 2: prefill writes into the same output and skips decode batches. Its
-  // softmax_lse likewise spans all total_q rows but is only valid on prefill rows.
-  auto prefill_ret = launch(prefill::mha_fwd, out, is_prefill.logical_not());
-  auto lse_prefill = prefill_ret[1];  // (num_heads, total_q), valid only on prefill rows
-
-  // Stitch softmax_lse: each sub-launch skipped the other's batches, leaving those
-  // rows uninitialized in its own LSE tensor. Select per query token from the
-  // launch that actually computed it. Columns are query tokens (total_q); a token
-  // belongs to a prefill batch iff its batch has seqlen_q > 1. at::where is a pure
-  // element-wise select, so the uninitialized rows are never read out. This runs
-  // entirely on device (no D2H sync). When return_softmax_lse is false the two
-  // sub-launches allocated empty LSE placeholders (no LSE compute), so skip the
-  // stitch and return an empty placeholder as well.
-  at::Tensor softmax_lse;
-  if (return_softmax_lse) {
-    auto token_is_prefill = is_prefill.repeat_interleave(seqlens_q.to(at::kLong));    // (total_q,)
-    softmax_lse = at::where(token_is_prefill.unsqueeze(0), lse_prefill, lse_decode);  // (num_heads, total_q)
-  } else {
-    softmax_lse = at::empty({0}, q.options().dtype(at::kFloat));
-  }
-
-  // accum tensors are internal to split-KV reduction and unused by the Python
-  // caller; return empty placeholders to keep the ABI stable.
-  auto empty_f = at::empty({0}, q.options().dtype(at::kFloat));
-  return {out, softmax_lse, empty_f, empty_f};
+  // Launch 1: decode writes the decode rows of ``out`` (and, when requested, of
+  // ``softmax_lse``) and skips prefill batches, leaving their rows untouched.
+  launch(decode::mha_fwd, is_prefill);
+  // Launch 2: prefill writes the prefill rows into the same buffers and skips
+  // decode batches. The two complementary skip masks partition every query token
+  // across the launches, so the shared buffers end up fully written with no
+  // stitching or extra copies needed.
+  launch(prefill::mha_fwd, is_prefill.logical_not());
 }
 
 }  // namespace chunkprefill
 
-SGL_KERNEL_EXPORT std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
+SGL_KERNEL_EXPORT void mha_fwd(
     const at::Tensor& q,  // (total_q, h, d) — ragged 3D
     const at::Tensor& k,  // (total_k, h_k, d) if non-paged, or (num_pages, page_size, h_k, d) if paged
     const at::Tensor& v,  // (total_k, h_k, dv) if non-paged, or (num_pages, page_size, h_k, dv) if paged
@@ -1401,69 +1356,79 @@ SGL_KERNEL_EXPORT std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    std::optional<at::Tensor>& out_,
-    bool return_softmax_lse = false) {
+    // Caller-provided output buffers, written in place (no value is returned).
+    // ``softmax_lse`` doubles as the "return LSE" flag: a non-empty tensor
+    // requests the logsumexp be computed and written; an empty (numel == 0)
+    // tensor skips the LSE computation entirely.
+    at::Tensor& out,
+    at::Tensor& softmax_lse) {
   TORCH_CHECK(q.dim() == 3, "query must be in ragged format (total_q, h, d)");
   // k and v may be 3D (total_k, h_k, d) for non-paged or 4D (num_pages, page_size, h_k, d)
   // for paged KV cache; sub-functions validate their own shapes.
-  if (out_.has_value()) {
-    const at::Tensor& out_val = out_.value();
-    TORCH_CHECK(out_val.scalar_type() == q.scalar_type(), "out dtype must match q dtype");
+  TORCH_CHECK(out.scalar_type() == q.scalar_type(), "out dtype must match q dtype");
+  TORCH_CHECK(
+      out.dim() == 3 && out.size(0) == q.size(0) && out.size(1) == q.size(1) && out.size(2) == v.size(-1),
+      "out shape must be [total_q, num_heads, head_size_v]");
+  TORCH_CHECK(out.device() == q.device(), "out must be on the same device as q");
+  TORCH_CHECK(out.stride(-1) == 1, "out must have a contiguous last dimension");
+
+  // Whether to compute the softmax logsumexp is derived from the caller-provided
+  // ``softmax_lse`` buffer: a non-empty tensor requests it. The sub-kernels
+  // derive the same flag and write into the buffer directly.
+  if (softmax_lse.numel() > 0) {
+    TORCH_CHECK(softmax_lse.scalar_type() == at::kFloat, "softmax_lse must be float32");
     TORCH_CHECK(
-        out_val.dim() == 3 && out_val.size(0) == q.size(0) && out_val.size(1) == q.size(1) &&
-            out_val.size(2) == v.size(-1),
-        "out shape must be [total_q, num_heads, head_size_v]");
-    TORCH_CHECK(out_val.device() == q.device(), "out must be on the same device as q");
-    TORCH_CHECK(out_val.stride(-1) == 1, "out must have a contiguous last dimension");
+        softmax_lse.dim() == 2 && softmax_lse.size(0) == q.size(1) && softmax_lse.size(1) == q.size(0),
+        "softmax_lse shape must be [num_heads, total_q]");
+    TORCH_CHECK(softmax_lse.device() == q.device(), "softmax_lse must be on the same device as q");
   }
-  auto to_tuple = [](std::vector<at::Tensor> v) { return std::make_tuple(v[0], v[1], v[2], v[3]); };
-  int const num_heads = q.size(-2);
-  int const num_heads_k = k.size(-2);
+
   int64_t batch_size = cu_seqlens_q.size(0) - 1;
 
   // decode / prefill / chunkprefill all take the same leading argument list;
   // only the trailing parameters differ. Bind the shared arguments once here so
-  // each branch reduces to a single call. ``tail`` carries the callee-specific
-  // suffix: decode and prefill additionally accept a per-batch skip mask (unused
-  // at this top level, so left as std::nullopt); chunkprefill has no such slot.
+  // each branch reduces to a single call. ``out`` and ``softmax_lse`` are
+  // threaded by reference and written in place; ``tail`` carries the
+  // callee-specific suffix: decode and prefill additionally accept a per-batch
+  // skip mask (unused at this top level, so left as std::nullopt); chunkprefill
+  // has no such slot.
   auto dispatch = [&](auto&& fn, auto&&... tail) {
-    return to_tuple(
-        fn(q,
-           k,
-           v,
-           q_v_,
-           cu_seqlens_q,
-           cu_seqlens_k,
-           max_seqlen_q,
-           max_seqlen_k,
-           page_table,
-           kv_batch_idx_,
-           leftpad_k_,
-           rotary_cos_,
-           rotary_sin_,
-           seqlens_rotary_,
-           q_descale_,
-           k_descale_,
-           v_descale_,
-           softmax_scale_,
-           sinks_,
-           is_causal,
-           window_size_left,
-           window_size_right,
-           softcap,
-           is_rotary_interleaved,
-           scheduler_metadata_,
-           num_kv_splits,
-           pack_gqa_,
-           sm_margin,
-           out_,
-           return_softmax_lse,
-           std::forward<decltype(tail)>(tail)...));
+    fn(q,
+       k,
+       v,
+       q_v_,
+       cu_seqlens_q,
+       cu_seqlens_k,
+       max_seqlen_q,
+       max_seqlen_k,
+       page_table,
+       kv_batch_idx_,
+       leftpad_k_,
+       rotary_cos_,
+       rotary_sin_,
+       seqlens_rotary_,
+       q_descale_,
+       k_descale_,
+       v_descale_,
+       softmax_scale_,
+       sinks_,
+       is_causal,
+       window_size_left,
+       window_size_right,
+       softcap,
+       is_rotary_interleaved,
+       scheduler_metadata_,
+       num_kv_splits,
+       pack_gqa_,
+       sm_margin,
+       out,
+       softmax_lse,
+       std::forward<decltype(tail)>(tail)...);
   };
 
   if (max_seqlen_q == 1) {
     // Pure decode path
-    return dispatch(decode::mha_fwd, std::nullopt);
+    dispatch(decode::mha_fwd, std::nullopt);
   } else if (!page_table.has_value() || batch_size == 1) {
     // Pure prefill path
     // Non-paged attn: assumption of all seqlen_q > 1;
@@ -1471,11 +1436,11 @@ SGL_KERNEL_EXPORT std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha
     // is_prefill.all() — a device reduction + D2H sync that costs more than it saves.
     // But batch_size == 1 makes it provable from host scalars:
     // a single sequence with max_seqlen_q > 1 is prefill
-    return dispatch(prefill::mha_fwd, std::nullopt);
+    dispatch(prefill::mha_fwd, std::nullopt);
   } else {
     // Chunk prefill path
     // Paged attn with max_seqlen_q > 1 and batch_size > 1
-    return dispatch(chunkprefill::mha_fwd);
+    dispatch(chunkprefill::mha_fwd);
   }
 }
 #undef SYCL_INTEL_TARGET

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -873,6 +873,7 @@ std::vector<at::Tensor> mha_fwd_nopage(
       TORCH_CHECK(false, "Unsupported head size for non-paged prefill attention: ", params.d);
   }
 
+  // TODO: Support prefill softmax_lse, now is 0
   return {out, softmax_lse, out_accum, softmax_lse_accum};
 }
 
@@ -1210,6 +1211,7 @@ std::vector<at::Tensor> mha_fwd(
       TORCH_CHECK(false, "Unsupported head size for paged prefill attention: ", params.d);
   }
 
+  // TODO: Support prefill softmax_lse, now is 0
   return {out, softmax_lse, out_accum, softmax_lse_accum};
 }
 
@@ -1277,6 +1279,8 @@ std::vector<at::Tensor> mha_fwd(
   TORCH_CHECK(batch_size >= 0, "cu_seqlens_q must have at least 1 element.");
 
   auto seqlens_q = cu_seqlens_q.slice(0, 1, batch_size + 1).sub(cu_seqlens_q.slice(0, 0, batch_size));
+  int total_q = q.size(0);
+  int num_heads = q.size(-2);
   auto is_prefill = seqlens_q.gt(1).contiguous();  // true for prefill batches
 
   // Forward every shared argument to a sub-kernel, overriding only the output
@@ -1323,8 +1327,9 @@ std::vector<at::Tensor> mha_fwd(
 
   // softmax_lse / accum tensors are not stitched here; return empty
   // placeholders to keep the Python ABI stable.
+  at::Tensor softmax_lse = at::empty({num_heads, total_q}, q.options().dtype(at::kFloat));
   auto empty_f = at::empty({0}, q.options().dtype(at::kFloat));
-  return {out, empty_f, empty_f, empty_f};
+  return {out, softmax_lse, empty_f, empty_f};
 }
 
 }  // namespace chunkprefill

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -95,7 +95,7 @@ void mha_fwd_nopage(
     int window_size_right,
     float const softcap,
     at::Tensor& out,
-    at::Tensor& softmax_lse,
+    std::optional<at::Tensor>& softmax_lse,
     std::optional<at::Tensor> skip_batch_mask_opt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -150,9 +150,9 @@ void mha_fwd_nopage(
   TORCH_CHECK(head_size_v % alignment == 0, "head_size_v should be a multiple of " + std::to_string(alignment));
 
   // ``out`` is caller-provided and written in place. Whether to compute the
-  // softmax logsumexp is derived from the caller-provided ``softmax_lse`` buffer
-  // (a non-empty tensor requests it; an empty one skips the LSE computation).
-  bool const return_softmax_lse = softmax_lse.numel() > 0;
+  // softmax logsumexp is derived from the caller-provided ``softmax_lse``
+  // optional (a present tensor requests it; std::nullopt skips it).
+  bool const return_softmax_lse = softmax_lse.has_value();
 
   int const head_size_rounded = round_up_headdim(head_size);
 
@@ -188,7 +188,7 @@ void mha_fwd_nopage(
   params.seqlen_knew = 0;
   params.total_knew = 0;
 
-  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse.data_ptr() : nullptr;
+  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse->data_ptr() : nullptr;
   params.return_softmax_lse = return_softmax_lse;
 
   params.b = batch_size;
@@ -295,11 +295,11 @@ void mha_fwd(
     std::optional<bool> pack_gqa_,
     int const sm_margin,
     // Caller-provided output buffers written in place: ``out`` receives the
-    // attention result and ``softmax_lse`` the logsumexp when non-empty. A
+    // attention result and ``softmax_lse`` the logsumexp when present. A
     // per-batch skip mask (length = batch, chunkprefill two-launch path) selects
     // which batches this launch processes.
     at::Tensor& out,
-    at::Tensor& softmax_lse,
+    std::optional<at::Tensor>& softmax_lse,
     std::optional<at::Tensor> skip_batch_mask_opt = std::nullopt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -415,9 +415,9 @@ void mha_fwd(
   TORCH_CHECK(head_size_v % alignment == 0, "head_size_v should be a multiple of " + std::to_string(alignment));
 
   // ``out`` is caller-provided and written in place. Whether to compute the
-  // softmax logsumexp is derived from the caller-provided ``softmax_lse`` buffer
-  // (a non-empty tensor requests it; an empty one skips the LSE computation).
-  bool const return_softmax_lse = softmax_lse.numel() > 0;
+  // softmax logsumexp is derived from the caller-provided ``softmax_lse``
+  // optional (a present tensor requests it; std::nullopt skips it).
+  bool const return_softmax_lse = softmax_lse.has_value();
   at::Tensor temp_out;    // [batch, num_kv_splits, num_head_q, seq_q, head_size]
   at::Tensor exp_sums;    // [batch, num_head_q, seq_q, num_kv_splits]
   at::Tensor max_logits;  // [batch, num_head_q, seq_q, num_kv_splits]
@@ -521,9 +521,8 @@ void mha_fwd(
   params.cu_seqlens_k = cu_seqlens_k.data_ptr<int>();
   params.num_kv_splits = num_kv_splits;
 
-  // Softmax sum (null when the caller does not request it, matching the empty
-  // placeholder tensor above).
-  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse.data_ptr() : nullptr;
+  // Softmax sum (null when the caller passes std::nullopt).
+  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse->data_ptr() : nullptr;
   params.return_softmax_lse = return_softmax_lse;
 
   // Set the dimensions.
@@ -686,7 +685,7 @@ void mha_fwd_nopage(
     int window_size_right,
     float const softcap,
     at::Tensor& out,
-    at::Tensor& softmax_lse,
+    std::optional<at::Tensor>& softmax_lse,
     std::optional<at::Tensor> skip_batch_mask_opt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -770,7 +769,7 @@ void mha_fwd_nopage(
   params.cu_seqlens_q = cu_seqlens_q.data_ptr<int>();
   params.cu_seqlens_k = cu_seqlens_k.data_ptr<int>();
 
-  params.softmax_lse_ptr = softmax_lse.numel() > 0 ? softmax_lse.data_ptr() : nullptr;
+  params.softmax_lse_ptr = softmax_lse.has_value() ? softmax_lse->data_ptr() : nullptr;
 
   params.b = batch_size;
   params.h = num_heads;
@@ -882,11 +881,11 @@ void mha_fwd(
     std::optional<bool> pack_gqa_,
     int const sm_margin,
     // Caller-provided output buffers written in place: ``out`` receives the
-    // attention result and ``softmax_lse`` the logsumexp when non-empty. A
+    // attention result and ``softmax_lse`` the logsumexp when present. A
     // per-batch skip mask (length = batch, chunkprefill two-launch path) selects
     // which batches this launch processes.
     at::Tensor& out,
-    at::Tensor& softmax_lse,
+    std::optional<at::Tensor>& softmax_lse,
     std::optional<at::Tensor> skip_batch_mask_opt = std::nullopt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -999,9 +998,9 @@ void mha_fwd(
   TORCH_CHECK(head_size_v % alignment == 0, "head_size_v should be a multiple of " + std::to_string(alignment));
 
   // ``out`` is caller-provided and written in place. Whether to compute the
-  // softmax logsumexp is derived from the caller-provided ``softmax_lse`` buffer
-  // (a non-empty tensor requests it; an empty one skips the LSE computation).
-  bool const return_softmax_lse = softmax_lse.numel() > 0;
+  // softmax logsumexp is derived from the caller-provided ``softmax_lse``
+  // optional (a present tensor requests it; std::nullopt skips it).
+  bool const return_softmax_lse = softmax_lse.has_value();
 
   int const head_size_rounded = round_up_headdim(head_size);
   int const head_size_v_rounded = head_size_v == head_size ? head_size_rounded : round_up_headdim(head_size_v);
@@ -1039,9 +1038,8 @@ void mha_fwd(
   params.cu_seqlens_q = cu_seqlens_q.data_ptr<int>();
   params.cu_seqlens_k = cu_seqlens_k.data_ptr<int>();
 
-  // Softmax sum (null when the caller does not request it, matching the empty
-  // placeholder tensor above).
-  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse.data_ptr() : nullptr;
+  // Softmax sum (null when the caller passes std::nullopt).
+  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse->data_ptr() : nullptr;
   params.return_softmax_lse = return_softmax_lse;
 
   // Set the dimensions.
@@ -1235,7 +1233,7 @@ void mha_fwd(
     std::optional<bool> pack_gqa_,
     int const sm_margin,
     at::Tensor& out,
-    at::Tensor& softmax_lse) {
+    std::optional<at::Tensor>& softmax_lse) {
   // Supports both paged (page_table != None) and non-paged (contiguous ragged
   // KV, page_table == None) layouts.
   // ``seqlens_rotary_`` is intentionally not checked here: callers pass it
@@ -1336,11 +1334,11 @@ SGL_KERNEL_EXPORT void mha_fwd(
     std::optional<bool> pack_gqa_,
     int const sm_margin,
     // Caller-provided output buffers, written in place (no value is returned).
-    // ``softmax_lse`` doubles as the "return LSE" flag: a non-empty tensor
-    // requests the logsumexp be computed and written; an empty (numel == 0)
-    // tensor skips the LSE computation entirely.
+    // ``softmax_lse`` doubles as the "return LSE" flag: a present optional
+    // requests the logsumexp be computed and written; std::nullopt skips the
+    // LSE computation entirely.
     at::Tensor& out,
-    at::Tensor& softmax_lse) {
+    std::optional<at::Tensor>& softmax_lse) {
   TORCH_CHECK(q.dim() == 3, "query must be in ragged format (total_q, h, d)");
   // k and v may be 3D (total_k, h_k, d) for non-paged or 4D (num_pages, page_size, h_k, d)
   // for paged KV cache; sub-functions validate their own shapes.
@@ -1352,14 +1350,14 @@ SGL_KERNEL_EXPORT void mha_fwd(
   TORCH_CHECK(out.stride(-1) == 1, "out must have a contiguous last dimension");
 
   // Whether to compute the softmax logsumexp is derived from the caller-provided
-  // ``softmax_lse`` buffer: a non-empty tensor requests it. The sub-kernels
+  // ``softmax_lse`` optional: a present tensor requests it. The sub-kernels
   // derive the same flag and write into the buffer directly.
-  if (softmax_lse.numel() > 0) {
-    TORCH_CHECK(softmax_lse.scalar_type() == at::kFloat, "softmax_lse must be float32");
+  if (softmax_lse.has_value()) {
+    TORCH_CHECK(softmax_lse->scalar_type() == at::kFloat, "softmax_lse must be float32");
     TORCH_CHECK(
-        softmax_lse.dim() == 2 && softmax_lse.size(0) == q.size(1) && softmax_lse.size(1) == q.size(0),
+        softmax_lse->dim() == 2 && softmax_lse->size(0) == q.size(1) && softmax_lse->size(1) == q.size(0),
         "softmax_lse shape must be [num_heads, total_q]");
-    TORCH_CHECK(softmax_lse.device() == q.device(), "softmax_lse must be on the same device as q");
+    TORCH_CHECK(softmax_lse->device() == q.device(), "softmax_lse must be on the same device as q");
   }
 
   int64_t batch_size = cu_seqlens_q.size(0) - 1;

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -1258,8 +1258,6 @@ std::vector<at::Tensor> mha_fwd(
   TORCH_CHECK(batch_size >= 0, "cu_seqlens_q must have at least 1 element.");
 
   auto seqlens_q = cu_seqlens_q.slice(0, 1, batch_size + 1).sub(cu_seqlens_q.slice(0, 0, batch_size));
-  int total_q = q.size(0);
-  int num_heads = q.size(-2);
   auto is_prefill = seqlens_q.gt(1).contiguous();  // true for prefill batches
 
   // Forward every shared argument to a sub-kernel, overriding only the output
@@ -1299,14 +1297,27 @@ std::vector<at::Tensor> mha_fwd(
   };
 
   // Launch 1: decode allocates the shared output (or reuses the caller-provided
-  // out_ buffer) and skips prefill batches.
-  auto out = launch(decode::mha_fwd, std::move(out_), is_prefill)[0];
-  // Launch 2: prefill writes into the same output and skips decode batches.
-  launch(prefill::mha_fwd, out, is_prefill.logical_not());
+  // out_ buffer) and skips prefill batches. It also allocates a full
+  // (num_heads, total_q) softmax_lse and fills only the decode rows.
+  auto decode_ret = launch(decode::mha_fwd, std::move(out_), is_prefill);
+  auto out = decode_ret[0];
+  auto lse_decode = decode_ret[1];  // (num_heads, total_q), valid only on decode rows
+  // Launch 2: prefill writes into the same output and skips decode batches. Its
+  // softmax_lse likewise spans all total_q rows but is only valid on prefill rows.
+  auto prefill_ret = launch(prefill::mha_fwd, out, is_prefill.logical_not());
+  auto lse_prefill = prefill_ret[1];  // (num_heads, total_q), valid only on prefill rows
 
-  // softmax_lse / accum tensors are not stitched here; return empty
-  // placeholders to keep the Python ABI stable.
-  at::Tensor softmax_lse = at::empty({num_heads, total_q}, q.options().dtype(at::kFloat));
+  // Stitch softmax_lse: each sub-launch skipped the other's batches, leaving those
+  // rows uninitialized in its own LSE tensor. Select per query token from the
+  // launch that actually computed it. Columns are query tokens (total_q); a token
+  // belongs to a prefill batch iff its batch has seqlen_q > 1. at::where is a pure
+  // element-wise select, so the uninitialized rows are never read out. This runs
+  // entirely on device (no D2H sync).
+  auto token_is_prefill = is_prefill.repeat_interleave(seqlens_q.to(at::kLong));         // (total_q,)
+  auto softmax_lse = at::where(token_is_prefill.unsqueeze(0), lse_prefill, lse_decode);  // (num_heads, total_q)
+
+  // accum tensors are internal to split-KV reduction and unused by the Python
+  // caller; return empty placeholders to keep the ABI stable.
   auto empty_f = at::empty({0}, q.options().dtype(at::kFloat));
   return {out, softmax_lse, empty_f, empty_f};
 }

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -853,6 +853,7 @@ std::vector<at::Tensor> mha_fwd_nopage(
       TORCH_CHECK(false, "Unsupported head size for non-paged prefill attention: ", params.d);
   }
 
+  // TODO: Support prefill softmax_lse, now is 0
   return {out, softmax_lse, out_accum, softmax_lse_accum};
 }
 
@@ -1189,6 +1190,7 @@ std::vector<at::Tensor> mha_fwd(
       TORCH_CHECK(false, "Unsupported head size for paged prefill attention: ", params.d);
   }
 
+  // TODO: Support prefill softmax_lse, now is 0
   return {out, softmax_lse, out_accum, softmax_lse_accum};
 }
 
@@ -1256,6 +1258,8 @@ std::vector<at::Tensor> mha_fwd(
   TORCH_CHECK(batch_size >= 0, "cu_seqlens_q must have at least 1 element.");
 
   auto seqlens_q = cu_seqlens_q.slice(0, 1, batch_size + 1).sub(cu_seqlens_q.slice(0, 0, batch_size));
+  int total_q = q.size(0);
+  int num_heads = q.size(-2);
   auto is_prefill = seqlens_q.gt(1).contiguous();  // true for prefill batches
 
   // Forward every shared argument to a sub-kernel, overriding only the output
@@ -1302,8 +1306,9 @@ std::vector<at::Tensor> mha_fwd(
 
   // softmax_lse / accum tensors are not stitched here; return empty
   // placeholders to keep the Python ABI stable.
+  at::Tensor softmax_lse = at::empty({num_heads, total_q}, q.options().dtype(at::kFloat));
   auto empty_f = at::empty({0}, q.options().dtype(at::kFloat));
-  return {out, empty_f, empty_f, empty_f};
+  return {out, softmax_lse, empty_f, empty_f};
 }
 
 }  // namespace chunkprefill

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -94,6 +94,7 @@ std::vector<at::Tensor> mha_fwd_nopage(
     int window_size_left,
     int window_size_right,
     float const softcap,
+    bool return_softmax_lse,
     std::optional<at::Tensor> out_opt,
     std::optional<at::Tensor> skip_batch_mask_opt) {
   auto q_type = q.scalar_type();
@@ -192,6 +193,7 @@ std::vector<at::Tensor> mha_fwd_nopage(
   params.total_knew = 0;
 
   params.softmax_lse_ptr = softmax_lse.data_ptr();
+  params.return_softmax_lse = return_softmax_lse;
 
   params.b = batch_size;
   params.h = num_heads;
@@ -304,6 +306,7 @@ std::vector<at::Tensor> mha_fwd(
     // chunkprefill two-launch path: pre-allocated shared output, and a per-batch
     // bool mask (length = batch) whose true entries are skipped by the kernel.
     std::optional<at::Tensor> out_opt = std::nullopt,
+    bool return_softmax_lse = false,
     std::optional<at::Tensor> skip_batch_mask_opt = std::nullopt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -349,6 +352,7 @@ std::vector<at::Tensor> mha_fwd(
         window_size_left,
         window_size_right,
         softcap,
+        return_softmax_lse,
         std::move(out_opt),
         std::move(skip_batch_mask_opt));
   }
@@ -490,8 +494,12 @@ std::vector<at::Tensor> mha_fwd(
   // Cast to char to avoid compiler warning about narrowing
   c10::DeviceGuard device_guard(q.device());
 
+  // Only allocate the (num_heads, total_q) LSE tensor when the caller asked for
+  // it; otherwise a zero-element placeholder keeps the return ABI stable while
+  // the kernel (LSE=false) skips every LSE write.
   at::Tensor softmax_lse;
-  softmax_lse = torch::empty({num_heads, total_q}, opts.dtype(at::kFloat));
+  softmax_lse = return_softmax_lse ? torch::empty({num_heads, total_q}, opts.dtype(at::kFloat))
+                                   : torch::empty({0}, opts.dtype(at::kFloat));
 
   // align with FA3
 
@@ -532,8 +540,10 @@ std::vector<at::Tensor> mha_fwd(
   params.cu_seqlens_k = cu_seqlens_k.data_ptr<int>();
   params.num_kv_splits = num_kv_splits;
 
-  // Softmax sum
-  params.softmax_lse_ptr = softmax_lse.data_ptr();
+  // Softmax sum (null when the caller does not request it, matching the empty
+  // placeholder tensor above).
+  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse.data_ptr() : nullptr;
+  params.return_softmax_lse = return_softmax_lse;
 
   // Set the dimensions.
   params.b = batch_size;
@@ -911,6 +921,7 @@ std::vector<at::Tensor> mha_fwd(
     // chunkprefill two-launch path: pre-allocated shared output, and a per-batch
     // bool mask (length = batch) whose true entries are skipped by the kernel.
     std::optional<at::Tensor> out_opt = std::nullopt,
+    bool return_softmax_lse = false,
     std::optional<at::Tensor> skip_batch_mask_opt = std::nullopt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -1031,8 +1042,12 @@ std::vector<at::Tensor> mha_fwd(
   // Cast to char to avoid compiler warning about narrowing
   c10::DeviceGuard device_guard(q.device());
 
+  // Only allocate the (num_heads, total_q) LSE tensor when the caller asked for
+  // it; otherwise a zero-element placeholder keeps the return ABI stable while
+  // the kernel (LSE=false) skips every LSE write.
   at::Tensor softmax_lse;
-  softmax_lse = torch::empty({num_heads, total_q}, opts.dtype(at::kFloat));
+  softmax_lse = return_softmax_lse ? torch::empty({num_heads, total_q}, opts.dtype(at::kFloat))
+                                   : torch::empty({0}, opts.dtype(at::kFloat));
 
   // align with FA3
   Arguments params;
@@ -1061,8 +1076,10 @@ std::vector<at::Tensor> mha_fwd(
   params.cu_seqlens_q = cu_seqlens_q.data_ptr<int>();
   params.cu_seqlens_k = cu_seqlens_k.data_ptr<int>();
 
-  // Softmax sum
-  params.softmax_lse_ptr = softmax_lse.data_ptr();
+  // Softmax sum (null when the caller does not request it, matching the empty
+  // placeholder tensor above).
+  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse.data_ptr() : nullptr;
+  params.return_softmax_lse = return_softmax_lse;
 
   // Set the dimensions.
   params.b = batch_size;
@@ -1257,7 +1274,8 @@ std::vector<at::Tensor> mha_fwd(
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    std::optional<at::Tensor> out_ = std::nullopt) {
+    std::optional<at::Tensor> out_ = std::nullopt,
+    bool return_softmax_lse = false) {
   // Supports both paged (page_table != None) and non-paged (contiguous ragged
   // KV, page_table == None) layouts.
   // ``seqlens_rotary_`` is intentionally not checked here: callers pass it
@@ -1314,12 +1332,14 @@ std::vector<at::Tensor> mha_fwd(
         pack_gqa_,
         sm_margin,
         std::move(out_opt),
+        return_softmax_lse,
         std::move(skip_mask));
   };
 
   // Launch 1: decode allocates the shared output (or reuses the caller-provided
-  // out_ buffer) and skips prefill batches. It also allocates a full
-  // (num_heads, total_q) softmax_lse and fills only the decode rows.
+  // out_ buffer) and skips prefill batches. When return_softmax_lse is set it
+  // also allocates a full (num_heads, total_q) softmax_lse and fills only the
+  // decode rows (otherwise an empty placeholder).
   auto decode_ret = launch(decode::mha_fwd, std::move(out_), is_prefill);
   auto out = decode_ret[0];
   auto lse_decode = decode_ret[1];  // (num_heads, total_q), valid only on decode rows
@@ -1333,9 +1353,16 @@ std::vector<at::Tensor> mha_fwd(
   // launch that actually computed it. Columns are query tokens (total_q); a token
   // belongs to a prefill batch iff its batch has seqlen_q > 1. at::where is a pure
   // element-wise select, so the uninitialized rows are never read out. This runs
-  // entirely on device (no D2H sync).
-  auto token_is_prefill = is_prefill.repeat_interleave(seqlens_q.to(at::kLong));         // (total_q,)
-  auto softmax_lse = at::where(token_is_prefill.unsqueeze(0), lse_prefill, lse_decode);  // (num_heads, total_q)
+  // entirely on device (no D2H sync). When return_softmax_lse is false the two
+  // sub-launches allocated empty LSE placeholders (no LSE compute), so skip the
+  // stitch and return an empty placeholder as well.
+  at::Tensor softmax_lse;
+  if (return_softmax_lse) {
+    auto token_is_prefill = is_prefill.repeat_interleave(seqlens_q.to(at::kLong));    // (total_q,)
+    softmax_lse = at::where(token_is_prefill.unsqueeze(0), lse_prefill, lse_decode);  // (num_heads, total_q)
+  } else {
+    softmax_lse = at::empty({0}, q.options().dtype(at::kFloat));
+  }
 
   // accum tensors are internal to split-KV reduction and unused by the Python
   // caller; return empty placeholders to keep the ABI stable.
@@ -1374,7 +1401,8 @@ SGL_KERNEL_EXPORT std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    std::optional<at::Tensor>& out_) {
+    std::optional<at::Tensor>& out_,
+    bool return_softmax_lse = false) {
   TORCH_CHECK(q.dim() == 3, "query must be in ragged format (total_q, h, d)");
   // k and v may be 3D (total_k, h_k, d) for non-paged or 4D (num_pages, page_size, h_k, d)
   // for paged KV cache; sub-functions validate their own shapes.
@@ -1429,6 +1457,7 @@ SGL_KERNEL_EXPORT std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha
            pack_gqa_,
            sm_margin,
            out_,
+           return_softmax_lse,
            std::forward<decltype(tail)>(tail)...));
   };
 

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -80,7 +80,7 @@ namespace decode {
 // chunkprefill dispatcher run on the decode-optimized kernel. The non-paged
 // decode kernel carries its own tile configuration (FMHA_DECODE_TILED_KV_NP_*)
 // so it can be tuned independently of both the paged decode and prefill paths.
-std::vector<at::Tensor> mha_fwd_nopage(
+void mha_fwd_nopage(
     const at::Tensor& q,             // (total_q, h, d)
     const at::Tensor& k,             // (total_k, h_k, d)
     const at::Tensor& v,             // (total_k, h_k, dv)
@@ -94,8 +94,8 @@ std::vector<at::Tensor> mha_fwd_nopage(
     int window_size_left,
     int window_size_right,
     float const softcap,
-    bool return_softmax_lse,
-    std::optional<at::Tensor> out_opt,
+    at::Tensor& out,
+    at::Tensor& softmax_lse,
     std::optional<at::Tensor> skip_batch_mask_opt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -149,17 +149,14 @@ std::vector<at::Tensor> mha_fwd_nopage(
   TORCH_CHECK(head_size % alignment == 0, "head_size should be a multiple of " + std::to_string(alignment));
   TORCH_CHECK(head_size_v % alignment == 0, "head_size_v should be a multiple of " + std::to_string(alignment));
 
-  auto opts = q.options();
-  // Use the caller-provided shared output when present (two-launch path); the
-  // first launch zero-initializes so that rows of batches with zero KV length
-  // (never written by the kernel) read back their correct value of 0.
-  at::Tensor out = out_opt.has_value() ? *out_opt : torch::zeros({total_q, num_heads, head_size_v}, opts);
+  // ``out`` is caller-provided and written in place. Whether to compute the
+  // softmax logsumexp is derived from the caller-provided ``softmax_lse`` buffer
+  // (a non-empty tensor requests it; an empty one skips the LSE computation).
+  bool const return_softmax_lse = softmax_lse.numel() > 0;
 
   int const head_size_rounded = round_up_headdim(head_size);
 
   c10::DeviceGuard device_guard(q.device());
-
-  at::Tensor softmax_lse = torch::empty({num_heads, total_q}, opts.dtype(at::kFloat));
 
   Arguments params;
   params.is_bf16 = q.dtype() == torch::kBFloat16;
@@ -191,7 +188,7 @@ std::vector<at::Tensor> mha_fwd_nopage(
   params.seqlen_knew = 0;
   params.total_knew = 0;
 
-  params.softmax_lse_ptr = softmax_lse.data_ptr();
+  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse.data_ptr() : nullptr;
   params.return_softmax_lse = return_softmax_lse;
 
   params.b = batch_size;
@@ -254,8 +251,6 @@ std::vector<at::Tensor> mha_fwd_nopage(
 
   params.tensor_opts = torch::TensorOptions().dtype(torch::kUInt8).device(q.device());
 
-  at::Tensor out_accum, softmax_lse_accum;
-
   int qg_sz = nextPowerOf2(params.q_group_size);
   TORCH_CHECK(qg_sz >= 1 && qg_sz <= 16, "Unsupported q_group_size for decode attention: ", params.q_group_size);
   // Non-paged decode supports its own (independent) set of head dims; see
@@ -266,11 +261,9 @@ std::vector<at::Tensor> mha_fwd_nopage(
       params.d);
 
   DISPATCH_DECODE_NOPAGE(qg_sz);
-
-  return {out, softmax_lse, out_accum, softmax_lse_accum};
 }
 
-std::vector<at::Tensor> mha_fwd(
+void mha_fwd(
     const at::Tensor& q,  // (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_q
     const at::Tensor& k,  // (b_k, s_k, h_k, d) or (total_k, h_k, d) if there is cu_seqlens_k or (num_pages, page_size,
                           // h_k, d) if there is page_table.
@@ -301,10 +294,12 @@ std::vector<at::Tensor> mha_fwd(
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    // chunkprefill two-launch path: pre-allocated shared output, and a per-batch
-    // bool mask (length = batch) whose true entries are skipped by the kernel.
-    std::optional<at::Tensor> out_opt = std::nullopt,
-    bool return_softmax_lse = false,
+    // Caller-provided output buffers written in place: ``out`` receives the
+    // attention result and ``softmax_lse`` the logsumexp when non-empty. A
+    // per-batch skip mask (length = batch, chunkprefill two-launch path) selects
+    // which batches this launch processes.
+    at::Tensor& out,
+    at::Tensor& softmax_lse,
     std::optional<at::Tensor> skip_batch_mask_opt = std::nullopt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -336,7 +331,7 @@ std::vector<at::Tensor> mha_fwd(
   // the decode-specific non-paged entry (decode::mha_fwd_nopage) so it can carry
   // its own parameter configuration independently of the prefill path.
   if (!page_table.has_value()) {
-    return mha_fwd_nopage(
+    mha_fwd_nopage(
         q,
         k,
         v,
@@ -350,9 +345,10 @@ std::vector<at::Tensor> mha_fwd(
         window_size_left,
         window_size_right,
         softcap,
-        return_softmax_lse,
-        std::move(out_opt),
+        out,
+        softmax_lse,
         std::move(skip_batch_mask_opt));
+    return;
   }
 
   TORCH_CHECK(page_table.value().dtype() == torch::kInt32, "page_table must have dtype torch.int32");
@@ -418,12 +414,13 @@ std::vector<at::Tensor> mha_fwd(
   TORCH_CHECK(head_size % alignment == 0, "head_size should be a multiple of " + std::to_string(alignment));
   TORCH_CHECK(head_size_v % alignment == 0, "head_size_v should be a multiple of " + std::to_string(alignment));
 
-  auto opts = q.options();
-  at::Tensor out;
+  // ``out`` is caller-provided and written in place. Whether to compute the
+  // softmax logsumexp is derived from the caller-provided ``softmax_lse`` buffer
+  // (a non-empty tensor requests it; an empty one skips the LSE computation).
+  bool const return_softmax_lse = softmax_lse.numel() > 0;
   at::Tensor temp_out;    // [batch, num_kv_splits, num_head_q, seq_q, head_size]
   at::Tensor exp_sums;    // [batch, num_head_q, seq_q, num_kv_splits]
   at::Tensor max_logits;  // [batch, num_head_q, seq_q, num_kv_splits]
-  out = out_opt.has_value() ? *out_opt : torch::empty({total_q, num_heads, head_size_v}, opts);
   Arguments params;
   // num_kv_splits semantics (host-side scalar, no D2H sync):
   //   -1 or 1 -> split-KV disabled, use the non-split FmhaDecodeRunner
@@ -483,12 +480,8 @@ std::vector<at::Tensor> mha_fwd(
   // Cast to char to avoid compiler warning about narrowing
   c10::DeviceGuard device_guard(q.device());
 
-  // Only allocate the (num_heads, total_q) LSE tensor when the caller asked for
-  // it; otherwise a zero-element placeholder keeps the return ABI stable while
-  // the kernel (LSE=false) skips every LSE write.
-  at::Tensor softmax_lse;
-  softmax_lse = return_softmax_lse ? torch::empty({num_heads, total_q}, opts.dtype(at::kFloat))
-                                   : torch::empty({0}, opts.dtype(at::kFloat));
+  // ``softmax_lse`` is caller-provided; empty (numel == 0) when the LSE was not
+  // requested, in which case the kernel skips every LSE write.
 
   // align with FA3
 
@@ -653,8 +646,6 @@ std::vector<at::Tensor> mha_fwd(
 
   params.tensor_opts = torch::TensorOptions().dtype(torch::kUInt8).device(q.device());
 
-  at::Tensor out_accum, softmax_lse_accum;
-
   int qg_sz = nextPowerOf2(params.q_group_size);
   TORCH_CHECK(qg_sz >= 1 && qg_sz <= 16, "Unsupported q_group_size for decode attention: ", params.q_group_size);
   // Paged decode supports its own (independent) set of head dims; see
@@ -669,8 +660,6 @@ std::vector<at::Tensor> mha_fwd(
       params.page_size);
 
   DISPATCH_DECODE(qg_sz);
-
-  return {out, softmax_lse, out_accum, softmax_lse_accum};
 }
 
 }  // namespace decode
@@ -679,9 +668,10 @@ namespace prefill {
 
 // Non-paged (contiguous ragged KV) prefill entry. Drives both the prefill and
 // the decode sub-launches of the no-page chunkprefill two-launch path: the
-// caller passes a shared output (out_opt) and a per-batch skip mask
-// (skip_batch_mask_opt) selecting which batches this launch processes.
-std::vector<at::Tensor> mha_fwd_nopage(
+// caller passes shared ``out`` / ``softmax_lse`` buffers (written in place) and
+// a per-batch skip mask (skip_batch_mask_opt) selecting which batches this
+// launch processes.
+void mha_fwd_nopage(
     const at::Tensor& q,             // (total_q, h, d)
     const at::Tensor& k,             // (total_k, h_k, d)
     const at::Tensor& v,             // (total_k, h_k, dv)
@@ -695,7 +685,8 @@ std::vector<at::Tensor> mha_fwd_nopage(
     int window_size_left,
     int window_size_right,
     float const softcap,
-    std::optional<at::Tensor> out_opt,
+    at::Tensor& out,
+    at::Tensor& softmax_lse,
     std::optional<at::Tensor> skip_batch_mask_opt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -749,17 +740,12 @@ std::vector<at::Tensor> mha_fwd_nopage(
   TORCH_CHECK(head_size % alignment == 0, "head_size should be a multiple of " + std::to_string(alignment));
   TORCH_CHECK(head_size_v % alignment == 0, "head_size_v should be a multiple of " + std::to_string(alignment));
 
-  auto opts = q.options();
-  // Use the caller-provided shared output when present (two-launch path); the
-  // first launch zero-initializes so that rows of batches with zero KV length
-  // (never written by the kernel) read back their correct value of 0.
-  at::Tensor out = out_opt.has_value() ? *out_opt : torch::zeros({total_q, num_heads, head_size_v}, opts);
+  // ``out`` is caller-provided and written in place. Non-paged prefill does not
+  // currently compute the softmax logsumexp (``softmax_lse`` is left untouched).
 
   int const head_size_rounded = round_up_headdim(head_size);
 
   c10::DeviceGuard device_guard(q.device());
-
-  at::Tensor softmax_lse = torch::empty({num_heads, total_q}, opts.dtype(at::kFloat));
 
   Arguments params;
   params.is_bf16 = q.dtype() == torch::kBFloat16;
@@ -784,7 +770,7 @@ std::vector<at::Tensor> mha_fwd_nopage(
   params.cu_seqlens_q = cu_seqlens_q.data_ptr<int>();
   params.cu_seqlens_k = cu_seqlens_k.data_ptr<int>();
 
-  params.softmax_lse_ptr = softmax_lse.data_ptr();
+  params.softmax_lse_ptr = softmax_lse.numel() > 0 ? softmax_lse.data_ptr() : nullptr;
 
   params.b = batch_size;
   params.h = num_heads;
@@ -831,8 +817,6 @@ std::vector<at::Tensor> mha_fwd_nopage(
 
   params.tensor_opts = torch::TensorOptions().dtype(torch::kUInt8).device(q.device());
 
-  at::Tensor out_accum, softmax_lse_accum;
-
   // Non-paged prefill supports its own (independent) set of head dims; see
   // FMHA_PREFILL_NP_HEAD_DIMS in FMHAPrefillXe20.cmake.
   TORCH_CHECK(
@@ -864,10 +848,9 @@ std::vector<at::Tensor> mha_fwd_nopage(
   }
 
   // TODO: Support prefill softmax_lse, now is 0
-  return {out, softmax_lse, out_accum, softmax_lse_accum};
 }
 
-std::vector<at::Tensor> mha_fwd(
+void mha_fwd(
     const at::Tensor& q,  // (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_q
     const at::Tensor& k,  // (b_k, s_k, h_k, d) or (total_k, h_k, d) if there is cu_seqlens_k or (num_pages, page_size,
                           // h_k, d) if there is page_table.
@@ -898,10 +881,12 @@ std::vector<at::Tensor> mha_fwd(
     int num_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    // chunkprefill two-launch path: pre-allocated shared output, and a per-batch
-    // bool mask (length = batch) whose true entries are skipped by the kernel.
-    std::optional<at::Tensor> out_opt = std::nullopt,
-    bool return_softmax_lse = false,
+    // Caller-provided output buffers written in place: ``out`` receives the
+    // attention result and ``softmax_lse`` the logsumexp when non-empty. A
+    // per-batch skip mask (length = batch, chunkprefill two-launch path) selects
+    // which batches this launch processes.
+    at::Tensor& out,
+    at::Tensor& softmax_lse,
     std::optional<at::Tensor> skip_batch_mask_opt = std::nullopt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -930,7 +915,7 @@ std::vector<at::Tensor> mha_fwd(
 
   // Non-paged (page_table == nullopt) prefill: contiguous ragged KV cache.
   if (!page_table.has_value()) {
-    return mha_fwd_nopage(
+    mha_fwd_nopage(
         q,
         k,
         v,
@@ -944,8 +929,10 @@ std::vector<at::Tensor> mha_fwd(
         window_size_left,
         window_size_right,
         softcap,
-        std::move(out_opt),
+        out,
+        softmax_lse,
         std::move(skip_batch_mask_opt));
+    return;
   }
 
   TORCH_CHECK(page_table.value().dtype() == torch::kInt32, "page_table must have dtype torch.int32");
@@ -1011,9 +998,10 @@ std::vector<at::Tensor> mha_fwd(
   TORCH_CHECK(head_size % alignment == 0, "head_size should be a multiple of " + std::to_string(alignment));
   TORCH_CHECK(head_size_v % alignment == 0, "head_size_v should be a multiple of " + std::to_string(alignment));
 
-  auto opts = q.options();
-  at::Tensor out;
-  out = out_opt.has_value() ? *out_opt : torch::empty({total_q, num_heads, head_size_v}, opts);
+  // ``out`` is caller-provided and written in place. Whether to compute the
+  // softmax logsumexp is derived from the caller-provided ``softmax_lse`` buffer
+  // (a non-empty tensor requests it; an empty one skips the LSE computation).
+  bool const return_softmax_lse = softmax_lse.numel() > 0;
 
   int const head_size_rounded = round_up_headdim(head_size);
   int const head_size_v_rounded = head_size_v == head_size ? head_size_rounded : round_up_headdim(head_size_v);
@@ -1022,12 +1010,8 @@ std::vector<at::Tensor> mha_fwd(
   // Cast to char to avoid compiler warning about narrowing
   c10::DeviceGuard device_guard(q.device());
 
-  // Only allocate the (num_heads, total_q) LSE tensor when the caller asked for
-  // it; otherwise a zero-element placeholder keeps the return ABI stable while
-  // the kernel (LSE=false) skips every LSE write.
-  at::Tensor softmax_lse;
-  softmax_lse = return_softmax_lse ? torch::empty({num_heads, total_q}, opts.dtype(at::kFloat))
-                                   : torch::empty({0}, opts.dtype(at::kFloat));
+  // ``softmax_lse`` is caller-provided; empty (numel == 0) when the LSE was not
+  // requested, in which case the kernel skips every LSE write.
 
   // align with FA3
   Arguments params;
@@ -1175,8 +1159,6 @@ std::vector<at::Tensor> mha_fwd(
 
   params.tensor_opts = torch::TensorOptions().dtype(torch::kUInt8).device(q.device());
 
-  at::Tensor out_accum, softmax_lse_accum;
-
   // Paged prefill supports its own (independent) set of head dims; see
   // FMHA_PREFILL_PAGED_HEAD_DIMS in FMHAPrefillXe20.cmake.
   TORCH_CHECK(
@@ -1208,7 +1190,6 @@ std::vector<at::Tensor> mha_fwd(
   }
 
   // TODO: Support prefill softmax_lse, now is 0
-  return {out, softmax_lse, out_accum, softmax_lse_accum};
 }
 
 }  // namespace prefill
@@ -1224,7 +1205,7 @@ namespace chunkprefill {
 // Limitations: paged KV cache required; rotary / q_v / descale / scheduler
 // metadata are not supported on this path. Sliding window and attention sinks
 // are forwarded to both sub-kernels, which support them.
-std::vector<at::Tensor> mha_fwd(
+void mha_fwd(
     const at::Tensor& q,
     const at::Tensor& k,
     const at::Tensor& v,
@@ -1253,8 +1234,8 @@ std::vector<at::Tensor> mha_fwd(
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    std::optional<at::Tensor> out_ = std::nullopt,
-    bool return_softmax_lse = false) {
+    at::Tensor& out,
+    at::Tensor& softmax_lse) {
   // Supports both paged (page_table != None) and non-paged (contiguous ragged
   // KV, page_table == None) layouts.
   // ``seqlens_rotary_`` is intentionally not checked here: callers pass it
@@ -1265,12 +1246,10 @@ std::vector<at::Tensor> mha_fwd(
           !scheduler_metadata_.has_value(),
       "chunkprefill two-launch path does not yet support q_v / rotary / q_descale / scheduler_metadata.");
   TORCH_CHECK(cu_seqlens_q.scalar_type() == at::kInt, "cu_seqlens_q must be int32.");
-  // Pre-allocated out requires paged KV: on the non-paged path zero-KV-length
-  // rows are never written by the kernel, so a caller buffer would retain stale
-  // values on graph replay. SGLang always provides page_table (paged KV cache),
-  // so this check should never fire in practice.
-  TORCH_CHECK(
-      !out_.has_value() || page_table.has_value(), "chunkprefill: out buffer requires page_table (paged KV cache).");
+  // chunkprefill is only reached for paged KV (the public dispatcher routes the
+  // non-paged and single-batch cases to the pure prefill path), so the
+  // caller-provided ``out`` buffer is always backed by a page table.
+  TORCH_CHECK(page_table.has_value(), "chunkprefill: requires page_table (paged KV cache).");
 
   int64_t batch_size = cu_seqlens_q.size(0) - 1;
   TORCH_CHECK(batch_size >= 0, "cu_seqlens_q must have at least 1 element.");
@@ -1278,80 +1257,56 @@ std::vector<at::Tensor> mha_fwd(
   auto seqlens_q = cu_seqlens_q.slice(0, 1, batch_size + 1).sub(cu_seqlens_q.slice(0, 0, batch_size));
   auto is_prefill = seqlens_q.gt(1).contiguous();  // true for prefill batches
 
-  // Forward every shared argument to a sub-kernel, overriding only the output
-  // tensor (out_opt) and the per-batch skip mask.
-  auto launch = [&](auto&& fn, std::optional<at::Tensor> out_opt, std::optional<at::Tensor> skip_mask) {
-    return fn(
-        q,
-        k,
-        v,
-        q_v_,
-        cu_seqlens_q,
-        cu_seqlens_k,
-        max_seqlen_q,
-        max_seqlen_k,
-        page_table,
-        kv_batch_idx_,
-        leftpad_k_,
-        rotary_cos_,
-        rotary_sin_,
-        seqlens_rotary_,
-        q_descale_,
-        k_descale_,
-        v_descale_,
-        softmax_scale_,
-        sinks_,
-        is_causal,
-        window_size_left,
-        window_size_right,
-        softcap,
-        is_rotary_interleaved,
-        scheduler_metadata_,
-        num_kv_splits,
-        pack_gqa_,
-        sm_margin,
-        std::move(out_opt),
-        return_softmax_lse,
-        std::move(skip_mask));
+  // Forward every shared argument to a sub-kernel, overriding only the per-batch
+  // skip mask. Both launches write into the same caller-provided ``out`` and
+  // ``softmax_lse`` buffers.
+  auto launch = [&](auto&& fn, std::optional<at::Tensor> skip_mask) {
+    fn(q,
+       k,
+       v,
+       q_v_,
+       cu_seqlens_q,
+       cu_seqlens_k,
+       max_seqlen_q,
+       max_seqlen_k,
+       page_table,
+       kv_batch_idx_,
+       leftpad_k_,
+       rotary_cos_,
+       rotary_sin_,
+       seqlens_rotary_,
+       q_descale_,
+       k_descale_,
+       v_descale_,
+       softmax_scale_,
+       sinks_,
+       is_causal,
+       window_size_left,
+       window_size_right,
+       softcap,
+       is_rotary_interleaved,
+       scheduler_metadata_,
+       num_kv_splits,
+       pack_gqa_,
+       sm_margin,
+       out,
+       softmax_lse,
+       std::move(skip_mask));
   };
 
-  // Launch 1: decode allocates the shared output (or reuses the caller-provided
-  // out_ buffer) and skips prefill batches. When return_softmax_lse is set it
-  // also allocates a full (num_heads, total_q) softmax_lse and fills only the
-  // decode rows (otherwise an empty placeholder).
-  auto decode_ret = launch(decode::mha_fwd, std::move(out_), is_prefill);
-  auto out = decode_ret[0];
-  auto lse_decode = decode_ret[1];  // (num_heads, total_q), valid only on decode rows
-  // Launch 2: prefill writes into the same output and skips decode batches. Its
-  // softmax_lse likewise spans all total_q rows but is only valid on prefill rows.
-  auto prefill_ret = launch(prefill::mha_fwd, out, is_prefill.logical_not());
-  auto lse_prefill = prefill_ret[1];  // (num_heads, total_q), valid only on prefill rows
-
-  // Stitch softmax_lse: each sub-launch skipped the other's batches, leaving those
-  // rows uninitialized in its own LSE tensor. Select per query token from the
-  // launch that actually computed it. Columns are query tokens (total_q); a token
-  // belongs to a prefill batch iff its batch has seqlen_q > 1. at::where is a pure
-  // element-wise select, so the uninitialized rows are never read out. This runs
-  // entirely on device (no D2H sync). When return_softmax_lse is false the two
-  // sub-launches allocated empty LSE placeholders (no LSE compute), so skip the
-  // stitch and return an empty placeholder as well.
-  at::Tensor softmax_lse;
-  if (return_softmax_lse) {
-    auto token_is_prefill = is_prefill.repeat_interleave(seqlens_q.to(at::kLong));    // (total_q,)
-    softmax_lse = at::where(token_is_prefill.unsqueeze(0), lse_prefill, lse_decode);  // (num_heads, total_q)
-  } else {
-    softmax_lse = at::empty({0}, q.options().dtype(at::kFloat));
-  }
-
-  // accum tensors are internal to split-KV reduction and unused by the Python
-  // caller; return empty placeholders to keep the ABI stable.
-  auto empty_f = at::empty({0}, q.options().dtype(at::kFloat));
-  return {out, softmax_lse, empty_f, empty_f};
+  // Launch 1: decode writes the decode rows of ``out`` (and, when requested, of
+  // ``softmax_lse``) and skips prefill batches, leaving their rows untouched.
+  launch(decode::mha_fwd, is_prefill);
+  // Launch 2: prefill writes the prefill rows into the same buffers and skips
+  // decode batches. The two complementary skip masks partition every query token
+  // across the launches, so the shared buffers end up fully written with no
+  // stitching or extra copies needed.
+  launch(prefill::mha_fwd, is_prefill.logical_not());
 }
 
 }  // namespace chunkprefill
 
-SGL_KERNEL_EXPORT std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
+SGL_KERNEL_EXPORT void mha_fwd(
     const at::Tensor& q,  // (total_q, h, d) — ragged 3D
     const at::Tensor& k,  // (total_k, h_k, d) if non-paged, or (num_pages, page_size, h_k, d) if paged
     const at::Tensor& v,  // (total_k, h_k, dv) if non-paged, or (num_pages, page_size, h_k, dv) if paged
@@ -1380,69 +1335,79 @@ SGL_KERNEL_EXPORT std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha
     int num_kv_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin,
-    std::optional<at::Tensor>& out_,
-    bool return_softmax_lse = false) {
+    // Caller-provided output buffers, written in place (no value is returned).
+    // ``softmax_lse`` doubles as the "return LSE" flag: a non-empty tensor
+    // requests the logsumexp be computed and written; an empty (numel == 0)
+    // tensor skips the LSE computation entirely.
+    at::Tensor& out,
+    at::Tensor& softmax_lse) {
   TORCH_CHECK(q.dim() == 3, "query must be in ragged format (total_q, h, d)");
   // k and v may be 3D (total_k, h_k, d) for non-paged or 4D (num_pages, page_size, h_k, d)
   // for paged KV cache; sub-functions validate their own shapes.
-  if (out_.has_value()) {
-    const at::Tensor& out_val = out_.value();
-    TORCH_CHECK(out_val.scalar_type() == q.scalar_type(), "out dtype must match q dtype");
+  TORCH_CHECK(out.scalar_type() == q.scalar_type(), "out dtype must match q dtype");
+  TORCH_CHECK(
+      out.dim() == 3 && out.size(0) == q.size(0) && out.size(1) == q.size(1) && out.size(2) == v.size(-1),
+      "out shape must be [total_q, num_heads, head_size_v]");
+  TORCH_CHECK(out.device() == q.device(), "out must be on the same device as q");
+  TORCH_CHECK(out.stride(-1) == 1, "out must have a contiguous last dimension");
+
+  // Whether to compute the softmax logsumexp is derived from the caller-provided
+  // ``softmax_lse`` buffer: a non-empty tensor requests it. The sub-kernels
+  // derive the same flag and write into the buffer directly.
+  if (softmax_lse.numel() > 0) {
+    TORCH_CHECK(softmax_lse.scalar_type() == at::kFloat, "softmax_lse must be float32");
     TORCH_CHECK(
-        out_val.dim() == 3 && out_val.size(0) == q.size(0) && out_val.size(1) == q.size(1) &&
-            out_val.size(2) == v.size(-1),
-        "out shape must be [total_q, num_heads, head_size_v]");
-    TORCH_CHECK(out_val.device() == q.device(), "out must be on the same device as q");
-    TORCH_CHECK(out_val.stride(-1) == 1, "out must have a contiguous last dimension");
+        softmax_lse.dim() == 2 && softmax_lse.size(0) == q.size(1) && softmax_lse.size(1) == q.size(0),
+        "softmax_lse shape must be [num_heads, total_q]");
+    TORCH_CHECK(softmax_lse.device() == q.device(), "softmax_lse must be on the same device as q");
   }
-  auto to_tuple = [](std::vector<at::Tensor> v) { return std::make_tuple(v[0], v[1], v[2], v[3]); };
-  int const num_heads = q.size(-2);
-  int const num_heads_k = k.size(-2);
+
   int64_t batch_size = cu_seqlens_q.size(0) - 1;
 
   // decode / prefill / chunkprefill all take the same leading argument list;
   // only the trailing parameters differ. Bind the shared arguments once here so
-  // each branch reduces to a single call. ``tail`` carries the callee-specific
-  // suffix: decode and prefill additionally accept a per-batch skip mask (unused
-  // at this top level, so left as std::nullopt); chunkprefill has no such slot.
+  // each branch reduces to a single call. ``out`` and ``softmax_lse`` are
+  // threaded by reference and written in place; ``tail`` carries the
+  // callee-specific suffix: decode and prefill additionally accept a per-batch
+  // skip mask (unused at this top level, so left as std::nullopt); chunkprefill
+  // has no such slot.
   auto dispatch = [&](auto&& fn, auto&&... tail) {
-    return to_tuple(
-        fn(q,
-           k,
-           v,
-           q_v_,
-           cu_seqlens_q,
-           cu_seqlens_k,
-           max_seqlen_q,
-           max_seqlen_k,
-           page_table,
-           kv_batch_idx_,
-           leftpad_k_,
-           rotary_cos_,
-           rotary_sin_,
-           seqlens_rotary_,
-           q_descale_,
-           k_descale_,
-           v_descale_,
-           softmax_scale_,
-           sinks_,
-           is_causal,
-           window_size_left,
-           window_size_right,
-           softcap,
-           is_rotary_interleaved,
-           scheduler_metadata_,
-           num_kv_splits,
-           pack_gqa_,
-           sm_margin,
-           out_,
-           return_softmax_lse,
-           std::forward<decltype(tail)>(tail)...));
+    fn(q,
+       k,
+       v,
+       q_v_,
+       cu_seqlens_q,
+       cu_seqlens_k,
+       max_seqlen_q,
+       max_seqlen_k,
+       page_table,
+       kv_batch_idx_,
+       leftpad_k_,
+       rotary_cos_,
+       rotary_sin_,
+       seqlens_rotary_,
+       q_descale_,
+       k_descale_,
+       v_descale_,
+       softmax_scale_,
+       sinks_,
+       is_causal,
+       window_size_left,
+       window_size_right,
+       softcap,
+       is_rotary_interleaved,
+       scheduler_metadata_,
+       num_kv_splits,
+       pack_gqa_,
+       sm_margin,
+       out,
+       softmax_lse,
+       std::forward<decltype(tail)>(tail)...);
   };
 
   if (max_seqlen_q == 1) {
     // Pure decode path
-    return dispatch(decode::mha_fwd, std::nullopt);
+    dispatch(decode::mha_fwd, std::nullopt);
   } else if (!page_table.has_value() || batch_size == 1) {
     // Pure prefill path
     // Non-paged attn: assumption of all seqlen_q > 1;
@@ -1450,11 +1415,11 @@ SGL_KERNEL_EXPORT std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha
     // is_prefill.all() — a device reduction + D2H sync that costs more than it saves.
     // But batch_size == 1 makes it provable from host scalars:
     // a single sequence with max_seqlen_q > 1 is prefill
-    return dispatch(prefill::mha_fwd, std::nullopt);
+    dispatch(prefill::mha_fwd, std::nullopt);
   } else {
     // Chunk prefill path
     // Paged attn with max_seqlen_q > 1 and batch_size > 1
-    return dispatch(chunkprefill::mha_fwd);
+    dispatch(chunkprefill::mha_fwd);
   }
 }
 #undef SYCL_INTEL_TARGET

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -1279,8 +1279,6 @@ std::vector<at::Tensor> mha_fwd(
   TORCH_CHECK(batch_size >= 0, "cu_seqlens_q must have at least 1 element.");
 
   auto seqlens_q = cu_seqlens_q.slice(0, 1, batch_size + 1).sub(cu_seqlens_q.slice(0, 0, batch_size));
-  int total_q = q.size(0);
-  int num_heads = q.size(-2);
   auto is_prefill = seqlens_q.gt(1).contiguous();  // true for prefill batches
 
   // Forward every shared argument to a sub-kernel, overriding only the output
@@ -1320,14 +1318,27 @@ std::vector<at::Tensor> mha_fwd(
   };
 
   // Launch 1: decode allocates the shared output (or reuses the caller-provided
-  // out_ buffer) and skips prefill batches.
-  auto out = launch(decode::mha_fwd, std::move(out_), is_prefill)[0];
-  // Launch 2: prefill writes into the same output and skips decode batches.
-  launch(prefill::mha_fwd, out, is_prefill.logical_not());
+  // out_ buffer) and skips prefill batches. It also allocates a full
+  // (num_heads, total_q) softmax_lse and fills only the decode rows.
+  auto decode_ret = launch(decode::mha_fwd, std::move(out_), is_prefill);
+  auto out = decode_ret[0];
+  auto lse_decode = decode_ret[1];  // (num_heads, total_q), valid only on decode rows
+  // Launch 2: prefill writes into the same output and skips decode batches. Its
+  // softmax_lse likewise spans all total_q rows but is only valid on prefill rows.
+  auto prefill_ret = launch(prefill::mha_fwd, out, is_prefill.logical_not());
+  auto lse_prefill = prefill_ret[1];  // (num_heads, total_q), valid only on prefill rows
 
-  // softmax_lse / accum tensors are not stitched here; return empty
-  // placeholders to keep the Python ABI stable.
-  at::Tensor softmax_lse = at::empty({num_heads, total_q}, q.options().dtype(at::kFloat));
+  // Stitch softmax_lse: each sub-launch skipped the other's batches, leaving those
+  // rows uninitialized in its own LSE tensor. Select per query token from the
+  // launch that actually computed it. Columns are query tokens (total_q); a token
+  // belongs to a prefill batch iff its batch has seqlen_q > 1. at::where is a pure
+  // element-wise select, so the uninitialized rows are never read out. This runs
+  // entirely on device (no D2H sync).
+  auto token_is_prefill = is_prefill.repeat_interleave(seqlens_q.to(at::kLong));         // (total_q,)
+  auto softmax_lse = at::where(token_is_prefill.unsqueeze(0), lse_prefill, lse_decode);  // (num_heads, total_q)
+
+  // accum tensors are internal to split-KV reduction and unused by the Python
+  // caller; return empty placeholders to keep the ABI stable.
   auto empty_f = at::empty({0}, q.options().dtype(at::kFloat));
   return {out, softmax_lse, empty_f, empty_f};
 }

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -95,7 +95,7 @@ void mha_fwd_nopage(
     int window_size_right,
     float const softcap,
     at::Tensor& out,
-    at::Tensor& softmax_lse,
+    std::optional<at::Tensor>& softmax_lse,
     std::optional<at::Tensor> skip_batch_mask_opt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -150,9 +150,9 @@ void mha_fwd_nopage(
   TORCH_CHECK(head_size_v % alignment == 0, "head_size_v should be a multiple of " + std::to_string(alignment));
 
   // ``out`` is caller-provided and written in place. Whether to compute the
-  // softmax logsumexp is derived from the caller-provided ``softmax_lse`` buffer
-  // (a non-empty tensor requests it; an empty one skips the LSE computation).
-  bool const return_softmax_lse = softmax_lse.numel() > 0;
+  // softmax logsumexp is derived from the caller-provided ``softmax_lse``
+  // optional (a present tensor requests it; std::nullopt skips it).
+  bool const return_softmax_lse = softmax_lse.has_value();
 
   int const head_size_rounded = round_up_headdim(head_size);
 
@@ -189,7 +189,7 @@ void mha_fwd_nopage(
   params.seqlen_knew = 0;
   params.total_knew = 0;
 
-  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse.data_ptr() : nullptr;
+  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse->data_ptr() : nullptr;
   params.return_softmax_lse = return_softmax_lse;
 
   params.b = batch_size;
@@ -297,11 +297,11 @@ void mha_fwd(
     std::optional<bool> pack_gqa_,
     int const sm_margin,
     // Caller-provided output buffers written in place: ``out`` receives the
-    // attention result and ``softmax_lse`` the logsumexp when non-empty. A
+    // attention result and ``softmax_lse`` the logsumexp when present. A
     // per-batch skip mask (length = batch, chunkprefill two-launch path) selects
     // which batches this launch processes.
     at::Tensor& out,
-    at::Tensor& softmax_lse,
+    std::optional<at::Tensor>& softmax_lse,
     std::optional<at::Tensor> skip_batch_mask_opt = std::nullopt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -417,9 +417,9 @@ void mha_fwd(
   TORCH_CHECK(head_size_v % alignment == 0, "head_size_v should be a multiple of " + std::to_string(alignment));
 
   // ``out`` is caller-provided and written in place. Whether to compute the
-  // softmax logsumexp is derived from the caller-provided ``softmax_lse`` buffer
-  // (a non-empty tensor requests it; an empty one skips the LSE computation).
-  bool const return_softmax_lse = softmax_lse.numel() > 0;
+  // softmax logsumexp is derived from the caller-provided ``softmax_lse``
+  // optional (a present tensor requests it; std::nullopt skips it).
+  bool const return_softmax_lse = softmax_lse.has_value();
   at::Tensor temp_out;    // [batch, num_kv_splits, num_head_q, seq_q, head_size]
   at::Tensor exp_sums;    // [batch, num_head_q, seq_q, num_kv_splits]
   at::Tensor max_logits;  // [batch, num_head_q, seq_q, num_kv_splits]
@@ -533,9 +533,8 @@ void mha_fwd(
   params.cu_seqlens_k = cu_seqlens_k.data_ptr<int>();
   params.num_kv_splits = num_kv_splits;
 
-  // Softmax sum (null when the caller does not request it, matching the empty
-  // placeholder tensor above).
-  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse.data_ptr() : nullptr;
+  // Softmax sum (null when the caller passes std::nullopt).
+  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse->data_ptr() : nullptr;
   params.return_softmax_lse = return_softmax_lse;
 
   // Set the dimensions.
@@ -698,7 +697,7 @@ void mha_fwd_nopage(
     int window_size_right,
     float const softcap,
     at::Tensor& out,
-    at::Tensor& softmax_lse,
+    std::optional<at::Tensor>& softmax_lse,
     std::optional<at::Tensor> skip_batch_mask_opt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -783,7 +782,7 @@ void mha_fwd_nopage(
   params.cu_seqlens_q = cu_seqlens_q.data_ptr<int>();
   params.cu_seqlens_k = cu_seqlens_k.data_ptr<int>();
 
-  params.softmax_lse_ptr = softmax_lse.numel() > 0 ? softmax_lse.data_ptr() : nullptr;
+  params.softmax_lse_ptr = softmax_lse.has_value() ? softmax_lse->data_ptr() : nullptr;
 
   params.b = batch_size;
   params.h = num_heads;
@@ -902,11 +901,11 @@ void mha_fwd(
     std::optional<bool> pack_gqa_,
     int const sm_margin,
     // Caller-provided output buffers written in place: ``out`` receives the
-    // attention result and ``softmax_lse`` the logsumexp when non-empty. A
+    // attention result and ``softmax_lse`` the logsumexp when present. A
     // per-batch skip mask (length = batch, chunkprefill two-launch path) selects
     // which batches this launch processes.
     at::Tensor& out,
-    at::Tensor& softmax_lse,
+    std::optional<at::Tensor>& softmax_lse,
     std::optional<at::Tensor> skip_batch_mask_opt = std::nullopt) {
   auto q_type = q.scalar_type();
   TORCH_CHECK(
@@ -1019,9 +1018,9 @@ void mha_fwd(
   TORCH_CHECK(head_size_v % alignment == 0, "head_size_v should be a multiple of " + std::to_string(alignment));
 
   // ``out`` is caller-provided and written in place. Whether to compute the
-  // softmax logsumexp is derived from the caller-provided ``softmax_lse`` buffer
-  // (a non-empty tensor requests it; an empty one skips the LSE computation).
-  bool const return_softmax_lse = softmax_lse.numel() > 0;
+  // softmax logsumexp is derived from the caller-provided ``softmax_lse``
+  // optional (a present tensor requests it; std::nullopt skips it).
+  bool const return_softmax_lse = softmax_lse.has_value();
 
   int const head_size_rounded = round_up_headdim(head_size);
   int const head_size_v_rounded = head_size_v == head_size ? head_size_rounded : round_up_headdim(head_size_v);
@@ -1060,9 +1059,8 @@ void mha_fwd(
   params.cu_seqlens_q = cu_seqlens_q.data_ptr<int>();
   params.cu_seqlens_k = cu_seqlens_k.data_ptr<int>();
 
-  // Softmax sum (null when the caller does not request it, matching the empty
-  // placeholder tensor above).
-  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse.data_ptr() : nullptr;
+  // Softmax sum (null when the caller passes std::nullopt).
+  params.softmax_lse_ptr = return_softmax_lse ? softmax_lse->data_ptr() : nullptr;
   params.return_softmax_lse = return_softmax_lse;
 
   // Set the dimensions.
@@ -1256,7 +1254,7 @@ void mha_fwd(
     std::optional<bool> pack_gqa_,
     int const sm_margin,
     at::Tensor& out,
-    at::Tensor& softmax_lse) {
+    std::optional<at::Tensor>& softmax_lse) {
   // Supports both paged (page_table != None) and non-paged (contiguous ragged
   // KV, page_table == None) layouts.
   // ``seqlens_rotary_`` is intentionally not checked here: callers pass it
@@ -1357,11 +1355,11 @@ SGL_KERNEL_EXPORT void mha_fwd(
     std::optional<bool> pack_gqa_,
     int const sm_margin,
     // Caller-provided output buffers, written in place (no value is returned).
-    // ``softmax_lse`` doubles as the "return LSE" flag: a non-empty tensor
-    // requests the logsumexp be computed and written; an empty (numel == 0)
-    // tensor skips the LSE computation entirely.
+    // ``softmax_lse`` doubles as the "return LSE" flag: a present optional
+    // requests the logsumexp be computed and written; std::nullopt skips the
+    // LSE computation entirely.
     at::Tensor& out,
-    at::Tensor& softmax_lse) {
+    std::optional<at::Tensor>& softmax_lse) {
   TORCH_CHECK(q.dim() == 3, "query must be in ragged format (total_q, h, d)");
   // k and v may be 3D (total_k, h_k, d) for non-paged or 4D (num_pages, page_size, h_k, d)
   // for paged KV cache; sub-functions validate their own shapes.
@@ -1373,14 +1371,14 @@ SGL_KERNEL_EXPORT void mha_fwd(
   TORCH_CHECK(out.stride(-1) == 1, "out must have a contiguous last dimension");
 
   // Whether to compute the softmax logsumexp is derived from the caller-provided
-  // ``softmax_lse`` buffer: a non-empty tensor requests it. The sub-kernels
+  // ``softmax_lse`` optional: a present tensor requests it. The sub-kernels
   // derive the same flag and write into the buffer directly.
-  if (softmax_lse.numel() > 0) {
-    TORCH_CHECK(softmax_lse.scalar_type() == at::kFloat, "softmax_lse must be float32");
+  if (softmax_lse.has_value()) {
+    TORCH_CHECK(softmax_lse->scalar_type() == at::kFloat, "softmax_lse must be float32");
     TORCH_CHECK(
-        softmax_lse.dim() == 2 && softmax_lse.size(0) == q.size(1) && softmax_lse.size(1) == q.size(0),
+        softmax_lse->dim() == 2 && softmax_lse->size(0) == q.size(1) && softmax_lse->size(1) == q.size(0),
         "softmax_lse shape must be [num_heads, total_q]");
-    TORCH_CHECK(softmax_lse.device() == q.device(), "softmax_lse must be on the same device as q");
+    TORCH_CHECK(softmax_lse->device() == q.device(), "softmax_lse must be on the same device as q");
   }
 
   int64_t batch_size = cu_seqlens_q.size(0) - 1;

--- a/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_epilogue.hpp
+++ b/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_epilogue.hpp
@@ -153,9 +153,27 @@ class FMHAFwdEpilogue {
       float scale_v = 1.0f,                   // Per-tensor V dequant scale (fp8 path)
       ElementSink sink_val = ElementSink{},   // Per-head sink logit (non-packed, used when Sink==true)
       const ElementSink* sink_ptr = nullptr,  // Per-row sink logits base (PackGQA, used when Sink==true)
-      int head_group_q = 0) {                 // # packed query heads in the M tile (PackGQA)
+      int head_group_q = 0,                   // # packed query heads in the M tile (PackGQA)
+      // Optional softmax LSE output (natural-log log-sum-exp), row-major
+      // (num_heads_q, total_q). Null => don't write. LSE is written in
+      // output-element space at the v==0 column so each query row is emitted
+      // exactly once.
+      float* lse_ptr = nullptr,     // Base pointer of softmax_lse, or null
+      int64_t lse_head_stride = 0,  // Row stride (= total_q)
+      int lse_q_base = 0,           // Query-token base (non-packed: batch offset; packed: this token)
+      int lse_head_base = 0,        // Head base (non-packed: q head; packed: head*head_group_q)
+      // Number of VALID query rows in this tile (non-packed only). The Q tile is
+      // padded up to TileShapeQK's M extent, so rows [seq_len_qo, TileM) are
+      // padding whose softmax state is degenerate (denom == seq_len_k, max == 0,
+      // i.e. LSE == log(seq_len_k)). Without this bound the per-row LSE store
+      // writes those padding rows at qtok = lse_q_base + row, which spills past
+      // this batch's tokens and corrupts other heads' rows in the row-major
+      // (num_heads_q, total_q) buffer. -1 => unbounded (legacy callers).
+      int lse_num_rows = -1) {
     using namespace cute;
     using ElementA = typename FragA::element_type;
+    // ln(2): converts the log2-domain row max back to the natural log used by LSE.
+    constexpr float kRcpLog2e = 0.6931471805599453f;
 
     // Reduce k-blocks of A and A_sum across WG, if needed.
     auto [rA, rA_max_local, rA_sum, active] = reduce_A(tArA, tA_max, tA_sum, thr_id);
@@ -233,6 +251,12 @@ class FMHAFwdEpilogue {
             denom += sink_term;
           }
         }
+        // Emit the natural-log LSE once per query head (at the v==0 column).
+        if (lse_ptr != nullptr && int(get<1>(tOgO(j))) == 0 && head_off < head_group_q) {
+          float d = float(denom);
+          float lse = (d > 0.f) ? (float(tO_max(j)) * kRcpLog2e + sycl::log(d)) : -INFINITY;
+          lse_ptr[(lse_head_base + head_off) * lse_head_stride + lse_q_base] = lse;
+        }
         // Rows that attend to no (unmasked) keys have denom==0 -> emit 0, not NaN.
         ElementA outv = (denom != ElementA(0)) ? (tO_num(j) / denom) : ElementA(0);
         //  For an fp8 KV cache the per-tensor V dequant scale is folded in here
@@ -251,6 +275,43 @@ class FMHAFwdEpilogue {
          For an fp8 KV cache the per-tensor V dequant scale is folded in here
          (O = scale_v * (P @ V_fp8) / sum), avoiding a per-element V scale in the
          mainloop GEMM2. */
+      // Emit the natural-log LSE in output-element space (before rA_sum is
+      // overwritten by its reciprocal). Each query row writes exactly once, at
+      // the v==0 column. Works for both non-packed (prefill / MHA decode) and
+      // non-sink PackGQA decode tiles.
+      if (lse_ptr != nullptr) {
+        auto denom_e = rA;  // per-element softmax denominator (sum of weights)
+        auto max_e = rA;    // per-element row max
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < rA.size(); i++) {
+          denom_e(i) = broadcast<0>(rA_sum, rA, i);
+          max_e(i) = broadcast<0>(rA_max_local, rA, i);
+        }
+        auto tv = tOrO.tv_layout();
+        auto tO_denom = make_subgroup_tensor(make_fragment_like<ElementA>(tOrO.layout()), tv);
+        auto tO_max = make_subgroup_tensor(make_fragment_like<ElementA>(tOrO.layout()), tv);
+        reorder(denom_e, tO_denom);
+        reorder(max_e, tO_max);
+        CUTLASS_PRAGMA_UNROLL
+        for (int j = 0; j < int(tO_denom.size()); j++) {
+          if (int(get<1>(tOgO(j))) != 0) continue;
+          int row = int(get<0>(tOgO(j)));
+          int h, qtok;
+          if constexpr (PackGQA_) {
+            if (row >= head_group_q) continue;
+            h = lse_head_base + row;
+            qtok = lse_q_base;
+          } else {
+            // Skip padding rows beyond the real query length (see lse_num_rows).
+            if (lse_num_rows >= 0 && row >= lse_num_rows) continue;
+            h = lse_head_base;
+            qtok = lse_q_base + row;
+          }
+          float d = float(tO_denom(j));
+          float lse = (d > 0.f) ? (float(tO_max(j)) * kRcpLog2e + sycl::log(d)) : -INFINITY;
+          lse_ptr[int64_t(h) * lse_head_stride + qtok] = lse;
+        }
+      }
       CUTLASS_PRAGMA_UNROLL
       for (int i = 0; i < rA_sum.size(); i++) {
         if constexpr (CollectiveMainloop::LocalMask || CollectiveMainloop::CausalMask) {
@@ -554,7 +615,13 @@ class DecodeFwdEpilogue {
       int head_group_q,
       TensorSink& tSink,  // Sink for current head
       int num_kv_splits,
-      bool is_single_split) {
+      bool is_single_split,
+      // Optional softmax LSE output (natural log). Written only for
+      // single-split sequences; multi-split LSE is produced by ReduceSplitK.
+      float* lse_ptr = nullptr,     // Base pointer of softmax_lse, or null
+      int64_t lse_head_stride = 0,  // Row stride (= total_q)
+      int lse_q_base = 0,           // Query-token index for this decode step
+      int lse_head_base = 0) {      // Head base (= head * head_group_q)
     using namespace cute;
     using ElementA = typename FragA::element_type;
 
@@ -593,6 +660,16 @@ class DecodeFwdEpilogue {
         exp_sums(thr_id, idx_kv_split) = rA_sum(0);
         max_logits(thr_id, idx_kv_split) = rA_max(0);
       }
+    }
+
+    // Single-split sequences are normalized here (ReduceSplitK is a pass-through
+    // for them), so emit their LSE directly. Multi-split LSE is written by
+    // ReduceSplitK after the cross-split reduction.
+    if (lse_ptr != nullptr && thr_id < head_group_q && (is_single_split || num_kv_splits <= 1)) {
+      constexpr float kRcpLog2e = 0.6931471805599453f;  // ln(2)
+      float d = float(rA_sum(0));
+      float lse = (d > 0.f) ? (float(rA_max(0)) * kRcpLog2e + sycl::log(d)) : -INFINITY;
+      lse_ptr[int64_t(lse_head_base + thr_id) * lse_head_stride + lse_q_base] = lse;
     }
 
     /* Some subgroups may not have any work to do; if so, quit early. */

--- a/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_epilogue.hpp
+++ b/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_epilogue.hpp
@@ -257,7 +257,7 @@ class FMHAFwdEpilogue {
         }
         // Emit the natural-log LSE once per query head (at the v==0 column).
         if constexpr (LSE) {
-          if (int(get<1>(tOgO(j))) == 0 && head_off < head_group_q) {
+          if (int(get<1>(blk_qv)) == 0 && int(get<1>(tOgO(j))) == 0 && head_off < head_group_q) {
             float d = float(denom);
             float lse = (d > 0.f) ? (float(tO_max(j)) * kRcpLog2e + sycl::log(d)) : -INFINITY;
             lse_ptr[(lse_head_base + head_off) * lse_head_stride + lse_q_base] = lse;
@@ -300,7 +300,7 @@ class FMHAFwdEpilogue {
         reorder(max_e, tO_max);
         CUTLASS_PRAGMA_UNROLL
         for (int j = 0; j < int(tO_denom.size()); j++) {
-          if (int(get<1>(tOgO(j))) != 0) continue;
+          if (int(get<1>(blk_qv)) != 0 || int(get<1>(tOgO(j))) != 0) continue;
           int row = int(get<0>(tOgO(j)));
           int h, qtok;
           if constexpr (PackGQA_) {
@@ -675,7 +675,7 @@ class DecodeFwdEpilogue {
     // for them), so emit their LSE directly. Multi-split LSE is written by
     // ReduceSplitK after the cross-split reduction.
     if constexpr (LSE) {
-      if (thr_id < head_group_q && (is_single_split || num_kv_splits <= 1)) {
+      if (int(get<1>(blk_qv)) == 0 && thr_id < head_group_q && (is_single_split || num_kv_splits <= 1)) {
         constexpr float kRcpLog2e = 0.6931471805599453f;  // ln(2)
         float d = float(rA_sum(0));
         float lse = (d > 0.f) ? (float(rA_max(0)) * kRcpLog2e + sycl::log(d)) : -INFINITY;

--- a/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_epilogue.hpp
+++ b/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_epilogue.hpp
@@ -57,7 +57,10 @@ template <
     // (decode only). Each packed row is a distinct query head with its own sink
     // logit, so the sink is applied per row. Default false keeps prefill and
     // non-packed decode on the scalar (per-head) path.
-    bool PackGQA_ = false>
+    bool PackGQA_ = false,
+    // LSE: when false, the epilogue skips writing softmax_lse.
+    // Defaults to false; every instantiation site threads the flag explicitly.
+    bool LSE_ = false>
 class FMHAFwdEpilogue {
  public:
   //
@@ -78,6 +81,7 @@ class FMHAFwdEpilogue {
 
   // Sink support
   static constexpr bool Sink = Sink_;
+  static constexpr bool LSE = LSE_;
   using ElementSink = typename CollectiveMainloop::TensorQ::element_type;
 
   // Split k-reduced tiles between participating subgroups.
@@ -252,10 +256,12 @@ class FMHAFwdEpilogue {
           }
         }
         // Emit the natural-log LSE once per query head (at the v==0 column).
-        if (lse_ptr != nullptr && int(get<1>(tOgO(j))) == 0 && head_off < head_group_q) {
-          float d = float(denom);
-          float lse = (d > 0.f) ? (float(tO_max(j)) * kRcpLog2e + sycl::log(d)) : -INFINITY;
-          lse_ptr[(lse_head_base + head_off) * lse_head_stride + lse_q_base] = lse;
+        if constexpr (LSE) {
+          if (int(get<1>(tOgO(j))) == 0 && head_off < head_group_q) {
+            float d = float(denom);
+            float lse = (d > 0.f) ? (float(tO_max(j)) * kRcpLog2e + sycl::log(d)) : -INFINITY;
+            lse_ptr[(lse_head_base + head_off) * lse_head_stride + lse_q_base] = lse;
+          }
         }
         // Rows that attend to no (unmasked) keys have denom==0 -> emit 0, not NaN.
         ElementA outv = (denom != ElementA(0)) ? (tO_num(j) / denom) : ElementA(0);
@@ -279,7 +285,7 @@ class FMHAFwdEpilogue {
       // overwritten by its reciprocal). Each query row writes exactly once, at
       // the v==0 column. Works for both non-packed (prefill / MHA decode) and
       // non-sink PackGQA decode tiles.
-      if (lse_ptr != nullptr) {
+      if constexpr (LSE) {
         auto denom_e = rA;  // per-element softmax denominator (sum of weights)
         auto max_e = rA;    // per-element row max
         CUTLASS_PRAGMA_UNROLL
@@ -449,7 +455,8 @@ template <
     class TensorLSE_ = void,   // Optional tensor for storing intermediate exp
                                // sums and max logits
     class TiledCopyO_ = void,  // Optional TiledCopy for loading O
-    bool Sink_ = false>        // Whether to sink softmax into epilogue
+    bool Sink_ = false,        // Whether to sink softmax into epilogue
+    bool LSE_ = false>         // Whether to emit softmax log-sum-exp
 class DecodeFwdEpilogue {
  public:
   //
@@ -477,6 +484,8 @@ class DecodeFwdEpilogue {
 
   // softmax sink, same dtype
   static constexpr bool Sink = Sink_;
+  // Whether to emit the softmax log-sum-exp output.
+  static constexpr bool LSE = LSE_;
   using ElementSink = typename CollectiveMainloop::TensorQ::element_type;
 
   // Split k-reduced tiles between participating subgroups.
@@ -665,11 +674,13 @@ class DecodeFwdEpilogue {
     // Single-split sequences are normalized here (ReduceSplitK is a pass-through
     // for them), so emit their LSE directly. Multi-split LSE is written by
     // ReduceSplitK after the cross-split reduction.
-    if (lse_ptr != nullptr && thr_id < head_group_q && (is_single_split || num_kv_splits <= 1)) {
-      constexpr float kRcpLog2e = 0.6931471805599453f;  // ln(2)
-      float d = float(rA_sum(0));
-      float lse = (d > 0.f) ? (float(rA_max(0)) * kRcpLog2e + sycl::log(d)) : -INFINITY;
-      lse_ptr[int64_t(lse_head_base + thr_id) * lse_head_stride + lse_q_base] = lse;
+    if constexpr (LSE) {
+      if (thr_id < head_group_q && (is_single_split || num_kv_splits <= 1)) {
+        constexpr float kRcpLog2e = 0.6931471805599453f;  // ln(2)
+        float d = float(rA_sum(0));
+        float lse = (d > 0.f) ? (float(rA_max(0)) * kRcpLog2e + sycl::log(d)) : -INFINITY;
+        lse_ptr[int64_t(lse_head_base + thr_id) * lse_head_stride + lse_q_base] = lse;
+      }
     }
 
     /* Some subgroups may not have any work to do; if so, quit early. */

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
@@ -120,6 +120,8 @@ class XeFMHAFwdKernel {
 
   // Sink support from epilogue
   static constexpr bool Sink = CollectiveEpilogue::Sink;
+  // Whether the epilogue emits softmax log-sum-exp.
+  static constexpr bool LSE = CollectiveEpilogue::LSE;
   using ElementSink = typename CollectiveEpilogue::ElementSink;
 
   // Kernel level shared memory storage
@@ -442,12 +444,15 @@ class XeFMHAFwdKernel {
       // tiles). For PackGQA decode the single query token maps to lse_q_base and
       // the row selects the query head within the KV group.
       int lse_q_base = 0;
-      if constexpr (is_var_len) {
-        lse_q_base = s.seq_len_qo.cumulative_length[idx_b];
-      } else {
-        lse_q_base = idx_b * seq_len_qo;
+      int lse_head_base = 0;
+      if constexpr (LSE) {
+        if constexpr (is_var_len) {
+          lse_q_base = s.seq_len_qo.cumulative_length[idx_b];
+        } else {
+          lse_q_base = idx_b * seq_len_qo;
+        }
+        lse_head_base = PackGQA_ ? (head * head_group_q) : q_head_idx;
       }
-      int lse_head_base = PackGQA_ ? (head * head_group_q) : q_head_idx;
       if constexpr (Sink) {
         if constexpr (PackGQA_) {
           // Packed decode: pass the per-row sink base for this KV head's group
@@ -1015,7 +1020,8 @@ class XeFMHAFwdSplitKVKernel {
   using ElementLSE = typename CollectiveEpilogue::ElementLSE;
   using StrideO = decltype(stride(typename CollectiveEpilogue::TensorO{}));
 
-  // Kernel level shared memory storage
+  // Whether the epilogue emits softmax log-sum-exp.
+  static constexpr bool LSE = CollectiveEpilogue::LSE;
   using MainloopSharedStorage = typename CollectiveMainloop::SharedStorage;
   using EpilogueSharedStorage = typename CollectiveEpilogue::SharedStorage;
   union SharedStorage {
@@ -1162,7 +1168,10 @@ class XeFMHAFwdSplitKVKernel {
       // Mix-batch dispatch: skip batches not owned by this kernel launch.
       if (p.skip_batch_mask != nullptr && p.skip_batch_mask[idx_b]) continue;
       auto blk_qv = make_coord(blk_q, blk_v);
-      int head_q_start = head * head_group_q;
+      int head_q_start = 0;
+      if constexpr (LSE) {
+        head_q_start = head * head_group_q;
+      }
 
       auto sequence_length_shape = get_sequence_length_shape(s, idx_b);
       auto [seq_len_qo, seq_len_kv] = sequence_length_shape;
@@ -1189,7 +1198,10 @@ class XeFMHAFwdSplitKVKernel {
       int offset_exp_sums = 0, offset_max_logits = 0;
       // Query-token index in the (num_heads_q, total_q) softmax_lse output. For
       // decode seq_len_qo == 1, so each (batch) maps to a single token.
-      int lse_q_base = idx_b;
+      int lse_q_base = 0;
+      if constexpr (LSE) {
+        lse_q_base = idx_b;
+      }
       if constexpr (is_var_len) {
         auto qo_cumulative = s.seq_len_qo.cumulative_length;
 
@@ -1197,7 +1209,9 @@ class XeFMHAFwdSplitKVKernel {
         offset_o = s.num_heads_q * s.head_size_vo * num_kv_splits * qo_cumulative[idx_b];
         offset_exp_sums = s.num_heads_q * num_kv_splits * qo_cumulative[idx_b];
         offset_max_logits = s.num_heads_q * num_kv_splits * qo_cumulative[idx_b];
-        lse_q_base = qo_cumulative[idx_b];
+        if constexpr (LSE) {
+          lse_q_base = qo_cumulative[idx_b];
+        }
 
         // for gqa packing, seq_len_qo must be 1
         seq_len_qo = 1;

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
@@ -135,6 +135,8 @@ class XeFMHAFwdKernel {
 
   // Sink support from epilogue
   static constexpr bool Sink = CollectiveEpilogue::Sink;
+  // Whether the epilogue emits softmax log-sum-exp.
+  static constexpr bool LSE = CollectiveEpilogue::LSE;
   using ElementSink = typename CollectiveEpilogue::ElementSink;
 
   // Kernel level shared memory storage
@@ -554,12 +556,15 @@ class XeFMHAFwdKernel {
       // tiles). For PackGQA decode the single query token maps to lse_q_base and
       // the row selects the query head within the KV group.
       int lse_q_base = 0;
-      if constexpr (is_var_len) {
-        lse_q_base = s.seq_len_qo.cumulative_length[idx_b];
-      } else {
-        lse_q_base = idx_b * seq_len_qo;
+      int lse_head_base = 0;
+      if constexpr (LSE) {
+        if constexpr (is_var_len) {
+          lse_q_base = s.seq_len_qo.cumulative_length[idx_b];
+        } else {
+          lse_q_base = idx_b * seq_len_qo;
+        }
+        lse_head_base = PackGQA_ ? (head * head_group_q) : q_head_idx;
       }
-      int lse_head_base = PackGQA_ ? (head * head_group_q) : q_head_idx;
       if constexpr (Sink) {
         if constexpr (PackGQA_) {
           // Packed decode: pass the per-row sink base for this KV head's group
@@ -1127,7 +1132,8 @@ class XeFMHAFwdSplitKVKernel {
   using ElementLSE = typename CollectiveEpilogue::ElementLSE;
   using StrideO = decltype(stride(typename CollectiveEpilogue::TensorO{}));
 
-  // Kernel level shared memory storage
+  // Whether the epilogue emits softmax log-sum-exp.
+  static constexpr bool LSE = CollectiveEpilogue::LSE;
   using MainloopSharedStorage = typename CollectiveMainloop::SharedStorage;
   using EpilogueSharedStorage = typename CollectiveEpilogue::SharedStorage;
   union SharedStorage {
@@ -1275,7 +1281,10 @@ class XeFMHAFwdSplitKVKernel {
       // Mix-batch dispatch: skip batches not owned by this kernel launch.
       if (p.skip_batch_mask != nullptr && p.skip_batch_mask[idx_b]) continue;
       auto blk_qv = make_coord(blk_q, blk_v);
-      int head_q_start = head * head_group_q;
+      int head_q_start = 0;
+      if constexpr (LSE) {
+        head_q_start = head * head_group_q;
+      }
 
       auto sequence_length_shape = get_sequence_length_shape(s, idx_b);
       auto [seq_len_qo, seq_len_kv] = sequence_length_shape;
@@ -1302,7 +1311,10 @@ class XeFMHAFwdSplitKVKernel {
       int offset_exp_sums = 0, offset_max_logits = 0;
       // Query-token index in the (num_heads_q, total_q) softmax_lse output. For
       // decode seq_len_qo == 1, so each (batch) maps to a single token.
-      int lse_q_base = idx_b;
+      int lse_q_base = 0;
+      if constexpr (LSE) {
+        lse_q_base = idx_b;
+      }
       if constexpr (is_var_len) {
         auto qo_cumulative = s.seq_len_qo.cumulative_length;
 
@@ -1310,7 +1322,9 @@ class XeFMHAFwdSplitKVKernel {
         offset_o = s.num_heads_q * s.head_size_vo * num_kv_splits * qo_cumulative[idx_b];
         offset_exp_sums = s.num_heads_q * num_kv_splits * qo_cumulative[idx_b];
         offset_max_logits = s.num_heads_q * num_kv_splits * qo_cumulative[idx_b];
-        lse_q_base = qo_cumulative[idx_b];
+        if constexpr (LSE) {
+          lse_q_base = qo_cumulative[idx_b];
+        }
 
         // for gqa packing, seq_len_qo must be 1
         seq_len_qo = 1;

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
@@ -171,6 +171,10 @@ class XeFMHAFwdKernel {
     // a host-side D2H sync (tensor.item()). Null => non-fp8 KV (scale = 1.0f).
     const float* scale_k_ptr = nullptr;
     const float* scale_v_ptr = nullptr;
+    // Optional softmax LSE output (natural-log log-sum-exp), row-major
+    // (num_heads_q, total_q). Null => don't write.
+    float* softmax_lse = nullptr;
+    int64_t lse_head_stride = 0;  // = total_q
   };
   using KernelParams = KernelArguments;
 
@@ -544,6 +548,18 @@ class XeFMHAFwdKernel {
       if constexpr (CollectiveMainloop::Fp8KV) {
         scale_v = *p.scale_v_ptr;
       }
+      // softmax_lse output coordinates. get<0>(tOgO) inside the epilogue is the
+      // global row within this head/batch O slice, so the query-token base is
+      // just this batch's offset (the epilogue adds the row for non-packed
+      // tiles). For PackGQA decode the single query token maps to lse_q_base and
+      // the row selects the query head within the KV group.
+      int lse_q_base = 0;
+      if constexpr (is_var_len) {
+        lse_q_base = s.seq_len_qo.cumulative_length[idx_b];
+      } else {
+        lse_q_base = idx_b * seq_len_qo;
+      }
+      int lse_head_base = PackGQA_ ? (head * head_group_q) : q_head_idx;
       if constexpr (Sink) {
         if constexpr (PackGQA_) {
           // Packed decode: pass the per-row sink base for this KV head's group
@@ -559,12 +575,47 @@ class XeFMHAFwdKernel {
               scale_v,
               ElementSink{},
               p.sm_sink + head * head_group_q,
-              head_group_q);
+              head_group_q,
+              p.softmax_lse,
+              p.lse_head_stride,
+              lse_q_base,
+              lse_head_base,
+              seq_len_qo);
         } else {
-          epilogue(O(_, _, q_head_idx, l_coord), tArA, tA_max, tA_sum, blk_qv, thr_id, scale_v, p.sm_sink[q_head_idx]);
+          epilogue(
+              O(_, _, q_head_idx, l_coord),
+              tArA,
+              tA_max,
+              tA_sum,
+              blk_qv,
+              thr_id,
+              scale_v,
+              p.sm_sink[q_head_idx],
+              nullptr,
+              0,
+              p.softmax_lse,
+              p.lse_head_stride,
+              lse_q_base,
+              lse_head_base,
+              seq_len_qo);
         }
       } else {
-        epilogue(O(_, _, q_head_idx, l_coord), tArA, tA_max, tA_sum, blk_qv, thr_id, scale_v);
+        epilogue(
+            O(_, _, q_head_idx, l_coord),
+            tArA,
+            tA_max,
+            tA_sum,
+            blk_qv,
+            thr_id,
+            scale_v,
+            ElementSink{},
+            nullptr,
+            head_group_q,
+            p.softmax_lse,
+            p.lse_head_stride,
+            lse_q_base,
+            lse_head_base,
+            seq_len_qo);
       }
     }
   }
@@ -1116,6 +1167,11 @@ class XeFMHAFwdSplitKVKernel {
     const float* scale_k_ptr = nullptr;
     const float* scale_v_ptr = nullptr;
     int min_blocks_for_split = 2;
+    // Optional softmax LSE output (natural-log log-sum-exp), row-major
+    // (num_heads_q, total_q). Written here only for single-split sequences;
+    // multi-split LSE is produced by ReduceSplitK. Null => don't write.
+    float* softmax_lse = nullptr;
+    int64_t lse_head_stride = 0;  // = total_q
   };
   using KernelParams = KernelArguments;
 
@@ -1244,6 +1300,9 @@ class XeFMHAFwdSplitKVKernel {
 
       int offset_q = 0, offset_k = 0, offset_v = 0, offset_o = 0;
       int offset_exp_sums = 0, offset_max_logits = 0;
+      // Query-token index in the (num_heads_q, total_q) softmax_lse output. For
+      // decode seq_len_qo == 1, so each (batch) maps to a single token.
+      int lse_q_base = idx_b;
       if constexpr (is_var_len) {
         auto qo_cumulative = s.seq_len_qo.cumulative_length;
 
@@ -1251,6 +1310,7 @@ class XeFMHAFwdSplitKVKernel {
         offset_o = s.num_heads_q * s.head_size_vo * num_kv_splits * qo_cumulative[idx_b];
         offset_exp_sums = s.num_heads_q * num_kv_splits * qo_cumulative[idx_b];
         offset_max_logits = s.num_heads_q * num_kv_splits * qo_cumulative[idx_b];
+        lse_q_base = qo_cumulative[idx_b];
 
         // for gqa packing, seq_len_qo must be 1
         seq_len_qo = 1;
@@ -1387,7 +1447,11 @@ class XeFMHAFwdSplitKVKernel {
             head_group_q,
             sinks_per_kv,
             num_kv_splits,
-            is_single_split);
+            is_single_split,
+            p.softmax_lse,
+            p.lse_head_stride,
+            lse_q_base,
+            head_q_start);
       } else {
         epilogue(
             O(_, _, head, idx_kv_split, l_coord),
@@ -1403,7 +1467,11 @@ class XeFMHAFwdSplitKVKernel {
             head_group_q,
             sinks,
             num_kv_splits,
-            is_single_split);
+            is_single_split,
+            p.softmax_lse,
+            p.lse_head_stride,
+            lse_q_base,
+            head_q_start);
       }
     }
   }

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
@@ -156,6 +156,10 @@ class XeFMHAFwdKernel {
     // a host-side D2H sync (tensor.item()). Null => non-fp8 KV (scale = 1.0f).
     const float* scale_k_ptr = nullptr;
     const float* scale_v_ptr = nullptr;
+    // Optional softmax LSE output (natural-log log-sum-exp), row-major
+    // (num_heads_q, total_q). Null => don't write.
+    float* softmax_lse = nullptr;
+    int64_t lse_head_stride = 0;  // = total_q
   };
   using KernelParams = KernelArguments;
 
@@ -432,6 +436,18 @@ class XeFMHAFwdKernel {
       if constexpr (CollectiveMainloop::Fp8KV) {
         scale_v = *p.scale_v_ptr;
       }
+      // softmax_lse output coordinates. get<0>(tOgO) inside the epilogue is the
+      // global row within this head/batch O slice, so the query-token base is
+      // just this batch's offset (the epilogue adds the row for non-packed
+      // tiles). For PackGQA decode the single query token maps to lse_q_base and
+      // the row selects the query head within the KV group.
+      int lse_q_base = 0;
+      if constexpr (is_var_len) {
+        lse_q_base = s.seq_len_qo.cumulative_length[idx_b];
+      } else {
+        lse_q_base = idx_b * seq_len_qo;
+      }
+      int lse_head_base = PackGQA_ ? (head * head_group_q) : q_head_idx;
       if constexpr (Sink) {
         if constexpr (PackGQA_) {
           // Packed decode: pass the per-row sink base for this KV head's group
@@ -447,12 +463,47 @@ class XeFMHAFwdKernel {
               scale_v,
               ElementSink{},
               p.sm_sink + head * head_group_q,
-              head_group_q);
+              head_group_q,
+              p.softmax_lse,
+              p.lse_head_stride,
+              lse_q_base,
+              lse_head_base,
+              seq_len_qo);
         } else {
-          epilogue(O(_, _, q_head_idx, l_coord), tArA, tA_max, tA_sum, blk_qv, thr_id, scale_v, p.sm_sink[q_head_idx]);
+          epilogue(
+              O(_, _, q_head_idx, l_coord),
+              tArA,
+              tA_max,
+              tA_sum,
+              blk_qv,
+              thr_id,
+              scale_v,
+              p.sm_sink[q_head_idx],
+              nullptr,
+              0,
+              p.softmax_lse,
+              p.lse_head_stride,
+              lse_q_base,
+              lse_head_base,
+              seq_len_qo);
         }
       } else {
-        epilogue(O(_, _, q_head_idx, l_coord), tArA, tA_max, tA_sum, blk_qv, thr_id, scale_v);
+        epilogue(
+            O(_, _, q_head_idx, l_coord),
+            tArA,
+            tA_max,
+            tA_sum,
+            blk_qv,
+            thr_id,
+            scale_v,
+            ElementSink{},
+            nullptr,
+            head_group_q,
+            p.softmax_lse,
+            p.lse_head_stride,
+            lse_q_base,
+            lse_head_base,
+            seq_len_qo);
       }
     }
   }
@@ -1003,6 +1054,11 @@ class XeFMHAFwdSplitKVKernel {
     // a host-side D2H sync (tensor.item()). Null => non-fp8 KV (scale = 1.0f).
     const float* scale_k_ptr = nullptr;
     const float* scale_v_ptr = nullptr;
+    // Optional softmax LSE output (natural-log log-sum-exp), row-major
+    // (num_heads_q, total_q). Written here only for single-split sequences;
+    // multi-split LSE is produced by ReduceSplitK. Null => don't write.
+    float* softmax_lse = nullptr;
+    int64_t lse_head_stride = 0;  // = total_q
   };
   using KernelParams = KernelArguments;
 
@@ -1131,6 +1187,9 @@ class XeFMHAFwdSplitKVKernel {
 
       int offset_q = 0, offset_k = 0, offset_v = 0, offset_o = 0;
       int offset_exp_sums = 0, offset_max_logits = 0;
+      // Query-token index in the (num_heads_q, total_q) softmax_lse output. For
+      // decode seq_len_qo == 1, so each (batch) maps to a single token.
+      int lse_q_base = idx_b;
       if constexpr (is_var_len) {
         auto qo_cumulative = s.seq_len_qo.cumulative_length;
 
@@ -1138,6 +1197,7 @@ class XeFMHAFwdSplitKVKernel {
         offset_o = s.num_heads_q * s.head_size_vo * num_kv_splits * qo_cumulative[idx_b];
         offset_exp_sums = s.num_heads_q * num_kv_splits * qo_cumulative[idx_b];
         offset_max_logits = s.num_heads_q * num_kv_splits * qo_cumulative[idx_b];
+        lse_q_base = qo_cumulative[idx_b];
 
         // for gqa packing, seq_len_qo must be 1
         seq_len_qo = 1;
@@ -1275,7 +1335,11 @@ class XeFMHAFwdSplitKVKernel {
             head_group_q,
             sinks_per_kv,
             num_kv_splits,
-            is_single_split);
+            is_single_split,
+            p.softmax_lse,
+            p.lse_head_stride,
+            lse_q_base,
+            head_q_start);
       } else {
         epilogue(
             O(_, _, head, idx_kv_split, l_coord),
@@ -1291,7 +1355,11 @@ class XeFMHAFwdSplitKVKernel {
             head_group_q,
             sinks,
             num_kv_splits,
-            is_single_split);
+            is_single_split,
+            p.softmax_lse,
+            p.lse_head_stride,
+            lse_q_base,
+            head_q_start);
       }
     }
   }

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
@@ -222,7 +222,9 @@ class XeFMHAFwdKernel {
         args.kernel.sm_sink,
         args.kernel.skip_batch_mask,
         args.kernel.scale_k_ptr,
-        args.kernel.scale_v_ptr};
+        args.kernel.scale_v_ptr,
+        args.kernel.softmax_lse,
+        args.kernel.lse_head_stride};
     auto scheduler_params =
         TileScheduler::to_underlying_arguments(args.kernel.shape, args.hw_info, TileShapeO{}, sched_num_kv_splits);
     if constexpr (CollectiveMainloop::ScoreBlock2D && StaticScoreMode_ >= 0) {

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_reduce_split_k.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_reduce_split_k.hpp
@@ -219,6 +219,7 @@ class ReduceSplitK {
       const int k_block0 = LocalMask ? cute::max(seq_len_kv - 1 - p.window_size_left, 0) / get<1>(TileShapeQK{}) : 0;
       const int windowed_k_blocks = k_blocks - k_block0;
       int num_blocks_per_split = cute::ceil_div(windowed_k_blocks, num_kv_splits);
+      bool is_single_split = (num_kv_splits > 1) && (windowed_k_blocks < 2);
 
       int offset_o = 0, offset_o_accum = 0;
       int offset_exp_sums = 0, offset_max_logits = 0;
@@ -339,22 +340,14 @@ class ReduceSplitK {
           total_sum += shared_storage.sum_slm_array[sg * intel::sg_size + tid_in_sg];
         }
         O(seq_idx, idx, head_q, l_coord) = static_cast<ElementO>(total_acc / total_sum);
-      }
 
-      // Emit the natural-log LSE for genuinely multi-split sequences. Short
-      // (single-split) sequences store sentinel exp_sums/max_logits (making this
-      // reduction a pass-through), so their LSE is written directly by the split
-      // epilogue instead; skip them here to avoid clobbering with a wrong value.
-      // thr_id == 0 retains a valid global_exp_sums from its idx==0 iteration
-      // (the combined sum is identical across idx).
-      if constexpr (LSE) {
-        constexpr int kMinBlocksForSplit = 128;
-        bool is_single_split = (num_kv_splits > 1) && (windowed_k_blocks < kMinBlocksForSplit);
-        if (!is_single_split && thr_id == 0) {
-          constexpr float kRcpLog2e = 0.6931471805599453f;  // ln(2)
-          float d = float(global_exp_sums);
-          float lse = (d > 0.f) ? (float(global_max_logits) * kRcpLog2e + sycl::log(d)) : -INFINITY;
-          p.softmax_lse[int64_t(head_q) * p.lse_head_stride + (lse_q_base + seq_idx)] = lse;
+        if constexpr (LSE) {
+          if (!is_single_split && idx == 0) {
+            constexpr float kRcpLog2e = 0.6931471805599453f;  // ln(2)
+            float d = float(total_sum);
+            float lse = (d > 0.f) ? (float(global_max_logits) * kRcpLog2e + sycl::log(d)) : -INFINITY;
+            p.softmax_lse[int64_t(head_q) * p.lse_head_stride + (lse_q_base + seq_idx)] = lse;
+          }
         }
       }
     }

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_reduce_split_k.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_reduce_split_k.hpp
@@ -97,6 +97,12 @@ class ReduceSplitK {
     // Per-batch skip mask for two-kernel mix-batch dispatch
     // (see https://github.com/vllm-project/vllm-xpu-kernels/pull/218).
     const bool* skip_batch_mask = nullptr;
+    // Optional softmax LSE output (natural-log log-sum-exp), row-major
+    // (num_heads_q, total_q). Written here only for genuinely multi-split
+    // sequences; single-split LSE is emitted by the split epilogue. Null =>
+    // don't write.
+    float* softmax_lse = nullptr;
+    int64_t lse_head_stride = 0;  // = total_q
   };
   using KernelParams = KernelArguments;
 
@@ -213,6 +219,8 @@ class ReduceSplitK {
 
       int offset_o = 0, offset_o_accum = 0;
       int offset_exp_sums = 0, offset_max_logits = 0;
+      // Query-token index in the (num_heads_q, total_q) softmax_lse output.
+      int lse_q_base = idx_b * seq_len_qo;
 
       if constexpr (is_var_len) {
         auto qo_cumulative = s.seq_len_qo.cumulative_length;
@@ -222,6 +230,7 @@ class ReduceSplitK {
         offset_max_logits = s.num_heads_q * num_kv_splits * qo_cumulative[idx_b];
 
         offset_o = s.num_heads_q * s.head_size_vo * qo_cumulative[idx_b];
+        lse_q_base = qo_cumulative[idx_b];
       }
 
       auto shape_O = make_shape(seq_len_qo, head_size_vo, num_heads_q, batch_dim);
@@ -322,6 +331,21 @@ class ReduceSplitK {
           total_sum += shared_storage.sum_slm_array[sg * intel::sg_size + tid_in_sg];
         }
         O(seq_idx, idx, head_q, l_coord) = static_cast<ElementO>(total_acc / total_sum);
+      }
+
+      // Emit the natural-log LSE for genuinely multi-split sequences. Short
+      // (single-split) sequences store sentinel exp_sums/max_logits (making this
+      // reduction a pass-through), so their LSE is written directly by the split
+      // epilogue instead; skip them here to avoid clobbering with a wrong value.
+      // thr_id == 0 retains a valid global_exp_sums from its idx==0 iteration
+      // (the combined sum is identical across idx).
+      constexpr int kMinBlocksForSplit = 128;
+      bool is_single_split = (num_kv_splits > 1) && (windowed_k_blocks < kMinBlocksForSplit);
+      if (p.softmax_lse != nullptr && !is_single_split && thr_id == 0) {
+        constexpr float kRcpLog2e = 0.6931471805599453f;  // ln(2)
+        float d = float(global_exp_sums);
+        float lse = (d > 0.f) ? (float(global_max_logits) * kRcpLog2e + sycl::log(d)) : -INFINITY;
+        p.softmax_lse[int64_t(head_q) * p.lse_head_stride + (lse_q_base + seq_idx)] = lse;
       }
     }
   }

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_reduce_split_k.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_reduce_split_k.hpp
@@ -71,6 +71,9 @@ class ReduceSplitK {
 
   using ElementLSE = typename FMHAKernel_::ElementLSE;
 
+  // Whether the split kernel emits softmax log-sum-exp.
+  static constexpr bool LSE = FMHAKernel_::LSE;
+
   using SGPerWG = typename FMHAKernel_::SGPerWG;
 
   // num values (head_dim) processed by each thread
@@ -220,7 +223,10 @@ class ReduceSplitK {
       int offset_o = 0, offset_o_accum = 0;
       int offset_exp_sums = 0, offset_max_logits = 0;
       // Query-token index in the (num_heads_q, total_q) softmax_lse output.
-      int lse_q_base = idx_b * seq_len_qo;
+      int lse_q_base = 0;
+      if constexpr (LSE) {
+        lse_q_base = idx_b * seq_len_qo;
+      }
 
       if constexpr (is_var_len) {
         auto qo_cumulative = s.seq_len_qo.cumulative_length;
@@ -230,7 +236,9 @@ class ReduceSplitK {
         offset_max_logits = s.num_heads_q * num_kv_splits * qo_cumulative[idx_b];
 
         offset_o = s.num_heads_q * s.head_size_vo * qo_cumulative[idx_b];
-        lse_q_base = qo_cumulative[idx_b];
+        if constexpr (LSE) {
+          lse_q_base = qo_cumulative[idx_b];
+        }
       }
 
       auto shape_O = make_shape(seq_len_qo, head_size_vo, num_heads_q, batch_dim);
@@ -339,13 +347,15 @@ class ReduceSplitK {
       // epilogue instead; skip them here to avoid clobbering with a wrong value.
       // thr_id == 0 retains a valid global_exp_sums from its idx==0 iteration
       // (the combined sum is identical across idx).
-      constexpr int kMinBlocksForSplit = 128;
-      bool is_single_split = (num_kv_splits > 1) && (windowed_k_blocks < kMinBlocksForSplit);
-      if (p.softmax_lse != nullptr && !is_single_split && thr_id == 0) {
-        constexpr float kRcpLog2e = 0.6931471805599453f;  // ln(2)
-        float d = float(global_exp_sums);
-        float lse = (d > 0.f) ? (float(global_max_logits) * kRcpLog2e + sycl::log(d)) : -INFINITY;
-        p.softmax_lse[int64_t(head_q) * p.lse_head_stride + (lse_q_base + seq_idx)] = lse;
+      if constexpr (LSE) {
+        constexpr int kMinBlocksForSplit = 128;
+        bool is_single_split = (num_kv_splits > 1) && (windowed_k_blocks < kMinBlocksForSplit);
+        if (!is_single_split && thr_id == 0) {
+          constexpr float kRcpLog2e = 0.6931471805599453f;  // ln(2)
+          float d = float(global_exp_sums);
+          float lse = (d > 0.f) ? (float(global_max_logits) * kRcpLog2e + sycl::log(d)) : -INFINITY;
+          p.softmax_lse[int64_t(head_q) * p.lse_head_stride + (lse_q_base + seq_idx)] = lse;
+        }
       }
     }
   }

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_reduce_split_k.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_reduce_split_k.hpp
@@ -71,6 +71,9 @@ class ReduceSplitK {
 
   using ElementLSE = typename FMHAKernel_::ElementLSE;
 
+  // Whether the split kernel emits softmax log-sum-exp.
+  static constexpr bool LSE = FMHAKernel_::LSE;
+
   using SGPerWG = typename FMHAKernel_::SGPerWG;
 
   // num values (head_dim) processed by each thread
@@ -218,7 +221,10 @@ class ReduceSplitK {
       int offset_o = 0, offset_o_accum = 0;
       int offset_exp_sums = 0, offset_max_logits = 0;
       // Query-token index in the (num_heads_q, total_q) softmax_lse output.
-      int lse_q_base = idx_b * seq_len_qo;
+      int lse_q_base = 0;
+      if constexpr (LSE) {
+        lse_q_base = idx_b * seq_len_qo;
+      }
 
       if constexpr (is_var_len) {
         auto qo_cumulative = s.seq_len_qo.cumulative_length;
@@ -228,7 +234,9 @@ class ReduceSplitK {
         offset_max_logits = s.num_heads_q * num_kv_splits * qo_cumulative[idx_b];
 
         offset_o = s.num_heads_q * s.head_size_vo * qo_cumulative[idx_b];
-        lse_q_base = qo_cumulative[idx_b];
+        if constexpr (LSE) {
+          lse_q_base = qo_cumulative[idx_b];
+        }
       }
 
       auto shape_O = make_shape(seq_len_qo, head_size_vo, num_heads_q, batch_dim);
@@ -318,13 +326,15 @@ class ReduceSplitK {
       // epilogue instead; skip them here to avoid clobbering with a wrong value.
       // thr_id == 0 retains a valid global_exp_sums from its idx==0 iteration
       // (the combined sum is identical across idx).
-      constexpr int kMinBlocksForSplit = 128;
-      bool is_single_split = (num_kv_splits > 1) && (windowed_k_blocks < kMinBlocksForSplit);
-      if (p.softmax_lse != nullptr && !is_single_split && thr_id == 0) {
-        constexpr float kRcpLog2e = 0.6931471805599453f;  // ln(2)
-        float d = float(global_exp_sums);
-        float lse = (d > 0.f) ? (float(global_max_logits) * kRcpLog2e + sycl::log(d)) : -INFINITY;
-        p.softmax_lse[int64_t(head_q) * p.lse_head_stride + (lse_q_base + seq_idx)] = lse;
+      if constexpr (LSE) {
+        constexpr int kMinBlocksForSplit = 128;
+        bool is_single_split = (num_kv_splits > 1) && (windowed_k_blocks < kMinBlocksForSplit);
+        if (!is_single_split && thr_id == 0) {
+          constexpr float kRcpLog2e = 0.6931471805599453f;  // ln(2)
+          float d = float(global_exp_sums);
+          float lse = (d > 0.f) ? (float(global_max_logits) * kRcpLog2e + sycl::log(d)) : -INFINITY;
+          p.softmax_lse[int64_t(head_q) * p.lse_head_stride + (lse_q_base + seq_idx)] = lse;
+        }
       }
     }
   }

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_reduce_split_k.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_reduce_split_k.hpp
@@ -97,6 +97,12 @@ class ReduceSplitK {
     // Per-batch skip mask for two-kernel mix-batch dispatch
     // (see https://github.com/vllm-project/vllm-xpu-kernels/pull/218).
     const bool* skip_batch_mask = nullptr;
+    // Optional softmax LSE output (natural-log log-sum-exp), row-major
+    // (num_heads_q, total_q). Written here only for genuinely multi-split
+    // sequences; single-split LSE is emitted by the split epilogue. Null =>
+    // don't write.
+    float* softmax_lse = nullptr;
+    int64_t lse_head_stride = 0;  // = total_q
   };
   using KernelParams = KernelArguments;
 
@@ -211,6 +217,8 @@ class ReduceSplitK {
 
       int offset_o = 0, offset_o_accum = 0;
       int offset_exp_sums = 0, offset_max_logits = 0;
+      // Query-token index in the (num_heads_q, total_q) softmax_lse output.
+      int lse_q_base = idx_b * seq_len_qo;
 
       if constexpr (is_var_len) {
         auto qo_cumulative = s.seq_len_qo.cumulative_length;
@@ -220,6 +228,7 @@ class ReduceSplitK {
         offset_max_logits = s.num_heads_q * num_kv_splits * qo_cumulative[idx_b];
 
         offset_o = s.num_heads_q * s.head_size_vo * qo_cumulative[idx_b];
+        lse_q_base = qo_cumulative[idx_b];
       }
 
       auto shape_O = make_shape(seq_len_qo, head_size_vo, num_heads_q, batch_dim);
@@ -301,6 +310,21 @@ class ReduceSplitK {
 
         acc *= inv_global_exp_sums;
         O(seq_idx, idx, head_q, l_coord) = static_cast<ElementO>(acc);
+      }
+
+      // Emit the natural-log LSE for genuinely multi-split sequences. Short
+      // (single-split) sequences store sentinel exp_sums/max_logits (making this
+      // reduction a pass-through), so their LSE is written directly by the split
+      // epilogue instead; skip them here to avoid clobbering with a wrong value.
+      // thr_id == 0 retains a valid global_exp_sums from its idx==0 iteration
+      // (the combined sum is identical across idx).
+      constexpr int kMinBlocksForSplit = 128;
+      bool is_single_split = (num_kv_splits > 1) && (windowed_k_blocks < kMinBlocksForSplit);
+      if (p.softmax_lse != nullptr && !is_single_split && thr_id == 0) {
+        constexpr float kRcpLog2e = 0.6931471805599453f;  // ln(2)
+        float d = float(global_exp_sums);
+        float lse = (d > 0.f) ? (float(global_max_logits) * kRcpLog2e + sycl::log(d)) : -INFINITY;
+        p.softmax_lse[int64_t(head_q) * p.lse_head_stride + (lse_q_base + seq_idx)] = lse;
       }
     }
   }

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_fp8_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_fp8_kernel.cpp.in
@@ -35,11 +35,11 @@ __attribute__((visibility("default"))) void FmhaDecodeFp8Runner<@QG_SZ@, @HEAD_D
     using QElement = @ELEM_TYPE@;
     if (params.is_e4m3) {
       DecodeConfig<
-          false, LocalMask, false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 1, false,
+          false, LocalMask, false, /*LSE=*/false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 1, false,
           QElement, cutlass::float_e4m3_t, cutlass::float_e4m3_t, QElement>::run_paged(params);
     } else {
       DecodeConfig<
-          false, LocalMask, false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 1, false,
+          false, LocalMask, false, /*LSE=*/false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 1, false,
           QElement, cutlass::float_e5m2_t, cutlass::float_e5m2_t, QElement>::run_paged(params);
     }
   });

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_fp8_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_fp8_kernel.cpp.in
@@ -30,11 +30,11 @@ __attribute__((visibility("default"))) void FmhaDecodeFp8Runner<@QG_SZ@, @HEAD_D
     using QElement = cutlass::bfloat16_t;
     if (params.is_e4m3) {
       DecodeConfig<
-          false, LocalMask, false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 1, false,
+          false, LocalMask, false, /*LSE=*/false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 1, false,
           QElement, cutlass::float_e4m3_t, cutlass::float_e4m3_t, QElement>::run_paged(params);
     } else {
       DecodeConfig<
-          false, LocalMask, false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 1, false,
+          false, LocalMask, false, /*LSE=*/false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 1, false,
           QElement, cutlass::float_e5m2_t, cutlass::float_e5m2_t, QElement>::run_paged(params);
     }
   });

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_kernel.cpp.in
@@ -61,7 +61,7 @@ __attribute__((visibility("default"))) void FmhaDecodeRunner<@QG_SZ@, @HEAD_DIM@
     TORCH_CHECK(
         !params.is_local && !params.use_sink,
         "return_softmax_lse is only supported without local/sink masking");
-    using Element = bfloat16_t;
+    using Element = @ELEM_TYPE@;
     DecodeConfig<
         false,
         false,
@@ -77,7 +77,8 @@ __attribute__((visibility("default"))) void FmhaDecodeRunner<@QG_SZ@, @HEAD_DIM@
         Element,
         Element,
         Element,
-        Element>::run_paged(params);
+        Element,
+        /*PackGQAEnabled=*/false>::run_paged(params);
     return;
   }
 

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_kernel.cpp.in
@@ -53,6 +53,34 @@ __attribute__((visibility("default"))) void FmhaDecodeRunner<@QG_SZ@, @HEAD_DIM@
       @PAGE_SIZE@ / 16, @QG_SZ@, ((@HEAD_DIM@ + 31) / 32) * 32);
   using SubgroupLayoutQK = cute::Layout<cute::Shape<cute::_1, cute::Int<kKvSubgroups>, cute::_1>>;
 
+  // softmax_lse output is only threaded as a template constexpr for the base
+  // (non-local / non-sink) configuration, matching the paged cascade-attention
+  // decode use case. All other mask combinations keep the always-off LSE path
+  // (LSE is not written).
+  if (params.return_softmax_lse) {
+    TORCH_CHECK(
+        !params.is_local && !params.use_sink,
+        "return_softmax_lse is only supported without local/sink masking");
+    using Element = bfloat16_t;
+    DecodeConfig<
+        false,
+        false,
+        false,
+        /*LSE=*/true,
+        TileShapeQK,
+        TileShapePV,
+        TileShapeOutput,
+        SubgroupLayoutQK,
+        void,
+        1,
+        false,
+        Element,
+        Element,
+        Element,
+        Element>::run_paged(params);
+    return;
+  }
+
 #if @HEAD_DIM@ == 64
     AT_DISPATCH_BOOL_NO_RETURN(params.use_sink, Sink, {
       AT_DISPATCH_BOOL_NO_RETURN(params.is_local, LocalMask, {
@@ -61,6 +89,7 @@ __attribute__((visibility("default"))) void FmhaDecodeRunner<@QG_SZ@, @HEAD_DIM@
               false,
               LocalMask,
               Sink,
+              /*LSE=*/false,
               TileShapeQK,
               TileShapePV,
               TileShapeOutput,
@@ -84,6 +113,7 @@ __attribute__((visibility("default"))) void FmhaDecodeRunner<@QG_SZ@, @HEAD_DIM@
             false,
             LocalMask,
             false,
+            /*LSE=*/false,
             TileShapeQK,
             TileShapePV,
             TileShapeOutput,

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_kernel.cpp.in
@@ -48,6 +48,34 @@ __attribute__((visibility("default"))) void FmhaDecodeRunner<@QG_SZ@, @HEAD_DIM@
   using TileShapeOutput = cute::Shape<cute::Int<@QG_SZ@>, cute::Int<((@HEAD_DIM@ + 31) / 32) * 32>>;
   using SubgroupLayoutQK = cute::Layout<cute::Shape<cute::_1, cute::Int<@PAGE_SIZE@ / 16>, cute::_1>>;
 
+  // softmax_lse output is only threaded as a template constexpr for the base
+  // (non-local / non-sink) configuration, matching the paged cascade-attention
+  // decode use case. All other mask combinations keep the always-off LSE path
+  // (LSE is not written).
+  if (params.return_softmax_lse) {
+    TORCH_CHECK(
+        !params.is_local && !params.use_sink,
+        "return_softmax_lse is only supported without local/sink masking");
+    using Element = bfloat16_t;
+    DecodeConfig<
+        false,
+        false,
+        false,
+        /*LSE=*/true,
+        TileShapeQK,
+        TileShapePV,
+        TileShapeOutput,
+        SubgroupLayoutQK,
+        void,
+        1,
+        false,
+        Element,
+        Element,
+        Element,
+        Element>::run_paged(params);
+    return;
+  }
+
 #if @HEAD_DIM@ == 64
     AT_DISPATCH_BOOL_NO_RETURN(params.use_sink, Sink, {
       AT_DISPATCH_BOOL_NO_RETURN(params.is_local, LocalMask, {
@@ -56,6 +84,7 @@ __attribute__((visibility("default"))) void FmhaDecodeRunner<@QG_SZ@, @HEAD_DIM@
               false,
               LocalMask,
               Sink,
+              /*LSE=*/false,
               TileShapeQK,
               TileShapePV,
               TileShapeOutput,
@@ -79,6 +108,7 @@ __attribute__((visibility("default"))) void FmhaDecodeRunner<@QG_SZ@, @HEAD_DIM@
             false,
             LocalMask,
             false,
+            /*LSE=*/false,
             TileShapeQK,
             TileShapePV,
             TileShapeOutput,

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_nopage_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_nopage_kernel.cpp.in
@@ -60,6 +60,35 @@ __attribute__((visibility("default"))) void FmhaDecodeNpRunner<@QG_SZ@, @HEAD_DI
   static constexpr int kKvSubgroups_NP = kv_subgroups_for_slm(
       @TILED_KV_NP@ / 16, @QG_SZ@, ((@HEAD_DIM@ + 31) / 32) * 32);
   using SubgroupLayoutQK_NP = cute::Layout<cute::Shape<cute::_1, cute::Int<kKvSubgroups_NP>, cute::_1>>;
+
+  // softmax_lse output is only threaded as a template constexpr for the base
+  // (non-local / non-sink) configuration, mirroring the paged decode path. It is
+  // used by the cascade tree-verify "expand" pass, which runs the non-paged
+  // decode kernel over a dense ragged branch-KV buffer and needs the LSE to
+  // merge with the paged prefix pass.
+  if (params.return_softmax_lse) {
+    TORCH_CHECK(
+        !params.is_local && !params.use_sink,
+        "return_softmax_lse is only supported without local/sink masking");
+    using Element = bfloat16_t;
+    DecodeConfig<
+        false,
+        false,
+        false,
+        /*LSE=*/true,
+        TileShapeQK_NP,
+        TileShapePV_NP,
+        TileShapeOutput_NP,
+        SubgroupLayoutQK_NP,
+        void,
+        1,
+        false,
+        Element,
+        Element,
+        Element,
+        Element>::run_nopaged(params);
+    return;
+  }
   // No sink support for no_page path; always use Sink=false
   AT_DISPATCH_BOOL_NO_RETURN(params.is_local, LocalMask, {
     using Element = @ELEM_TYPE@;
@@ -67,6 +96,7 @@ __attribute__((visibility("default"))) void FmhaDecodeNpRunner<@QG_SZ@, @HEAD_DI
         false,
         LocalMask,
         false,
+        /*LSE=*/false,
         TileShapeQK_NP,
         TileShapePV_NP,
         TileShapeOutput_NP,

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_nopage_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_nopage_kernel.cpp.in
@@ -55,6 +55,34 @@ __attribute__((visibility("default"))) void FmhaDecodeNpRunner<@QG_SZ@, @HEAD_DI
   using TileShapePV_NP = cute::Shape<cute::Int<@QG_SZ@>, cute::_32, cute::Int<@TILED_KV_NP@>>;
   using TileShapeOutput_NP = cute::Shape<cute::Int<@QG_SZ@>, cute::Int<((@HEAD_DIM@ + 31) / 32) * 32>>;
   using SubgroupLayoutQK_NP = cute::Layout<cute::Shape<cute::_1, cute::Int<@TILED_KV_NP@ / 16>, cute::_1>>;
+  // softmax_lse output is only threaded as a template constexpr for the base
+  // (non-local / non-sink) configuration, mirroring the paged decode path. It is
+  // used by the cascade tree-verify "expand" pass, which runs the non-paged
+  // decode kernel over a dense ragged branch-KV buffer and needs the LSE to
+  // merge with the paged prefix pass.
+  if (params.return_softmax_lse) {
+    TORCH_CHECK(
+        !params.is_local && !params.use_sink,
+        "return_softmax_lse is only supported without local/sink masking");
+    using Element = bfloat16_t;
+    DecodeConfig<
+        false,
+        false,
+        false,
+        /*LSE=*/true,
+        TileShapeQK_NP,
+        TileShapePV_NP,
+        TileShapeOutput_NP,
+        SubgroupLayoutQK_NP,
+        void,
+        1,
+        false,
+        Element,
+        Element,
+        Element,
+        Element>::run_nopaged(params);
+    return;
+  }
   // No sink support for no_page path; always use Sink=false
   AT_DISPATCH_BOOL_NO_RETURN(params.is_local, LocalMask, {
     using Element = bfloat16_t;
@@ -62,6 +90,7 @@ __attribute__((visibility("default"))) void FmhaDecodeNpRunner<@QG_SZ@, @HEAD_DI
         false,
         LocalMask,
         false,
+        /*LSE=*/false,
         TileShapeQK_NP,
         TileShapePV_NP,
         TileShapeOutput_NP,

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_nopage_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_nopage_kernel.cpp.in
@@ -70,7 +70,7 @@ __attribute__((visibility("default"))) void FmhaDecodeNpRunner<@QG_SZ@, @HEAD_DI
     TORCH_CHECK(
         !params.is_local && !params.use_sink,
         "return_softmax_lse is only supported without local/sink masking");
-    using Element = bfloat16_t;
+    using Element = @ELEM_TYPE@;
     DecodeConfig<
         false,
         false,

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
@@ -373,6 +373,8 @@ struct DecodeRunner {
             static_cast<const bool*>(params.skip_batch_mask_ptr),
             params.k_scale_ptr,
             params.v_scale_ptr,
+            static_cast<float*>(params.softmax_lse_ptr),
+            static_cast<int64_t>(params.total_q),
         },
         {params.softmax_scale,
          params.page_table,
@@ -543,6 +545,8 @@ struct SplitDecodeKernelRunner {
             static_cast<const bool*>(params.skip_batch_mask_ptr),
             params.k_scale_ptr,
             params.v_scale_ptr,
+            static_cast<float*>(params.softmax_lse_ptr),
+            static_cast<int64_t>(params.total_q),
         },
         {params.softmax_scale,
          static_cast<int*>(params.page_table),
@@ -566,7 +570,9 @@ struct SplitDecodeKernelRunner {
          reinterpret_cast<ElementLSE*>(params.max_logits_ptr),
          stride_max_logits,
          params.window_size_left,
-         static_cast<const bool*>(params.skip_batch_mask_ptr)},
+         static_cast<const bool*>(params.skip_batch_mask_ptr),
+         static_cast<float*>(params.softmax_lse_ptr),
+         static_cast<int64_t>(params.total_q)},
         hw_info,
         params.num_kv_splits};
 

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
@@ -131,8 +131,8 @@ struct Arguments {
   bool use_sink = false;
   bool is_causal = false;
   bool is_local = false;
-  // When false, the epilogue skips writing softmax_lse (paged bf16 only; other
-  // paths always write). Threaded as a template constexpr via DecodeConfig.
+  // When false, the epilogue skips writing softmax_lse. Threaded as a template
+  // constexpr via DecodeConfig.
   bool return_softmax_lse = false;
 
   // The O matrix (output).
@@ -548,6 +548,7 @@ struct SplitDecodeKernelRunner {
             static_cast<const bool*>(params.skip_batch_mask_ptr),
             params.k_scale_ptr,
             params.v_scale_ptr,
+            /*min_blocks_for_split=*/2,
             static_cast<float*>(params.softmax_lse_ptr),
             static_cast<int64_t>(params.total_q),
         },
@@ -644,6 +645,7 @@ template <
     typename ElementK = bfloat16_t,
     typename ElementV = bfloat16_t,
     typename ElementO = bfloat16_t,
+    bool PackGQAEnabled = true,
     typename MMAOperation_ = void, /* void -> default */
     typename StrideQ = Stride<int, _1, int, int>,
     typename StrideK = Stride<int, _1, int, int>,
@@ -709,7 +711,7 @@ struct DecodeConfig {
 #ifdef SGL_DISABLE_PACKGQA
     constexpr bool PackGQA = false;
 #else
-    constexpr bool PackGQA = true;
+    constexpr bool PackGQA = PackGQAEnabled;
 #endif
 
     // Mainloop
@@ -782,6 +784,7 @@ template <
     bool Causal,
     bool LocalMask,
     bool Sink,
+    bool LSE,
     typename TileShapeQK,
     typename TileShapePV,
     typename TileShapeOutput,
@@ -857,7 +860,7 @@ struct SplitDecodeConfig {
 
     // Epilogue
     using CollectiveEpilogue = cutlass::fmha::collective::
-        DecodeFwdEpilogue<CollectiveMainloop, TileShapeOutput, TensorO, TensorLSE, void, Sink>;
+        DecodeFwdEpilogue<CollectiveMainloop, TileShapeOutput, TensorO, TensorLSE, void, Sink, LSE>;
 
     using FMHAKernel = cutlass::fmha::kernel::
         XeFMHAFwdSplitKVKernel<ProblemShapeType, CollectiveMainloop, CollectiveEpilogue, Scheduler>;

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
@@ -90,6 +90,9 @@ struct Arguments {
   bool use_sink = false;
   bool is_causal = false;
   bool is_local = false;
+  // When false, the epilogue skips writing softmax_lse (paged bf16 only; other
+  // paths always write). Threaded as a template constexpr via DecodeConfig.
+  bool return_softmax_lse = false;
 
   // The O matrix (output).
   void* __restrict__ o_ptr;
@@ -566,6 +569,7 @@ template <
     bool Causal,
     bool LocalMask,
     bool Sink,
+    bool LSE,
     typename TileShapeQK,
     typename TileShapePV,
     typename TileShapeOutput,
@@ -670,7 +674,7 @@ struct DecodeConfig {
 
     // Epilogue
     using CollectiveEpilogue = cutlass::fmha::collective::
-        FMHAFwdEpilogue<CollectiveMainloop, TileShapeOutput, TensorO, GmemTiledCopyO, Sink, PackGQA>;
+        FMHAFwdEpilogue<CollectiveMainloop, TileShapeOutput, TensorO, GmemTiledCopyO, Sink, PackGQA, LSE>;
 
     static_assert(!(persistent & Causal), "persistent SDPA kernel not support Causal yet");
     using FMHADecodeKernel = conditional_t<

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
@@ -131,6 +131,9 @@ struct Arguments {
   bool use_sink = false;
   bool is_causal = false;
   bool is_local = false;
+  // When false, the epilogue skips writing softmax_lse (paged bf16 only; other
+  // paths always write). Threaded as a template constexpr via DecodeConfig.
+  bool return_softmax_lse = false;
 
   // The O matrix (output).
   void* __restrict__ o_ptr;
@@ -629,6 +632,7 @@ template <
     bool Causal,
     bool LocalMask,
     bool Sink,
+    bool LSE,
     typename TileShapeQK,
     typename TileShapePV,
     typename TileShapeOutput,
@@ -733,7 +737,7 @@ struct DecodeConfig {
 
     // Epilogue
     using CollectiveEpilogue = cutlass::fmha::collective::
-        FMHAFwdEpilogue<CollectiveMainloop, TileShapeOutput, TensorO, GmemTiledCopyO, Sink, PackGQA>;
+        FMHAFwdEpilogue<CollectiveMainloop, TileShapeOutput, TensorO, GmemTiledCopyO, Sink, PackGQA, LSE>;
 
     static_assert(!(persistent & Causal), "persistent SDPA kernel not support Causal yet");
     using FMHADecodeKernel = conditional_t<

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
@@ -327,6 +327,8 @@ struct DecodeRunner {
             static_cast<const bool*>(params.skip_batch_mask_ptr),
             params.k_scale_ptr,
             params.v_scale_ptr,
+            static_cast<float*>(params.softmax_lse_ptr),
+            static_cast<int64_t>(params.total_q),
         },
         {params.softmax_scale,
          params.page_table,
@@ -490,6 +492,8 @@ struct SplitDecodeKernelRunner {
             static_cast<const bool*>(params.skip_batch_mask_ptr),
             params.k_scale_ptr,
             params.v_scale_ptr,
+            static_cast<float*>(params.softmax_lse_ptr),
+            static_cast<int64_t>(params.total_q),
         },
         {params.softmax_scale,
          static_cast<int*>(params.page_table),
@@ -513,7 +517,9 @@ struct SplitDecodeKernelRunner {
          reinterpret_cast<ElementLSE*>(params.max_logits_ptr),
          stride_max_logits,
          params.window_size_left,
-         static_cast<const bool*>(params.skip_batch_mask_ptr)},
+         static_cast<const bool*>(params.skip_batch_mask_ptr),
+         static_cast<float*>(params.softmax_lse_ptr),
+         static_cast<int64_t>(params.total_q)},
         hw_info,
         params.num_kv_splits};
 

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_fp8_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_fp8_kernel.cpp.in
@@ -33,11 +33,11 @@ __attribute__((visibility("default"))) void FmhaPrefillFp8Runner<@HEAD_DIM@, @EL
       using QElement = @ELEM_TYPE@;
       if (params.is_e4m3) {
         FMHAConfig<
-            Causal, LocalMask, false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 2, false,
+            Causal, LocalMask, false, /*LSE=*/false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 2, false,
             QElement, cutlass::float_e4m3_t, cutlass::float_e4m3_t, QElement>::run_paged(params);
       } else {
         FMHAConfig<
-            Causal, LocalMask, false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 2, false,
+            Causal, LocalMask, false, /*LSE=*/false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 2, false,
             QElement, cutlass::float_e5m2_t, cutlass::float_e5m2_t, QElement>::run_paged(params);
       }
     });

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_fp8_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_fp8_kernel.cpp.in
@@ -33,11 +33,11 @@ __attribute__((visibility("default"))) void FmhaPrefillFp8Runner<@HEAD_DIM@>::op
       using QElement = cutlass::bfloat16_t;
       if (params.is_e4m3) {
         FMHAConfig<
-            Causal, LocalMask, false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 2, false,
+            Causal, LocalMask, false, /*LSE=*/false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 2, false,
             QElement, cutlass::float_e4m3_t, cutlass::float_e4m3_t, QElement>::run_paged(params);
       } else {
         FMHAConfig<
-            Causal, LocalMask, false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 2, false,
+            Causal, LocalMask, false, /*LSE=*/false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 2, false,
             QElement, cutlass::float_e5m2_t, cutlass::float_e5m2_t, QElement>::run_paged(params);
       }
     });

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_kernel.cpp.in
@@ -49,6 +49,34 @@ __attribute__((visibility("default"))) void FmhaPrefillRunner<@HEAD_DIM@>::opera
   using SubgroupLayoutQK =
       cute::Layout<cute::Shape<cute::Int<@NUM_SG@>, cute::_1, cute::_1>, cute::Stride<cute::_1, cute::_1, cute::_1>>;
 
+  // softmax_lse output is only threaded as a template constexpr for the base
+  // (non-causal / non-local / non-sink) configuration, matching the paged
+  // cascade-attention use case. All other mask combinations keep the always-off
+  // LSE path (LSE is not written).
+  if (params.return_softmax_lse) {
+    TORCH_CHECK(
+        !params.is_causal && !params.is_local && !use_sink,
+        "return_softmax_lse is only supported without causal/local/sink masking");
+    using Element = bfloat16_t;
+    FMHAConfig<
+        false,
+        false,
+        false,
+        /*LSE=*/true,
+        TileShapeQK,
+        TileShapePV,
+        TileShapeOutput,
+        SubgroupLayoutQK,
+        void,
+        2,
+        false,
+        Element,
+        Element,
+        Element,
+        Element>::run_paged(params);
+    return;
+  }
+
 #if @HEAD_DIM@ == 64
   AT_DISPATCH_BOOL_NO_RETURN(use_sink, Sink, {
     AT_DISPATCH_BOOL_NO_RETURN(params.is_local, LocalMask, {
@@ -59,6 +87,7 @@ __attribute__((visibility("default"))) void FmhaPrefillRunner<@HEAD_DIM@>::opera
               Causal,
               LocalMask,
               Sink,
+              /*LSE=*/false,
               TileShapeQK,
               TileShapePV,
               TileShapeOutput,
@@ -85,6 +114,7 @@ __attribute__((visibility("default"))) void FmhaPrefillRunner<@HEAD_DIM@>::opera
             Causal,
             LocalMask,
             false,
+            /*LSE=*/false,
             TileShapeQK,
             TileShapePV,
             TileShapeOutput,

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_kernel.cpp.in
@@ -53,6 +53,34 @@ __attribute__((visibility("default"))) void FmhaPrefillRunner<@HEAD_DIM@, @ELEM_
   using SubgroupLayoutQK =
       cute::Layout<cute::Shape<cute::Int<@NUM_SG@>, cute::_1, cute::_1>, cute::Stride<cute::_1, cute::_1, cute::_1>>;
 
+  // softmax_lse output is only threaded as a template constexpr for the base
+  // (non-causal / non-local / non-sink) configuration, matching the paged
+  // cascade-attention use case. All other mask combinations keep the always-off
+  // LSE path (LSE is not written).
+  if (params.return_softmax_lse) {
+    TORCH_CHECK(
+        !params.is_causal && !params.is_local && !use_sink,
+        "return_softmax_lse is only supported without causal/local/sink masking");
+    using Element = bfloat16_t;
+    FMHAConfig<
+        false,
+        false,
+        false,
+        /*LSE=*/true,
+        TileShapeQK,
+        TileShapePV,
+        TileShapeOutput,
+        SubgroupLayoutQK,
+        void,
+        2,
+        false,
+        Element,
+        Element,
+        Element,
+        Element>::run_paged(params);
+    return;
+  }
+
 #if @HEAD_DIM@ == 64
   AT_DISPATCH_BOOL_NO_RETURN(use_sink, Sink, {
     AT_DISPATCH_BOOL_NO_RETURN(params.is_local, LocalMask, {
@@ -63,6 +91,7 @@ __attribute__((visibility("default"))) void FmhaPrefillRunner<@HEAD_DIM@, @ELEM_
               Causal,
               LocalMask,
               Sink,
+              /*LSE=*/false,
               TileShapeQK,
               TileShapePV,
               TileShapeOutput,
@@ -89,6 +118,7 @@ __attribute__((visibility("default"))) void FmhaPrefillRunner<@HEAD_DIM@, @ELEM_
             Causal,
             LocalMask,
             false,
+            /*LSE=*/false,
             TileShapeQK,
             TileShapePV,
             TileShapeOutput,

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_kernel.cpp.in
@@ -61,7 +61,7 @@ __attribute__((visibility("default"))) void FmhaPrefillRunner<@HEAD_DIM@, @ELEM_
     TORCH_CHECK(
         !params.is_causal && !params.is_local && !use_sink,
         "return_softmax_lse is only supported without causal/local/sink masking");
-    using Element = bfloat16_t;
+    using Element = @ELEM_TYPE@;
     FMHAConfig<
         false,
         false,

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_nopage_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_nopage_kernel.cpp.in
@@ -66,6 +66,7 @@ __attribute__((visibility("default"))) void FmhaPrefillNpRunner<@HEAD_DIM@, @ELE
           Causal,
           LocalMask,
           false,
+          /*LSE=*/false,
           TileShapeQK,
           TileShapePV,
           TileShapeOutput,

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_nopage_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_nopage_kernel.cpp.in
@@ -62,6 +62,7 @@ __attribute__((visibility("default"))) void FmhaPrefillNpRunner<@HEAD_DIM@>::ope
           Causal,
           LocalMask,
           false,
+          /*LSE=*/false,
           TileShapeQK,
           TileShapePV,
           TileShapeOutput,

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -177,8 +177,8 @@ struct Arguments {
   bool is_e5m2 = false;
   bool is_causal;
   bool is_local;
-  // When false, the epilogue skips writing softmax_lse (paged bf16 only; other
-  // paths always write). Threaded as a template constexpr via FMHAConfig.
+  // When false, the epilogue skips writing softmax_lse. Threaded as a template
+  // constexpr via FMHAConfig.
   bool return_softmax_lse = false;
 
   bool is_rotary_interleaved;

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -177,6 +177,9 @@ struct Arguments {
   bool is_e5m2 = false;
   bool is_causal;
   bool is_local;
+  // When false, the epilogue skips writing softmax_lse (paged bf16 only; other
+  // paths always write). Threaded as a template constexpr via FMHAConfig.
+  bool return_softmax_lse = false;
 
   bool is_rotary_interleaved;
 
@@ -423,6 +426,7 @@ template <
     bool Causal,
     bool LocalMask,
     bool Sink,
+    bool LSE,
     typename TileShapeQK,
     typename TileShapePV,
     typename TileShapeOutput,
@@ -510,8 +514,8 @@ struct FMHAConfig {
         LocalMask>;
 
     // Epilogue
-    using CollectiveEpilogue =
-        cutlass::fmha::collective::FMHAFwdEpilogue<CollectiveMainloop, TileShapeOutput, TensorO, GmemTiledCopyO, Sink>;
+    using CollectiveEpilogue = cutlass::fmha::collective::
+        FMHAFwdEpilogue<CollectiveMainloop, TileShapeOutput, TensorO, GmemTiledCopyO, Sink, /*PackGQA*/ false, LSE>;
 
     static_assert(!(persistent & Causal), "persistent SDPA kernel not support Causal yet");
     using FMHAPrefillKernel = conditional_t<

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -343,6 +343,8 @@ struct PrefillRunner {
             static_cast<const bool*>(params.skip_batch_mask_ptr),
             params.k_scale_ptr,
             params.v_scale_ptr,
+            static_cast<float*>(params.softmax_lse_ptr),
+            static_cast<int64_t>(params.total_q),
         },
         {
             params.softmax_scale,

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -312,6 +312,8 @@ struct PrefillRunner {
             static_cast<const bool*>(params.skip_batch_mask_ptr),
             params.k_scale_ptr,
             params.v_scale_ptr,
+            static_cast<float*>(params.softmax_lse_ptr),
+            static_cast<int64_t>(params.total_q),
         },
         {
             params.softmax_scale,

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -174,6 +174,9 @@ struct Arguments {
   bool is_e5m2 = false;
   bool is_causal;
   bool is_local;
+  // When false, the epilogue skips writing softmax_lse (paged bf16 only; other
+  // paths always write). Threaded as a template constexpr via FMHAConfig.
+  bool return_softmax_lse = false;
 
   bool is_rotary_interleaved;
 
@@ -349,6 +352,7 @@ template <
     bool Causal,
     bool LocalMask,
     bool Sink,
+    bool LSE,
     typename TileShapeQK,
     typename TileShapePV,
     typename TileShapeOutput,
@@ -436,8 +440,8 @@ struct FMHAConfig {
         LocalMask>;
 
     // Epilogue
-    using CollectiveEpilogue =
-        cutlass::fmha::collective::FMHAFwdEpilogue<CollectiveMainloop, TileShapeOutput, TensorO, GmemTiledCopyO, Sink>;
+    using CollectiveEpilogue = cutlass::fmha::collective::
+        FMHAFwdEpilogue<CollectiveMainloop, TileShapeOutput, TensorO, GmemTiledCopyO, Sink, /*PackGQA*/ false, LSE>;
 
     static_assert(!(persistent & Causal), "persistent SDPA kernel not support Causal yet");
     using FMHAPrefillKernel = conditional_t<

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_split_decode_fp8_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_split_decode_fp8_kernel.cpp.in
@@ -37,11 +37,11 @@ __attribute__((visibility("default"))) void FmhaSplitDecodeFp8Runner<@QG_SZ@, @H
     using QElement = @ELEM_TYPE@;
     if (params.is_e4m3) {
       SplitDecodeConfig<
-          false, LocalMask, false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 1,
+          false, LocalMask, false, /*LSE=*/false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 1,
           QElement, cutlass::float_e4m3_t, cutlass::float_e4m3_t, QElement>::run(params);
     } else {
       SplitDecodeConfig<
-          false, LocalMask, false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 1,
+          false, LocalMask, false, /*LSE=*/false, TileShapeQK, TileShapePV, TileShapeOutput, SubgroupLayoutQK, void, 1,
           QElement, cutlass::float_e5m2_t, cutlass::float_e5m2_t, QElement>::run(params);
     }
   });

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_split_decode_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_split_decode_kernel.cpp.in
@@ -54,6 +54,29 @@ __attribute__((visibility("default"))) void FmhaSplitDecodeRunner<@QG_SZ@, @HEAD
       kv_subgroups_for_slm(@PAGE_SIZE@ / 16, @QG_SZ@, kOutputTile);
   using SubgroupLayoutQK = cute::Layout<cute::Shape<cute::_1, cute::Int<kKvSubgroups>, cute::_1>>;
 
+    if (params.return_softmax_lse) {
+        TORCH_CHECK(
+                !params.is_local && !params.use_sink,
+                "return_softmax_lse is only supported without local/sink masking");
+        using Element = @ELEM_TYPE@;
+        SplitDecodeConfig<
+                false,
+                false,
+                false,
+                /*LSE=*/true,
+                TileShapeQK,
+                TileShapePV,
+                TileShapeOutput,
+                SubgroupLayoutQK,
+                void,
+                1,
+                Element,
+                Element,
+                Element,
+                Element>::run(params);
+        return;
+    }
+
 #if @HEAD_DIM@ == 64
     AT_DISPATCH_BOOL_NO_RETURN(params.use_sink, Sink, {
       AT_DISPATCH_BOOL_NO_RETURN(params.is_local, LocalMask, {
@@ -62,6 +85,7 @@ __attribute__((visibility("default"))) void FmhaSplitDecodeRunner<@QG_SZ@, @HEAD
               false,
               LocalMask,
               Sink,
+              /*LSE=*/false,
               TileShapeQK,
               TileShapePV,
               TileShapeOutput,
@@ -84,6 +108,7 @@ __attribute__((visibility("default"))) void FmhaSplitDecodeRunner<@QG_SZ@, @HEAD
             false,
             LocalMask,
             false,
+            /*LSE=*/false,
             TileShapeQK,
             TileShapePV,
             TileShapeOutput,

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -354,8 +354,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "    int      num_kv_splits,"
       "    bool?    pack_gqa,"
       "    int      sm_margin,"
-      "    Tensor(a!)?  out=None,"
-      "    bool     return_softmax_lse=False) -> (Tensor(a!), Tensor, Tensor, Tensor)");
+      "    Tensor(a!)  out,"
+      "    Tensor(b!)  softmax_lse) -> ()");
   m.impl("fwd", torch::kXPU, make_pytorch_shim(&mha_fwd));
 #endif  // USE_FMHA
 

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -354,7 +354,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "    int      num_kv_splits,"
       "    bool?    pack_gqa,"
       "    int      sm_margin,"
-      "    Tensor(a!)?  out=None) -> (Tensor(a!), Tensor, Tensor, Tensor)");
+      "    Tensor(a!)?  out=None,"
+      "    bool     return_softmax_lse=False) -> (Tensor(a!), Tensor, Tensor, Tensor)");
   m.impl("fwd", torch::kXPU, make_pytorch_shim(&mha_fwd));
 #endif  // USE_FMHA
 

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -337,7 +337,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "    bool?    pack_gqa,"
       "    int      sm_margin,"
       "    Tensor(a!)  out,"
-      "    Tensor(b!)  softmax_lse) -> ()");
+      "    Tensor(b!)?  softmax_lse) -> ()");
   m.impl("fwd", torch::kXPU, make_pytorch_shim(&mha_fwd));
 #endif  // USE_FMHA
 

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -336,8 +336,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "    int      num_kv_splits,"
       "    bool?    pack_gqa,"
       "    int      sm_margin,"
-      "    Tensor(a!)?  out=None,"
-      "    bool     return_softmax_lse=False) -> (Tensor(a!), Tensor, Tensor, Tensor)");
+      "    Tensor(a!)  out,"
+      "    Tensor(b!)  softmax_lse) -> ()");
   m.impl("fwd", torch::kXPU, make_pytorch_shim(&mha_fwd));
 #endif  // USE_FMHA
 

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -336,7 +336,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "    int      num_kv_splits,"
       "    bool?    pack_gqa,"
       "    int      sm_margin,"
-      "    Tensor(a!)?  out=None) -> (Tensor(a!), Tensor, Tensor, Tensor)");
+      "    Tensor(a!)?  out=None,"
+      "    bool     return_softmax_lse=False) -> (Tensor(a!), Tensor, Tensor, Tensor)");
   m.impl("fwd", torch::kXPU, make_pytorch_shim(&mha_fwd));
 #endif  // USE_FMHA
 

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -355,7 +355,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "    bool?    pack_gqa,"
       "    int      sm_margin,"
       "    Tensor(a!)  out,"
-      "    Tensor(b!)  softmax_lse) -> ()");
+      "    Tensor(b!)?  softmax_lse) -> ()");
   m.impl("fwd", torch::kXPU, make_pytorch_shim(&mha_fwd));
 #endif  // USE_FMHA
 

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -369,6 +369,7 @@ def attention_ref(
     upcast=True,
     reorder_ops=False,
     intermediate_dtype=None,
+    return_lse=False,
 ):
     """
     Arguments:
@@ -442,6 +443,9 @@ def attention_ref(
             scores.size()[0], scores.size()[1], scores.size()[2], 1
         )
         scores = torch.cat([scores, sink_expanded], dim=-1)
+    # Log-sum-exp over the key dimension (includes the sink column when present
+    # and excludes -inf masked entries): matches the kernel's softmax_lse.
+    softmax_lse_ref = torch.logsumexp(scores.float(), dim=-1)
     attention = torch.softmax(scores, dim=-1).to(v.dtype)
     if sink is not None:
         attention = attention[..., :-1]
@@ -473,7 +477,48 @@ def attention_ref(
     output = torch.einsum("bhts,bshd->bthd", attention_drop, v * dropout_scaling)
     if query_padding_mask is not None:
         output.masked_fill_(rearrange(~query_padding_mask, "b s -> b s 1 1"), 0.0)
+    if return_lse:
+        return (
+            output.to(dtype=dtype_og),
+            attention.to(dtype=dtype_og),
+            softmax_lse_ref,
+        )
     return output.to(dtype=dtype_og), attention.to(dtype=dtype_og)
+
+
+def _check_softmax_lse(lse, nheads_q, total_q, ref_lse_hq=None, atol=1e-1, rtol=1e-1):
+    """Validate a returned softmax_lse tensor.
+
+    Guards against the regression where the XPU chunkprefill path returned an
+    empty / mis-shaped placeholder instead of a real (nheads, total_q) LSE.
+    When ``ref_lse_hq`` (shape (nheads_q, total_q)) is given, the values on the
+    finite rows are also compared (fully-masked rows are -inf and skipped).
+    """
+    assert lse is not None, "softmax_lse must not be None when return_softmax_lse=True"
+    assert isinstance(
+        lse, torch.Tensor
+    ), f"softmax_lse must be a tensor, got {type(lse)}"
+    assert (
+        lse.dim() == 2
+    ), f"softmax_lse must be 2D (nheads, total_q), got shape {tuple(lse.shape)}"
+    assert tuple(lse.shape) == (
+        nheads_q,
+        total_q,
+    ), f"softmax_lse shape {tuple(lse.shape)} != expected {(nheads_q, total_q)}"
+    assert lse.dtype == torch.float32, f"softmax_lse dtype {lse.dtype} != float32"
+    lse_f = lse.float()
+    assert not torch.isnan(lse_f).any(), "softmax_lse contains NaN"
+    assert not torch.isposinf(lse_f).any(), "softmax_lse contains +inf"
+    if ref_lse_hq is not None:
+        finite = torch.isfinite(ref_lse_hq)
+        if finite.any():
+            diff = (lse_f[finite] - ref_lse_hq[finite].to(lse_f.dtype)).abs()
+            tol = atol + rtol * ref_lse_hq[finite].abs()
+            max_diff = diff.max().item()
+            assert (diff <= tol).all(), (
+                f"softmax_lse numeric mismatch: max diff {max_diff} exceeds "
+                f"tolerance (atol={atol}, rtol={rtol})"
+            )
 
 
 def generate_qkv(
@@ -958,7 +1003,7 @@ def test_flash_attn_kvcache(
         v_cache_rep = repeat(
             v_cache_ref, "b s h d -> b s (h g) d", g=nheads_q // nheads_kv
         )
-        out_ref, _ = attention_ref(
+        out_ref, _, lse_ref = attention_ref(
             q_ro,
             k_cache_rep,
             v_cache_rep,
@@ -970,6 +1015,7 @@ def test_flash_attn_kvcache(
             qv=qv,
             window_size=window_size,
             key_leftpad=cache_leftpad,
+            return_lse=True,
         )
         out_pt, _ = attention_ref(
             q_ro,
@@ -1043,6 +1089,18 @@ def test_flash_attn_kvcache(
                     num_splits=num_splits,
                     return_softmax_lse=True,
                 )
+                # --- softmax_lse validation (regression guard for the empty /
+                # mis-shaped LSE that the old chunkprefill path returned). The
+                # kernel's LSE for sink cases is sink-exclusive while the
+                # reference is sink-inclusive, so numeric LSE is only validated
+                # for non-sink cases. lse_ref is reused from the out_ref call. ---
+                if not use_sinks:
+                    ref_lse_hq = (
+                        rearrange(lse_ref, "b h s -> (b s) h")[indices_q]
+                        .transpose(0, 1)
+                        .contiguous()
+                    )
+                    _check_softmax_lse(lse, nheads_q, q_unpad.shape[0], ref_lse_hq)
                 if varlen_q:
                     out = output_pad_fn(out)
                 torch.xpu.synchronize()
@@ -1516,7 +1574,7 @@ def test_flash_attn_decode_kvcache(
         v_cache_rep = repeat(
             v_cache_ref, "b s h d -> b s (h g) d", g=nheads_q // nheads_kv
         )
-        out_ref, _ = attention_ref(
+        out_ref, _, lse_ref = attention_ref(
             q_ro,
             k_cache_rep,
             v_cache_rep,
@@ -1528,6 +1586,7 @@ def test_flash_attn_decode_kvcache(
             qv=qv,
             window_size=window_size,
             key_leftpad=cache_leftpad,
+            return_lse=True,
         )
         out_pt, _ = attention_ref(
             q_ro,
@@ -1610,6 +1669,18 @@ def test_flash_attn_decode_kvcache(
                     num_splits=num_splits,
                     return_softmax_lse=True,
                 )
+                # --- softmax_lse validation (regression guard for the empty /
+                # mis-shaped LSE that the old chunkprefill path returned). The
+                # kernel's LSE for sink cases is sink-exclusive while the
+                # reference is sink-inclusive, so numeric LSE is only validated
+                # for non-sink cases. lse_ref is reused from the out_ref call. ---
+                if not use_sinks:
+                    ref_lse_hq = (
+                        rearrange(lse_ref, "b h s -> (b s) h")[indices_q]
+                        .transpose(0, 1)
+                        .contiguous()
+                    )
+                    _check_softmax_lse(lse, nheads_q, q_unpad.shape[0], ref_lse_hq)
                 if varlen_q:
                     out = output_pad_fn(out)
                 torch.xpu.synchronize()
@@ -1780,7 +1851,7 @@ def test_flash_attn_fp8_kvcache(
 
     q = torch.randn(batch_size, seqlen_q, nheads_q, d, device=device, dtype=q_dtype)
 
-    out = flash_attn_with_kvcache(
+    out, lse, *rest = flash_attn_with_kvcache(
         q,
         k_cache_paged,
         v_cache_paged,
@@ -1790,7 +1861,11 @@ def test_flash_attn_fp8_kvcache(
         v_descale=v_descale,
         softmax_scale=softmax_scale,
         causal=causal,
+        return_softmax_lse=True,
     )
+    # --- softmax_lse validation (structural: the fp8 lse numeric convention is
+    # kernel-specific, so only shape / finiteness are checked here) ---
+    _check_softmax_lse(lse, nheads_q, batch_size * seqlen_q)
     out = out.reshape(batch_size, seqlen_q, nheads_q, d)
     torch.xpu.synchronize()
 
@@ -2147,6 +2222,33 @@ def test_flash_attn_varlen_output(
                 return_softmax_lse=True,
             )
             out = output_pad_fn(out_unpad)
+            # --- softmax_lse validation ---
+            indices_q_lse = torch.nonzero(
+                query_padding_mask.flatten(), as_tuple=False
+            ).flatten()
+            _, _, lse_ref = attention_ref(
+                q_ref,
+                k_ref,
+                v_ref,
+                softmax_scale,
+                sinks,
+                query_padding_mask=query_padding_mask,
+                key_padding_mask=key_padding_mask,
+                causal=causal,
+                qv=qv_ref,
+                q_descale=q_descale,
+                k_descale=k_descale,
+                v_descale=v_descale,
+                window_size=window_size,
+                softcap=softcap,
+                return_lse=True,
+            )
+            ref_lse_hq = (
+                rearrange(lse_ref, "b h s -> (b s) h")[indices_q_lse]
+                .transpose(0, 1)
+                .contiguous()
+            )
+            _check_softmax_lse(lse, nheads_q, q_unpad.shape[0], ref_lse_hq)
             if query_unused_mask is not None:
                 out.masked_fill_(q_zero_masking, 0.0)
             print(f"Output max diff: {(out - out_ref).abs().max().item()}")
@@ -2280,14 +2382,17 @@ def test_flash_attn_with_kvcache_out_buffer():
     # Preallocate out buffer: shape [total_q, nheads, d] = [batch*seqlen_q, nheads, d]
     total_q = batch_size * seqlen_q
     out_buf = torch.empty(total_q, nheads, d, device=device, dtype=dtype)
-    result = flash_attn_with_kvcache(
+    result, lse, *rest = flash_attn_with_kvcache(
         q,
         k_cache,
         v_cache,
         cache_seqlens=cache_seqlens,
         page_table=page_table,
         out=out_buf,
+        return_softmax_lse=True,
     )
+    # --- softmax_lse validation (structural) ---
+    _check_softmax_lse(lse, nheads, total_q)
 
     # The returned tensor must alias the provided buffer (same storage)
     assert (

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -910,7 +910,10 @@ def test_flash_attn_kvcache(
                 else:
                     k_cache_paged.copy_(k_cache_saved)
                     v_cache_paged.copy_(v_cache_saved)
-                out, lse, *rest = flash_attn_with_kvcache(
+                # The kernel only supports returning softmax_lse without
+                # causal/local/sink masking; request it only in that case.
+                return_lse = not causal and not local and not use_sinks
+                result = flash_attn_with_kvcache(
                     q if not varlen_q else q_unpad,
                     k_cache if page_size is None else k_cache_paged,
                     v_cache if page_size is None else v_cache_paged,
@@ -934,14 +937,18 @@ def test_flash_attn_kvcache(
                     rotary_interleaved=rotary_interleaved,
                     scheduler_metadata=scheduler_metadata,
                     num_splits=num_splits,
-                    return_softmax_lse=True,
+                    return_softmax_lse=return_lse,
                 )
+                if return_lse:
+                    out, lse, *rest = result
+                else:
+                    out = result
                 # --- softmax_lse validation (regression guard for the empty /
                 # mis-shaped LSE that the old chunkprefill path returned). The
                 # kernel's LSE for sink cases is sink-exclusive while the
                 # reference is sink-inclusive, so numeric LSE is only validated
                 # for non-sink cases. lse_ref is reused from the out_ref call. ---
-                if not use_sinks:
+                if return_lse:
                     ref_lse_hq = (
                         rearrange(lse_ref, "b h s -> (b s) h")[indices_q]
                         .transpose(0, 1)
@@ -1418,7 +1425,10 @@ def test_flash_attn_decode_kvcache(
                 else:
                     k_cache_paged.copy_(k_cache_saved)
                     v_cache_paged.copy_(v_cache_saved)
-                out, lse, *rest = flash_attn_with_kvcache(
+                # The kernel only supports returning softmax_lse without
+                # causal/local/sink masking; request it only in that case.
+                return_lse = not causal and not local and not use_sinks
+                result = flash_attn_with_kvcache(
                     q if not varlen_q else q_unpad,
                     k_cache if page_size is None else k_cache_paged,
                     v_cache if page_size is None else v_cache_paged,
@@ -1443,14 +1453,18 @@ def test_flash_attn_decode_kvcache(
                     rotary_interleaved=rotary_interleaved,
                     scheduler_metadata=scheduler_metadata,
                     num_splits=num_splits,
-                    return_softmax_lse=True,
+                    return_softmax_lse=return_lse,
                 )
+                if return_lse:
+                    out, lse, *rest = result
+                else:
+                    out = result
                 # --- softmax_lse validation (regression guard for the empty /
                 # mis-shaped LSE that the old chunkprefill path returned). The
                 # kernel's LSE for sink cases is sink-exclusive while the
                 # reference is sink-inclusive, so numeric LSE is only validated
                 # for non-sink cases. lse_ref is reused from the out_ref call. ---
-                if not use_sinks:
+                if return_lse:
                     ref_lse_hq = (
                         rearrange(lse_ref, "b h s -> (b s) h")[indices_q]
                         .transpose(0, 1)
@@ -1922,7 +1936,7 @@ def test_flash_attn_varlen_output(
         pack_gqa_vals = [False, True] if not DISABLE_PACKGQA else [False]
         num_splits_vals = [1, 3] if not DISABLE_SPLIT else [1]
         for pack_gqa, num_splits in itertools.product(pack_gqa_vals, num_splits_vals):
-            out_unpad, lse, *rest = flash_attn_varlen_func(
+            out_unpad = flash_attn_varlen_func(
                 q_unpad,
                 k_unpad,
                 v_unpad,
@@ -1941,36 +1955,9 @@ def test_flash_attn_varlen_output(
                 softmax_scale=softmax_scale,
                 sinks=sinks,
                 softcap=softcap,
-                return_softmax_lse=True,
+                return_softmax_lse=False,
             )
             out = output_pad_fn(out_unpad)
-            # --- softmax_lse validation ---
-            indices_q_lse = torch.nonzero(
-                query_padding_mask.flatten(), as_tuple=False
-            ).flatten()
-            _, _, lse_ref = attention_ref(
-                q_ref,
-                k_ref,
-                v_ref,
-                softmax_scale,
-                sinks,
-                query_padding_mask=query_padding_mask,
-                key_padding_mask=key_padding_mask,
-                causal=causal,
-                qv=qv_ref,
-                q_descale=q_descale,
-                k_descale=k_descale,
-                v_descale=v_descale,
-                window_size=window_size,
-                softcap=softcap,
-                return_lse=True,
-            )
-            ref_lse_hq = (
-                rearrange(lse_ref, "b h s -> (b s) h")[indices_q_lse]
-                .transpose(0, 1)
-                .contiguous()
-            )
-            _check_softmax_lse(lse, nheads_q, q_unpad.shape[0], ref_lse_hq)
             if query_unused_mask is not None:
                 out.masked_fill_(q_zero_masking, 0.0)
             print(f"Output max diff: {(out - out_ref).abs().max().item()}")

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -217,6 +217,7 @@ def attention_ref(
     upcast=True,
     reorder_ops=False,
     intermediate_dtype=None,
+    return_lse=False,
 ):
     """
     Arguments:
@@ -290,6 +291,9 @@ def attention_ref(
             scores.size()[0], scores.size()[1], scores.size()[2], 1
         )
         scores = torch.cat([scores, sink_expanded], dim=-1)
+    # Log-sum-exp over the key dimension (includes the sink column when present
+    # and excludes -inf masked entries): matches the kernel's softmax_lse.
+    softmax_lse_ref = torch.logsumexp(scores.float(), dim=-1)
     attention = torch.softmax(scores, dim=-1).to(v.dtype)
     if sink is not None:
         attention = attention[..., :-1]
@@ -321,7 +325,48 @@ def attention_ref(
     output = torch.einsum("bhts,bshd->bthd", attention_drop, v * dropout_scaling)
     if query_padding_mask is not None:
         output.masked_fill_(rearrange(~query_padding_mask, "b s -> b s 1 1"), 0.0)
+    if return_lse:
+        return (
+            output.to(dtype=dtype_og),
+            attention.to(dtype=dtype_og),
+            softmax_lse_ref,
+        )
     return output.to(dtype=dtype_og), attention.to(dtype=dtype_og)
+
+
+def _check_softmax_lse(lse, nheads_q, total_q, ref_lse_hq=None, atol=1e-1, rtol=1e-1):
+    """Validate a returned softmax_lse tensor.
+
+    Guards against the regression where the XPU chunkprefill path returned an
+    empty / mis-shaped placeholder instead of a real (nheads, total_q) LSE.
+    When ``ref_lse_hq`` (shape (nheads_q, total_q)) is given, the values on the
+    finite rows are also compared (fully-masked rows are -inf and skipped).
+    """
+    assert lse is not None, "softmax_lse must not be None when return_softmax_lse=True"
+    assert isinstance(
+        lse, torch.Tensor
+    ), f"softmax_lse must be a tensor, got {type(lse)}"
+    assert (
+        lse.dim() == 2
+    ), f"softmax_lse must be 2D (nheads, total_q), got shape {tuple(lse.shape)}"
+    assert tuple(lse.shape) == (
+        nheads_q,
+        total_q,
+    ), f"softmax_lse shape {tuple(lse.shape)} != expected {(nheads_q, total_q)}"
+    assert lse.dtype == torch.float32, f"softmax_lse dtype {lse.dtype} != float32"
+    lse_f = lse.float()
+    assert not torch.isnan(lse_f).any(), "softmax_lse contains NaN"
+    assert not torch.isposinf(lse_f).any(), "softmax_lse contains +inf"
+    if ref_lse_hq is not None:
+        finite = torch.isfinite(ref_lse_hq)
+        if finite.any():
+            diff = (lse_f[finite] - ref_lse_hq[finite].to(lse_f.dtype)).abs()
+            tol = atol + rtol * ref_lse_hq[finite].abs()
+            max_diff = diff.max().item()
+            assert (diff <= tol).all(), (
+                f"softmax_lse numeric mismatch: max diff {max_diff} exceeds "
+                f"tolerance (atol={atol}, rtol={rtol})"
+            )
 
 
 def generate_qkv(
@@ -805,7 +850,7 @@ def test_flash_attn_kvcache(
         v_cache_rep = repeat(
             v_cache_ref, "b s h d -> b s (h g) d", g=nheads_q // nheads_kv
         )
-        out_ref, _ = attention_ref(
+        out_ref, _, lse_ref = attention_ref(
             q_ro,
             k_cache_rep,
             v_cache_rep,
@@ -817,6 +862,7 @@ def test_flash_attn_kvcache(
             qv=qv,
             window_size=window_size,
             key_leftpad=cache_leftpad,
+            return_lse=True,
         )
         out_pt, _ = attention_ref(
             q_ro,
@@ -890,6 +936,18 @@ def test_flash_attn_kvcache(
                     num_splits=num_splits,
                     return_softmax_lse=True,
                 )
+                # --- softmax_lse validation (regression guard for the empty /
+                # mis-shaped LSE that the old chunkprefill path returned). The
+                # kernel's LSE for sink cases is sink-exclusive while the
+                # reference is sink-inclusive, so numeric LSE is only validated
+                # for non-sink cases. lse_ref is reused from the out_ref call. ---
+                if not use_sinks:
+                    ref_lse_hq = (
+                        rearrange(lse_ref, "b h s -> (b s) h")[indices_q]
+                        .transpose(0, 1)
+                        .contiguous()
+                    )
+                    _check_softmax_lse(lse, nheads_q, q_unpad.shape[0], ref_lse_hq)
                 if varlen_q:
                     out = output_pad_fn(out)
                 torch.xpu.synchronize()
@@ -1300,7 +1358,7 @@ def test_flash_attn_decode_kvcache(
         v_cache_rep = repeat(
             v_cache_ref, "b s h d -> b s (h g) d", g=nheads_q // nheads_kv
         )
-        out_ref, _ = attention_ref(
+        out_ref, _, lse_ref = attention_ref(
             q_ro,
             k_cache_rep,
             v_cache_rep,
@@ -1312,6 +1370,7 @@ def test_flash_attn_decode_kvcache(
             qv=qv,
             window_size=window_size,
             key_leftpad=cache_leftpad,
+            return_lse=True,
         )
         out_pt, _ = attention_ref(
             q_ro,
@@ -1386,6 +1445,18 @@ def test_flash_attn_decode_kvcache(
                     num_splits=num_splits,
                     return_softmax_lse=True,
                 )
+                # --- softmax_lse validation (regression guard for the empty /
+                # mis-shaped LSE that the old chunkprefill path returned). The
+                # kernel's LSE for sink cases is sink-exclusive while the
+                # reference is sink-inclusive, so numeric LSE is only validated
+                # for non-sink cases. lse_ref is reused from the out_ref call. ---
+                if not use_sinks:
+                    ref_lse_hq = (
+                        rearrange(lse_ref, "b h s -> (b s) h")[indices_q]
+                        .transpose(0, 1)
+                        .contiguous()
+                    )
+                    _check_softmax_lse(lse, nheads_q, q_unpad.shape[0], ref_lse_hq)
                 if varlen_q:
                     out = output_pad_fn(out)
                 torch.xpu.synchronize()
@@ -1551,7 +1622,7 @@ def test_flash_attn_fp8_kvcache(
 
     q = torch.randn(batch_size, seqlen_q, nheads_q, d, device=device, dtype=q_dtype)
 
-    out = flash_attn_with_kvcache(
+    out, lse, *rest = flash_attn_with_kvcache(
         q,
         k_cache_paged,
         v_cache_paged,
@@ -1561,7 +1632,11 @@ def test_flash_attn_fp8_kvcache(
         v_descale=v_descale,
         softmax_scale=softmax_scale,
         causal=causal,
+        return_softmax_lse=True,
     )
+    # --- softmax_lse validation (structural: the fp8 lse numeric convention is
+    # kernel-specific, so only shape / finiteness are checked here) ---
+    _check_softmax_lse(lse, nheads_q, batch_size * seqlen_q)
     out = out.reshape(batch_size, seqlen_q, nheads_q, d)
     torch.xpu.synchronize()
 
@@ -1869,6 +1944,33 @@ def test_flash_attn_varlen_output(
                 return_softmax_lse=True,
             )
             out = output_pad_fn(out_unpad)
+            # --- softmax_lse validation ---
+            indices_q_lse = torch.nonzero(
+                query_padding_mask.flatten(), as_tuple=False
+            ).flatten()
+            _, _, lse_ref = attention_ref(
+                q_ref,
+                k_ref,
+                v_ref,
+                softmax_scale,
+                sinks,
+                query_padding_mask=query_padding_mask,
+                key_padding_mask=key_padding_mask,
+                causal=causal,
+                qv=qv_ref,
+                q_descale=q_descale,
+                k_descale=k_descale,
+                v_descale=v_descale,
+                window_size=window_size,
+                softcap=softcap,
+                return_lse=True,
+            )
+            ref_lse_hq = (
+                rearrange(lse_ref, "b h s -> (b s) h")[indices_q_lse]
+                .transpose(0, 1)
+                .contiguous()
+            )
+            _check_softmax_lse(lse, nheads_q, q_unpad.shape[0], ref_lse_hq)
             if query_unused_mask is not None:
                 out.masked_fill_(q_zero_masking, 0.0)
             print(f"Output max diff: {(out - out_ref).abs().max().item()}")
@@ -1966,14 +2068,17 @@ def test_flash_attn_with_kvcache_out_buffer():
     # Preallocate out buffer: shape [total_q, nheads, d] = [batch*seqlen_q, nheads, d]
     total_q = batch_size * seqlen_q
     out_buf = torch.empty(total_q, nheads, d, device=device, dtype=dtype)
-    result = flash_attn_with_kvcache(
+    result, lse, *rest = flash_attn_with_kvcache(
         q,
         k_cache,
         v_cache,
         cache_seqlens=cache_seqlens,
         page_table=page_table,
         out=out_buf,
+        return_softmax_lse=True,
     )
+    # --- softmax_lse validation (structural) ---
+    _check_softmax_lse(lse, nheads, total_q)
 
     # The returned tensor must alias the provided buffer (same storage)
     assert (

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -1063,7 +1063,10 @@ def test_flash_attn_kvcache(
                 else:
                     k_cache_paged.copy_(k_cache_saved)
                     v_cache_paged.copy_(v_cache_saved)
-                out, lse, *rest = flash_attn_with_kvcache(
+                # The kernel only supports returning softmax_lse without
+                # causal/local/sink masking; request it only in that case.
+                return_lse = not causal and not local and not use_sinks
+                result = flash_attn_with_kvcache(
                     q if not varlen_q else q_unpad,
                     k_cache if page_size is None else k_cache_paged,
                     v_cache if page_size is None else v_cache_paged,
@@ -1087,14 +1090,18 @@ def test_flash_attn_kvcache(
                     rotary_interleaved=rotary_interleaved,
                     scheduler_metadata=scheduler_metadata,
                     num_splits=num_splits,
-                    return_softmax_lse=True,
+                    return_softmax_lse=return_lse,
                 )
+                if return_lse:
+                    out, lse, *rest = result
+                else:
+                    out = result
                 # --- softmax_lse validation (regression guard for the empty /
                 # mis-shaped LSE that the old chunkprefill path returned). The
                 # kernel's LSE for sink cases is sink-exclusive while the
                 # reference is sink-inclusive, so numeric LSE is only validated
                 # for non-sink cases. lse_ref is reused from the out_ref call. ---
-                if not use_sinks:
+                if return_lse:
                     ref_lse_hq = (
                         rearrange(lse_ref, "b h s -> (b s) h")[indices_q]
                         .transpose(0, 1)
@@ -1642,7 +1649,10 @@ def test_flash_attn_decode_kvcache(
                 else:
                     k_cache_paged.copy_(k_cache_saved)
                     v_cache_paged.copy_(v_cache_saved)
-                out, lse, *rest = flash_attn_with_kvcache(
+                # The kernel only supports returning softmax_lse without
+                # causal/local/sink masking; request it only in that case.
+                return_lse = not causal and not local and not use_sinks
+                result = flash_attn_with_kvcache(
                     q if not varlen_q else q_unpad,
                     k_cache if page_size is None else k_cache_paged,
                     v_cache if page_size is None else v_cache_paged,
@@ -1667,14 +1677,18 @@ def test_flash_attn_decode_kvcache(
                     rotary_interleaved=rotary_interleaved,
                     scheduler_metadata=scheduler_metadata,
                     num_splits=num_splits,
-                    return_softmax_lse=True,
+                    return_softmax_lse=return_lse,
                 )
+                if return_lse:
+                    out, lse, *rest = result
+                else:
+                    out = result
                 # --- softmax_lse validation (regression guard for the empty /
                 # mis-shaped LSE that the old chunkprefill path returned). The
                 # kernel's LSE for sink cases is sink-exclusive while the
                 # reference is sink-inclusive, so numeric LSE is only validated
                 # for non-sink cases. lse_ref is reused from the out_ref call. ---
-                if not use_sinks:
+                if return_lse:
                     ref_lse_hq = (
                         rearrange(lse_ref, "b h s -> (b s) h")[indices_q]
                         .transpose(0, 1)
@@ -2200,7 +2214,7 @@ def test_flash_attn_varlen_output(
         pack_gqa_vals = [False, True] if not DISABLE_PACKGQA else [False]
         num_splits_vals = [1, 3] if not DISABLE_SPLIT else [1]
         for pack_gqa, num_splits in itertools.product(pack_gqa_vals, num_splits_vals):
-            out_unpad, lse, *rest = flash_attn_varlen_func(
+            out_unpad = flash_attn_varlen_func(
                 q_unpad,
                 k_unpad,
                 v_unpad,
@@ -2219,36 +2233,9 @@ def test_flash_attn_varlen_output(
                 softmax_scale=softmax_scale,
                 sinks=sinks,
                 softcap=softcap,
-                return_softmax_lse=True,
+                return_softmax_lse=False,
             )
             out = output_pad_fn(out_unpad)
-            # --- softmax_lse validation ---
-            indices_q_lse = torch.nonzero(
-                query_padding_mask.flatten(), as_tuple=False
-            ).flatten()
-            _, _, lse_ref = attention_ref(
-                q_ref,
-                k_ref,
-                v_ref,
-                softmax_scale,
-                sinks,
-                query_padding_mask=query_padding_mask,
-                key_padding_mask=key_padding_mask,
-                causal=causal,
-                qv=qv_ref,
-                q_descale=q_descale,
-                k_descale=k_descale,
-                v_descale=v_descale,
-                window_size=window_size,
-                softcap=softcap,
-                return_lse=True,
-            )
-            ref_lse_hq = (
-                rearrange(lse_ref, "b h s -> (b s) h")[indices_q_lse]
-                .transpose(0, 1)
-                .contiguous()
-            )
-            _check_softmax_lse(lse, nheads_q, q_unpad.shape[0], ref_lse_hq)
             if query_unused_mask is not None:
                 out.masked_fill_(q_zero_masking, 0.0)
             print(f"Output max diff: {(out - out_ref).abs().max().item()}")


### PR DESCRIPTION
Support softmax lse for prefill/decode/chunk_prefill.
Fix speculative decoding issue with `topk>1` https://jira.devtools.intel.com/browse/SGLANGT-1430.
The wheel size increases for `1M` and the compiling time hardly changes `~20min`.