### PR TITLE
ci(xpu): nightly-image-based PR CI + new nightly test flow

### DIFF
--- a/.github/workflows/nightly_pr_nightly_xpu.yml
+++ b/.github/workflows/nightly_pr_nightly_xpu.yml
@@ -1,0 +1,121 @@
+name: Nightly Test (XPU Kernel)
+
+# Runs against the nightly Docker image published by
+# release-docker-xpu-kernel-nightly.yml. The image already contains an
+# installed sgl-kernel wheel, so this workflow does NOT rebuild the
+# kernel from source — it exercises exactly what was shipped.
+#
+# Mirrors the structure of sglang/.github/workflows/nightly-test-intel.yml:
+#   - Cron + workflow_dispatch + workflow_call triggers
+#   - One GPU-count job per matrix entry (placeholder: 1-gpu only)
+#   - check-all-jobs aggregator so a single failure fails the workflow
+
+on:
+  schedule:
+    # A few hours after the nightly image publish (12:00 UTC).
+    - cron: '0 16 * * *'
+  workflow_dispatch:
+    inputs:
+      continue_on_error:
+        description: 'Continue on error (do not fail the workflow on test failures)'
+        required: false
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      ref:
+        description: "Branch, tag or SHA to checkout"
+        required: false
+        type: string
+        default: ""
+      continue_on_error:
+        description: 'Continue on error (do not fail the workflow on test failures)'
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: nightly-xpu-kernel-${{ github.event_name == 'workflow_dispatch' && format('manual-{0}', github.run_id) || inputs.ref && format('caller-{0}', github.run_id) || github.ref }}
+  cancel-in-progress: ${{ !inputs.ref && github.event_name != 'workflow_call' && github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  nightly-xpu-1-gpu:
+    if: github.repository == 'sgl-project/sgl-kernel-xpu'
+    runs-on: sglang-bmg
+    env:
+      DOCKERHUB_INTEL_USERNAME: ${{ secrets.DOCKERHUB_INTEL_USERNAME }}
+      DOCKERHUB_INTEL_TOKEN: ${{ secrets.DOCKERHUB_INTEL_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Pull nightly Docker image
+        run: |
+          docker pull intel/sgl-kernel-xpu-dev:latest
+
+      - name: Run container
+        run: |
+          docker run -dt \
+            --device /dev/dri/ \
+            --name nightly_sglkernel_xpu \
+            -e HF_TOKEN=$(cat ~/huggingface_token.txt) \
+            intel/sgl-kernel-xpu-dev:latest
+
+      - name: Install run_suite extras + HF login
+        timeout-minutes: 20
+        run: |
+          docker exec nightly_sglkernel_xpu /miniforge3/envs/py3.10/bin/python3 -m pip install --upgrade pip
+          docker exec nightly_sglkernel_xpu /miniforge3/envs/py3.10/bin/python3 -m pip install pytest expecttest ray huggingface_hub scipy tabulate
+          docker exec nightly_sglkernel_xpu /bin/bash -c '/miniforge3/envs/py3.10/bin/hf auth login --token ${HF_TOKEN}'
+          docker exec nightly_sglkernel_xpu /bin/bash -c "ln -sf /miniforge3/envs/py3.10/bin/python3 /usr/bin/python3"
+
+      - name: Verify pre-installed sgl-kernel wheel
+        run: |
+          docker exec nightly_sglkernel_xpu /miniforge3/envs/py3.10/bin/python3 -c \
+            "import sgl_kernel; print('sgl_kernel loaded from', sgl_kernel.__file__)"
+
+      - name: Nightly Test (1-GPU XPU Kernel)
+        timeout-minutes: 240
+        run: |
+          docker exec -w /root/sglang/sgl-kernel-xpu/tests nightly_sglkernel_xpu \
+            /miniforge3/envs/py3.10/bin/python3 run_suite.py \
+              --suite nightly-xpu \
+              --timeout-per-file 7200 \
+            || TEST_EXIT_CODE=$?
+          exit ${TEST_EXIT_CODE:-0}
+        # continue_on_error semantics: schedule/workflow_dispatch swallow
+        # failures per the input flag; workflow_call runs propagate as-is.
+        continue-on-error: ${{ github.event_name == 'schedule' || inputs.continue_on_error == true }}
+
+      # ------------------------------------------------------------------
+      # Placeholder for future multi-GPU nightly suites. Add
+      # nightly-xpu-2-gpu / nightly-xpu-4-gpu jobs modeled on the sglang
+      # nightly-test-intel.yml pattern once the corresponding suites
+      # exist in tests/run_suite.py.
+      # ------------------------------------------------------------------
+
+      - name: Cleanup container
+        if: always()
+        run: |
+          docker rm -f nightly_sglkernel_xpu || true
+
+  check-all-jobs:
+    if: always() && (github.repository == 'sgl-project/sgl-kernel-xpu' || github.event_name == 'workflow_dispatch')
+    needs:
+      - nightly-xpu-1-gpu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if any job failed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more nightly test jobs failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more nightly test jobs were cancelled"
+            exit 1
+          fi
+          echo "All nightly test jobs passed"

--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -20,15 +20,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build Docker image
+      - name: Pull nightly Docker image
         run: |
-          docker build \
-            --build-arg SG_LANG_KERNEL_BRANCH=${{ github.head_ref }} \
-            --build-arg SG_LANG_KERNEL_REPO=${{ github.event.pull_request.head.repo.clone_url }} \
-            --no-cache --progress=plain -f Dockerfile.xpu_kernel -t xpu_sglang:kernel .
+          docker pull intel/sgl-kernel-xpu-dev:latest
 
       - name: Run container
         run: |
@@ -36,7 +30,30 @@ jobs:
             --device /dev/dri/ \
             --name ci_sglkernel_xpu \
             -e HF_TOKEN=$(cat ~/huggingface_token.txt) \
-            xpu_sglang:kernel
+            intel/sgl-kernel-xpu-dev:latest
+
+      - name: Rebuild sgl-kernel from latest main + PR
+        timeout-minutes: 40
+        env:
+          # refs/pull/N/merge is GitHub's pre-computed merge commit:
+          # current base (main) merged with this PR. Testing that ref
+          # catches conflicts with anything that landed on main while
+          # the PR was in flight.
+          PR_MERGE_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          docker exec -e PR_MERGE_REF="${PR_MERGE_REF}" ci_sglkernel_xpu \
+            /bin/bash -c '\
+              set -euxo pipefail && \
+              . /miniforge3/bin/activate && \
+              conda activate py3.10 && \
+              cd /root/sglang/sgl-kernel-xpu && \
+              git remote set-url origin https://github.com/sgl-project/sgl-kernel-xpu.git && \
+              git fetch --depth=1 origin "${PR_MERGE_REF}" && \
+              git checkout FETCH_HEAD && \
+              pip uninstall -y sgl-kernel || true && \
+              pip install --force-reinstall -v . && \
+              python -c "import sgl_kernel; print(sgl_kernel.__file__)" \
+            '
 
       - name: Install Dependency
         timeout-minutes: 20
@@ -93,10 +110,8 @@ jobs:
               python3 bench_jit_qknorm.py 2>&1 | tee bench_jit_qknorm.py.log && \
               python3 bench_jit_rope.py 2>&1 | tee bench_jit_rope.py.log && \
               python3 bench_jit_timestep_embedding.py 2>&1 | tee bench_jit_timestep_embedding.py.log && \
-              python3 bench_jit_moe_align_block_size.py 2>&1 | tee bench_jit_moe_align_block_size.py.log && \
-              python3 bench_jit_per_token_group_quant_8bit_v2.py 2>&1 | tee bench_jit_per_token_group_quant_8bit_v2.py.log && \
-              python3 bench_jit_activation.py 2>&1 | tee bench_jit_activation.py.log && \
-              python3 bench_hc_post.py 2>&1 | tee bench_hc_post.py.log && \
+              python3 bench_jit_activation.py 2>&1 | tee bench_jit_activation.py.log
+              python3 bench_hc_post.py 2>&1 | tee bench_hc_post.py.log
               python3 bench_hc_post.py 2>&1 | tee bench_hc_post.py.log && \
               python3 bench_sgemm_lora_a_fwd.py 2>&1 | tee bench_sgemm_lora_a_fwd.py.log
             "

--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -50,6 +50,12 @@ jobs:
               git remote set-url origin https://github.com/sgl-project/sgl-kernel-xpu.git && \
               git fetch --depth=1 origin "${PR_MERGE_REF}" && \
               git checkout FETCH_HEAD && \
+              # Nuke the image-baked build/ tree so Ninja recompiles against
+              # the freshly checked-out source. Without this, C++/SYCL PRs
+              # get silently linked against the prebuilt .o files from the
+              # nightly image and the wheel that ships to tests contains
+              # the pre-PR kernel code.
+              rm -rf build && \
               pip uninstall -y sgl-kernel || true && \
               pip install --force-reinstall -v . && \
               python -c "import sgl_kernel; print(sgl_kernel.__file__)" \

--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           docker exec -e PR_MERGE_REF="${PR_MERGE_REF}" ci_sglkernel_xpu \
             /bin/bash -c '\
-              set -euxo pipefail && \
+              set -exo pipefail && \
               . /miniforge3/bin/activate && \
               conda activate py3.10 && \
               cd /root/sglang/sgl-kernel-xpu && \

--- a/.github/workflows/release-docker-xpu-kernel-nightly.yml
+++ b/.github/workflows/release-docker-xpu-kernel-nightly.yml
@@ -58,5 +58,13 @@ jobs:
 
       - name: Push intel/sgl-kernel-xpu-dev
         run: |
-          docker push "intel/sgl-kernel-xpu-dev:${{ env.IMAGE_TAG }}"
-          docker push "intel/sgl-kernel-xpu-dev:latest"
+          push_with_retry() {
+            for i in 1 2 3 4 5; do
+              docker push "$1" && return 0
+              echo "push failed (attempt $i), retrying in $((i*15))s..."
+              sleep $((i*15))
+            done
+            return 1
+          }
+          push_with_retry "intel/sgl-kernel-xpu-dev:${{ env.IMAGE_TAG }}"
+          push_with_retry "intel/sgl-kernel-xpu-dev:latest"

--- a/tests/run_suite.py
+++ b/tests/run_suite.py
@@ -61,6 +61,12 @@ suites = {
         TestFile("test_embedding_lora_a_fwd.py"),
         TestFile("test_sgemm_lora_a_fwd.py"),
     ],
+    # Nightly suite: exercises the wheel installed in the intel/sgl-kernel-xpu-dev
+    # nightly image. Populate with longer-running or full-shape tests that are
+    # too slow for per-commit CI. Placeholder for now.
+    "nightly-xpu": [
+        TestFile("test_activation.py"),
+    ],
 }
 
 


### PR DESCRIPTION
## Summary

Follow-up to #323 (nightly Docker build + push). Switches PR CI to consume the published image and adds a nightly test workflow that exercises exactly the artifact that was shipped.

- **`pr-test-xpu.yml`**: pull `intel/sgl-kernel-xpu-dev:latest` instead of building `Dockerfile.xpu_kernel` from scratch on every PR. To avoid testing against the stale wheel baked into the image, a new step checks out `refs/pull/<N>/merge` (base+PR merge commit) inside the container and rebuilds/reinstalls `sgl-kernel` from source via `pip install .` before tests run — so PRs are exercised against latest `main` + the PR patch, not against whatever the image was built from.

- **`nightly_pr_nightly_xpu.yml` (new)**: mirrors the shape of sglang's `nightly-test-intel.yml` — `schedule` + `workflow_dispatch` + `workflow_call` triggers, per-GPU-count job (placeholder: `nightly-xpu-1-gpu`), and a `check-all-jobs` aggregator. Pulls the nightly image and does **not** rebuild the kernel, exercising exactly the artifact that was shipped by #323.

- **`tests/run_suite.py`**: adds a `nightly-xpu` suite entry (placeholder, one test today) that the nightly workflow invokes; populate over time with longer-running tests unsuitable for per-commit CI.

## Dependencies

Depends on #323 landing first so that `intel/sgl-kernel-xpu-dev:latest` exists on Docker Hub.

## Test plan

- [ ] After #323 has run at least once, open a PR with the `run-ci` label against a branch based on this one; confirm the PR workflow pulls the image, rebuilds the kernel from PR source, and the existing test/benchmark steps still run to completion.
- [ ] Trigger `Nightly Test (XPU Kernel)` via `workflow_dispatch`; confirm it pulls the image, verifies `import sgl_kernel`, and runs `run_suite.py --suite nightly-xpu`.
