### PR TITLE
Rename fused_qk_norm_rope_with_cos_sin_cache_inplace to to align with CUDA

### DIFF
--- a/benchmark/bench_fused_qk_norm_rope.py
+++ b/benchmark/bench_fused_qk_norm_rope.py
@@ -459,7 +459,7 @@ def benchmark_cache(
     elif provider == "cache_fused":
 
         def fn() -> None:
-            sgl_kernel.fused_qk_norm_rope_with_cos_sin_cache_inplace(
+            sgl_kernel.fused_inplace_qknorm_rope(
                 q,
                 k,
                 q_weight,

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -115,7 +115,7 @@ void rmsnorm(torch::Tensor& output, torch::Tensor& input, torch::Tensor& weight,
 void fused_add_rmsnorm(torch::Tensor input, torch::Tensor residual, torch::Tensor weight, double eps);
 void gemma_rmsnorm(torch::Tensor& output, torch::Tensor& input, torch::Tensor& weight, double eps);
 void gemma_fused_add_rmsnorm(torch::Tensor& input, torch::Tensor& residual, torch::Tensor& weight, double eps);
-void fused_qk_norm_rope_with_cos_sin_cache_inplace(
+void fused_inplace_qknorm_rope(
     torch::Tensor& q,
     torch::Tensor& k,
     torch::Tensor& q_weight,

--- a/python/sgl_kernel/__init__.py
+++ b/python/sgl_kernel/__init__.py
@@ -31,8 +31,8 @@ from sgl_kernel.compress_plan_torch import (
 from sgl_kernel.elementwise import (
     apply_rope_with_cos_sin_cache_inplace,
     fused_add_rmsnorm,
+    fused_inplace_qknorm_rope,
     fused_qk_norm_rope,
-    fused_qk_norm_rope_with_cos_sin_cache_inplace,
     fused_qk_rope,
     fused_qk_rope_with_cos_sin_cache_inplace,
     gelu_and_mul,

--- a/python/sgl_kernel/elementwise.py
+++ b/python/sgl_kernel/elementwise.py
@@ -140,7 +140,7 @@ def gemma_fused_add_rmsnorm(
     torch.ops.sgl_kernel.gemma_fused_add_rmsnorm(input, residual, weight, eps)
 
 
-def fused_qk_norm_rope_with_cos_sin_cache_inplace(
+def fused_inplace_qknorm_rope(
     q: torch.Tensor,
     k: torch.Tensor,
     q_weight: torch.Tensor,
@@ -182,7 +182,7 @@ def fused_qk_norm_rope_with_cos_sin_cache_inplace(
     ----
     This is an in-place operation that modifies ``q`` and ``k`` directly.
     """
-    torch.ops.sgl_kernel.fused_qk_norm_rope_with_cos_sin_cache_inplace(
+    torch.ops.sgl_kernel.fused_inplace_qknorm_rope(
         q, k, q_weight, k_weight, cos_sin_cache, positions, is_neox, eps
     )
 

--- a/src/sycl/FusedQKNormRope.cpp
+++ b/src/sycl/FusedQKNormRope.cpp
@@ -834,7 +834,7 @@ void launchFusedQKNormRopeCacheImpl(
   });
 }
 
-void fused_qk_norm_rope_with_cos_sin_cache_inplace(
+void fused_inplace_qknorm_rope(
     torch::Tensor& q,
     torch::Tensor& k,
     torch::Tensor& q_weight,
@@ -904,55 +904,52 @@ void fused_qk_norm_rope_with_cos_sin_cache_inplace(
 
   auto queue = dpcppGetCurrentQueue();
 
-  dispatchFusedQKNormRopeScalarType<false>(
-      q_view.scalar_type(), "fused_qk_norm_rope_with_cos_sin_cache_inplace", [&](auto scalar_tag) {
-        using scalar_t = typename decltype(scalar_tag)::type;
-        dispatchFusedQKNormRopePositionsType(
-            positions.scalar_type(), "fused_qk_norm_rope_with_cos_sin_cache_inplace", [&](auto id_tag) {
-              using IdType = typename decltype(id_tag)::type;
-              dispatchFusedQKNormRopeHeadDim(
-                  head_dim, "fused_qk_norm_rope_with_cos_sin_cache_inplace", [&](auto head_dim_tag) {
-                    constexpr int64_t kHeadDimConst = decltype(head_dim_tag)::value;
-                    if (is_neox) {
-                      launchFusedQKNormRopeCacheImpl<kHeadDimConst, true, scalar_t, IdType>(
-                          static_cast<scalar_t*>(q_view.data_ptr()),
-                          static_cast<scalar_t*>(k_view.data_ptr()),
-                          static_cast<const scalar_t*>(q_weight.data_ptr()),
-                          static_cast<const scalar_t*>(k_weight.data_ptr()),
-                          static_cast<const float*>(cos_sin_cache.data_ptr()),
-                          static_cast<const IdType*>(positions.data_ptr()),
-                          q_view.stride(0),
-                          k_view.stride(0),
-                          q_head_stride,
-                          k_head_stride,
-                          num_tokens,
-                          num_qo_heads,
-                          num_kv_heads,
-                          rope_dim,
-                          static_cast<float>(eps),
-                          queue);
-                    } else {
-                      launchFusedQKNormRopeCacheImpl<kHeadDimConst, false, scalar_t, IdType>(
-                          static_cast<scalar_t*>(q_view.data_ptr()),
-                          static_cast<scalar_t*>(k_view.data_ptr()),
-                          static_cast<const scalar_t*>(q_weight.data_ptr()),
-                          static_cast<const scalar_t*>(k_weight.data_ptr()),
-                          static_cast<const float*>(cos_sin_cache.data_ptr()),
-                          static_cast<const IdType*>(positions.data_ptr()),
-                          q_view.stride(0),
-                          k_view.stride(0),
-                          q_head_stride,
-                          k_head_stride,
-                          num_tokens,
-                          num_qo_heads,
-                          num_kv_heads,
-                          rope_dim,
-                          static_cast<float>(eps),
-                          queue);
-                    }
-                  });
-            });
+  dispatchFusedQKNormRopeScalarType<false>(q_view.scalar_type(), "fused_inplace_qknorm_rope", [&](auto scalar_tag) {
+    using scalar_t = typename decltype(scalar_tag)::type;
+    dispatchFusedQKNormRopePositionsType(positions.scalar_type(), "fused_inplace_qknorm_rope", [&](auto id_tag) {
+      using IdType = typename decltype(id_tag)::type;
+      dispatchFusedQKNormRopeHeadDim(head_dim, "fused_inplace_qknorm_rope", [&](auto head_dim_tag) {
+        constexpr int64_t kHeadDimConst = decltype(head_dim_tag)::value;
+        if (is_neox) {
+          launchFusedQKNormRopeCacheImpl<kHeadDimConst, true, scalar_t, IdType>(
+              static_cast<scalar_t*>(q_view.data_ptr()),
+              static_cast<scalar_t*>(k_view.data_ptr()),
+              static_cast<const scalar_t*>(q_weight.data_ptr()),
+              static_cast<const scalar_t*>(k_weight.data_ptr()),
+              static_cast<const float*>(cos_sin_cache.data_ptr()),
+              static_cast<const IdType*>(positions.data_ptr()),
+              q_view.stride(0),
+              k_view.stride(0),
+              q_head_stride,
+              k_head_stride,
+              num_tokens,
+              num_qo_heads,
+              num_kv_heads,
+              rope_dim,
+              static_cast<float>(eps),
+              queue);
+        } else {
+          launchFusedQKNormRopeCacheImpl<kHeadDimConst, false, scalar_t, IdType>(
+              static_cast<scalar_t*>(q_view.data_ptr()),
+              static_cast<scalar_t*>(k_view.data_ptr()),
+              static_cast<const scalar_t*>(q_weight.data_ptr()),
+              static_cast<const scalar_t*>(k_weight.data_ptr()),
+              static_cast<const float*>(cos_sin_cache.data_ptr()),
+              static_cast<const IdType*>(positions.data_ptr()),
+              q_view.stride(0),
+              k_view.stride(0),
+              q_head_stride,
+              k_head_stride,
+              num_tokens,
+              num_qo_heads,
+              num_kv_heads,
+              rope_dim,
+              static_cast<float>(eps),
+              queue);
+        }
       });
+    });
+  });
 }
 
 }  // namespace at::native::xpu

--- a/src/sycl/FusedQKNormRope.cpp
+++ b/src/sycl/FusedQKNormRope.cpp
@@ -30,7 +30,7 @@ inline T divUp(T m, T n) {
   return (m + n - 1) / n;
 }
 
-// Sub-group reduction for sum
+// Sub-group reduction for sum.
 template <typename T>
 inline T subGroupReduceSum(T val, const sycl::sub_group& sg) {
   return sycl::reduce_over_group(sg, val, sycl::plus<T>());

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -225,12 +225,9 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "float factor, float low, float high, float attention_factor, int rotary_dim) -> ()");
   m.impl("fused_qk_norm_rope", torch::kXPU, &at::native::xpu::fused_qk_norm_rope);
   m.def(
-      "fused_qk_norm_rope_with_cos_sin_cache_inplace(Tensor! q, Tensor! k, Tensor q_weight, Tensor k_weight, "
+      "fused_inplace_qknorm_rope(Tensor! q, Tensor! k, Tensor q_weight, Tensor k_weight, "
       "Tensor cos_sin_cache, Tensor positions, bool is_neox, float eps) -> ()");
-  m.impl(
-      "fused_qk_norm_rope_with_cos_sin_cache_inplace",
-      torch::kXPU,
-      &at::native::xpu::fused_qk_norm_rope_with_cos_sin_cache_inplace);
+  m.impl("fused_inplace_qknorm_rope", torch::kXPU, &at::native::xpu::fused_inplace_qknorm_rope);
   /*
    * Fused QK RoPE (no RMS_Norm)
    */

--- a/tests/test_fused_qk_norm_rope.py
+++ b/tests/test_fused_qk_norm_rope.py
@@ -609,7 +609,7 @@ def test_fused_qk_norm_rope_with_cache(
 
     q_test = q.clone()
     k_test = k.clone()
-    sgl_kernel.fused_qk_norm_rope_with_cos_sin_cache_inplace(
+    sgl_kernel.fused_inplace_qknorm_rope(
         q_test,
         k_test,
         q_weight,
@@ -710,7 +710,7 @@ def test_fused_qk_norm_rope_with_cache_last_dim_strided(
         is_neox,
     )
 
-    sgl_kernel.fused_qk_norm_rope_with_cos_sin_cache_inplace(
+    sgl_kernel.fused_inplace_qknorm_rope(
         q,
         k,
         q_weight,


### PR DESCRIPTION
Rename `fused_qk_norm_rope_with_cos_sin_cache_inplace` to `fused_inplace_qknorm_rope` to align with CUDA.