### PR TITLE
Update fused_inplace_qknorm_rope signature to align with CUDA

### DIFF
--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -123,7 +123,9 @@ void fused_inplace_qknorm_rope(
     torch::Tensor& cos_sin_cache,
     torch::Tensor& positions,
     bool is_neox,
-    double eps);
+    double eps,
+    int64_t head_dim,
+    int64_t rope_dim);
 void topk_softmax(at::Tensor& topk_weights, at::Tensor& topk_indices, at::Tensor& gating_output, bool renormalize);
 void topk_sigmoid(
     at::Tensor& topk_weights,

--- a/python/sgl_kernel/elementwise.py
+++ b/python/sgl_kernel/elementwise.py
@@ -179,6 +179,10 @@ def fused_inplace_qknorm_rope(
         Whether to apply NeoX-style rotary layout.
     eps: float
         Epsilon for RMS normalization.
+    head_dim: int
+        Optional explicit head dimension. Defaults to ``q.size(-1)`` when set to 0.
+    rope_dim: int
+        Optional explicit rotary dimension. Defaults to ``cos_sin_cache.size(-1)`` when set to 0.
 
     Note
     ----

--- a/python/sgl_kernel/elementwise.py
+++ b/python/sgl_kernel/elementwise.py
@@ -149,6 +149,8 @@ def fused_inplace_qknorm_rope(
     positions: torch.Tensor,
     is_neox: bool,
     eps: float = 1e-6,
+    head_dim: int = 0,
+    rope_dim: int = 0,
 ) -> None:
     r"""Apply fused RMSNorm + RoPE to Q/K using a precomputed cos/sin cache.
 
@@ -183,7 +185,16 @@ def fused_inplace_qknorm_rope(
     This is an in-place operation that modifies ``q`` and ``k`` directly.
     """
     torch.ops.sgl_kernel.fused_inplace_qknorm_rope(
-        q, k, q_weight, k_weight, cos_sin_cache, positions, is_neox, eps
+        q,
+        k,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        positions,
+        is_neox,
+        eps,
+        head_dim,
+        rope_dim,
     )
 
 

--- a/src/sycl/FusedQKNormRope.cpp
+++ b/src/sycl/FusedQKNormRope.cpp
@@ -842,7 +842,9 @@ void fused_inplace_qknorm_rope(
     torch::Tensor& cos_sin_cache,
     torch::Tensor& positions,
     bool is_neox,
-    double eps) {
+    double eps,
+    int64_t head_dim,
+    int64_t rope_dim) {
   TORCH_CHECK(q.dim() == k.dim(), "q and k must have the same rank, got q:", q.dim(), " k:", k.dim());
   TORCH_CHECK(q.dim() == 3 || q.dim() == 4, "q/k must be 3D or 4D tensors, got q:", q.dim());
   TORCH_CHECK(q.scalar_type() == k.scalar_type(), "q and k must have the same dtype");
@@ -887,16 +889,34 @@ void fused_inplace_qknorm_rope(
   const int64_t num_tokens = q_view.size(0);
   const int64_t num_qo_heads = q_view.size(1);
   const int64_t num_kv_heads = k_view.size(1);
-  const int64_t head_dim = q_view.size(2);
+  const int64_t inferred_head_dim = q_view.size(2);
   const int64_t q_head_stride = q_view.stride(1);
   const int64_t k_head_stride = k_view.stride(1);
 
   TORCH_CHECK(q_weight.dim() == 1, "q_weight must be 1D [head_dim]");
   TORCH_CHECK(k_weight.dim() == 1, "k_weight must be 1D [head_dim]");
-  TORCH_CHECK(q_weight.size(0) == head_dim, "q_weight size must match head_dim");
-  TORCH_CHECK(k_weight.size(0) == head_dim, "k_weight size must match head_dim");
+  TORCH_CHECK(q_weight.size(0) == inferred_head_dim, "q_weight size must match head_dim");
+  TORCH_CHECK(k_weight.size(0) == inferred_head_dim, "k_weight size must match head_dim");
   TORCH_CHECK(cos_sin_cache.dim() == 2, "cos_sin_cache must be 2D [max_position, rope_dim]");
-  const int64_t rope_dim = cos_sin_cache.size(1);
+  const int64_t inferred_rope_dim = cos_sin_cache.size(1);
+  if (head_dim != 0) {
+    TORCH_CHECK(
+        head_dim == inferred_head_dim,
+        "head_dim must match q/k hidden size, got ",
+        head_dim,
+        " vs ",
+        inferred_head_dim);
+  }
+  if (rope_dim != 0) {
+    TORCH_CHECK(
+        rope_dim == inferred_rope_dim,
+        "rope_dim must match cos_sin_cache width, got ",
+        rope_dim,
+        " vs ",
+        inferred_rope_dim);
+  }
+  head_dim = inferred_head_dim;
+  rope_dim = inferred_rope_dim;
   TORCH_CHECK(rope_dim % 2 == 0, "rope_dim must be even");
   TORCH_CHECK(rope_dim <= head_dim, "rope_dim must be <= head_dim");
   TORCH_CHECK(positions.dim() == 1, "positions must be 1D [num_tokens]");

--- a/src/sycl/FusedQKNormRope.cpp
+++ b/src/sycl/FusedQKNormRope.cpp
@@ -30,7 +30,7 @@ inline T divUp(T m, T n) {
   return (m + n - 1) / n;
 }
 
-// Sub-group reduction for sum.
+// Sub-group reduction for sum
 template <typename T>
 inline T subGroupReduceSum(T val, const sycl::sub_group& sg) {
   return sycl::reduce_over_group(sg, val, sycl::plus<T>());

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -226,7 +226,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("fused_qk_norm_rope", torch::kXPU, &at::native::xpu::fused_qk_norm_rope);
   m.def(
       "fused_inplace_qknorm_rope(Tensor! q, Tensor! k, Tensor q_weight, Tensor k_weight, "
-      "Tensor cos_sin_cache, Tensor positions, bool is_neox, float eps) -> ()");
+      "Tensor cos_sin_cache, Tensor positions, bool is_neox, float eps, int head_dim=0, int rope_dim=0) -> ()");
   m.impl("fused_inplace_qknorm_rope", torch::kXPU, &at::native::xpu::fused_inplace_qknorm_rope);
   /*
    * Fused QK RoPE (no RMS_Norm)


### PR DESCRIPTION
Update for `fused_inplace_qknorm_rope` to align with CUDA.