### PR TITLE
ci(xpu): sync tests/ from checkout into nightly container

### DIFF
--- a/.github/workflows/nightly_pr_nightly_xpu.yml
+++ b/.github/workflows/nightly_pr_nightly_xpu.yml
@@ -64,6 +64,15 @@ jobs:
             -e HF_TOKEN=$(cat ~/huggingface_token.txt) \
             intel/sgl-kernel-xpu-dev:latest
 
+      - name: Sync tests/ from checkout into container
+        # The nightly image bakes tests/ at build time, so any suite added to
+        # tests/run_suite.py after the last image publish is missing at runtime
+        # (e.g. --suite nightly-xpu → "invalid choice"). Copy the checked-out
+        # tests/ over the baked copy so the workflow always exercises the
+        # current source-of-truth harness against the shipped wheel.
+        run: |
+          docker cp ./tests/. nightly_sglkernel_xpu:/root/sglang/sgl-kernel-xpu/tests/
+
       - name: Install run_suite extras + HF login
         timeout-minutes: 20
         run: |


### PR DESCRIPTION
## Summary

Nightly workflow run [30165414916](https://github.com/sgl-project/sgl-kernel-xpu/actions/runs/30165414916) never actually ran any tests — it exited with:

```
run_suite.py: error: argument --suite: invalid choice: 'nightly-xpu' (choose from 'per-commit', 'all')
Process completed with exit code 2.
```

Root cause: the nightly image `intel/sgl-kernel-xpu-dev:latest` was published **before** the `nightly-xpu` suite was added to `tests/run_suite.py`, and the workflow uses the baked-in copy inside the container (`/root/sglang/sgl-kernel-xpu/tests/run_suite.py`) instead of the current source tree. The step-level `continue-on-error: schedule` then reported the job as `success` — so this has been silently failing since the workflow landed.

## Fix

Add one step right after `Run container` that `docker cp`s the checked-out `tests/` over the baked copy inside the container:

```yaml
- name: Sync tests/ from checkout into container
  run: |
    docker cp ./tests/. nightly_sglkernel_xpu:/root/sglang/sgl-kernel-xpu/tests/
```

The shipped `sgl-kernel` wheel is untouched — the workflow still exercises exactly what was published. Only the test harness gets refreshed. Future suite additions (e.g. `nightly-xpu-2gpu`) will work on the next scheduled run with no image rebuild required.

## Test plan

- [ ] Manually trigger the workflow via `workflow_dispatch` on this branch; expect `run_suite.py` to accept `--suite nightly-xpu` and actually execute `test_activation.py`.
- [ ] Confirm the shipped wheel still loads (existing `Verify pre-installed sgl-kernel wheel` step).
- [ ] Follow-up (not in this PR): consider removing `github.event_name == 'schedule'` from `continue-on-error` so a broken nightly turns red instead of green.