### PR TITLE
[XPU] Optimize paged FMHA prefill for head dim 512

### DIFF
--- a/src/FMHAPrefillXe20.cmake
+++ b/src/FMHAPrefillXe20.cmake
@@ -51,7 +51,7 @@ set(FMHA_PREFILL_NUM_SG_512 32)
 set(FMHA_PREFILL_TILED_OUT_512 256)
 option(
     FMHA_PREFILL_ENABLE_SCORE_BLOCK2D_512
-    "Reuse QK scores across the two output tiles for paged HEAD_DIM=512 prefill"
+    "Reuse QK scores across the two output tiles for HEAD_DIM=512 prefill"
     ON)
 
 # Per-HEAD_DIM tile shape parameters for the NON-PAGED (contiguous ragged) KV
@@ -89,6 +89,7 @@ set(FMHA_PREFILL_NUM_SG_NP_256 16)
 set(FMHA_PREFILL_TILED_Q_NP_512 128)
 set(FMHA_PREFILL_TILED_KV_NP_512 128)
 set(FMHA_PREFILL_NUM_SG_NP_512 16)
+set(FMHA_PREFILL_TILED_OUT_NP_512 256)
 
 # --- Paged prefill + FP8: paged head dims only, bf16 query only. ---
 # prefill_paged (16-bit KV) and prefill_fp8 (e4m3/e5m2 KV) are independent
@@ -131,6 +132,16 @@ foreach(HEAD_DIM ${FMHA_PREFILL_NP_HEAD_DIMS})
     set(NUM_SG_NP ${FMHA_PREFILL_NUM_SG_NP_${HEAD_DIM}})
     if(NOT TILED_Q_NP OR NOT TILED_KV_NP OR NOT NUM_SG_NP)
         message(FATAL_ERROR "Missing non-paged tile params for prefill HEAD_DIM=${HEAD_DIM}")
+    endif()
+
+    math(EXPR TILED_OUT_NP "((${HEAD_DIM} + 31) / 32) * 32")
+    if(DEFINED FMHA_PREFILL_TILED_OUT_NP_${HEAD_DIM})
+        set(TILED_OUT_NP ${FMHA_PREFILL_TILED_OUT_NP_${HEAD_DIM}})
+    endif()
+
+    set(ENABLE_SCORE_BLOCK2D 0)
+    if(HEAD_DIM STREQUAL "512" AND FMHA_PREFILL_ENABLE_SCORE_BLOCK2D_512)
+        set(ENABLE_SCORE_BLOCK2D 1)
     endif()
 
     set(GENERATED_NP_FILE

--- a/src/FMHAPrefillXe20.cmake
+++ b/src/FMHAPrefillXe20.cmake
@@ -49,6 +49,10 @@ set(FMHA_PREFILL_TILED_Q_512 256)
 set(FMHA_PREFILL_TILED_KV_512 64)
 set(FMHA_PREFILL_NUM_SG_512 32)
 set(FMHA_PREFILL_TILED_OUT_512 256)
+option(
+    FMHA_PREFILL_ENABLE_SCORE_BLOCK2D_512
+    "Reuse QK scores across the two output tiles for paged HEAD_DIM=512 prefill"
+    ON)
 
 # Per-HEAD_DIM tile shape parameters for the NON-PAGED (contiguous ragged) KV
 # path (TILED_Q_NP, TILED_KV_NP, NUM_SG_NP). These are kept as a separate set so
@@ -102,6 +106,11 @@ foreach(HEAD_DIM ${FMHA_PREFILL_PAGED_HEAD_DIMS})
     math(EXPR TILED_OUT "((${HEAD_DIM} + 31) / 32) * 32")
     if(DEFINED FMHA_PREFILL_TILED_OUT_${HEAD_DIM})
         set(TILED_OUT ${FMHA_PREFILL_TILED_OUT_${HEAD_DIM}})
+    endif()
+
+    set(ENABLE_SCORE_BLOCK2D 0)
+    if(HEAD_DIM STREQUAL "512" AND FMHA_PREFILL_ENABLE_SCORE_BLOCK2D_512)
+        set(ENABLE_SCORE_BLOCK2D 1)
     endif()
 
     set(GENERATED_FILE

--- a/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_mainloop.hpp
+++ b/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_mainloop.hpp
@@ -39,6 +39,10 @@
 #include "cutlass/gemm/dispatch_policy.hpp"
 #include "fmha_fusion.hpp"
 
+#ifndef FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
+#define FMHA_PREFILL_ENABLE_SCORE_BLOCK2D 0
+#endif
+
 namespace cutlass::fmha {
 
 template <int Stages>
@@ -194,6 +198,7 @@ struct FMHAFwdMainloop<
   static constexpr bool PagedKV = PagedKV_;
   static constexpr bool LocalMask = LocalMask_;
   static constexpr bool PackGQA = PackGQA_;
+  static constexpr bool ScoreBlock2D = FMHA_PREFILL_ENABLE_SCORE_BLOCK2D;
 
   // FP8 KV cache: enabled when the K element type is an 8-bit float. The fp8
   // K/V are dequantized (cast to ElementQ and multiplied by the per-tensor
@@ -208,6 +213,7 @@ struct FMHAFwdMainloop<
     int max_num_pages_per_seq = 0;
     int window_size_left = -1;
     int window_size_right = -1;
+    ElementS* ptr_score = nullptr;
   };
 
   // Kernel-facing parameters
@@ -224,7 +230,7 @@ struct FMHAFwdMainloop<
 
   FMHAFwdMainloop(Params const& params_, SharedStorage&) : params(params_) {}
 
-  static constexpr Params to_underlying_arguments(Arguments const& args, void* /* workspace */) {
+  static constexpr Params to_underlying_arguments(Arguments const& args, void* workspace) {
     constexpr double kLog2e = 1.4426950408889634074;  // log_2(e)
     ElementS val = args.scale * static_cast<ElementS>(kLog2e);
     return Params{
@@ -233,7 +239,8 @@ struct FMHAFwdMainloop<
         args.page_size,
         args.max_num_pages_per_seq,
         args.window_size_left,
-        args.window_size_right};
+        args.window_size_right,
+        ScoreBlock2D ? reinterpret_cast<ElementS*>(workspace) : nullptr};
   }
 
   CUTLASS_HOST_DEVICE static bool can_implement(Arguments const&) {
@@ -254,7 +261,7 @@ struct FMHAFwdMainloop<
     return params.ptr_page_table[batch_offset + next_page_logical_idx] * tiles_per_page + K % tiles_per_page;
   }
 
-  template <typename QVCoord>
+  template <int StaticScoreMode = -1, typename QVCoord>
   CUTLASS_DEVICE void operator()(
       TensorQ2D const& Q_2D,  // (q,d)
       TensorK2D const& K_2D,  // (k,d)
@@ -275,7 +282,8 @@ struct FMHAFwdMainloop<
       int discard_seq_coord,
       TensorK_cache2D const& K_cache_2D = TensorK_cache2D{},
       TensorV_cache2D const& V_cache_2D = TensorV_cache2D{},
-      float scale_k = 1.0f) {  // FP8 K per-tensor dequant scale
+      float scale_k = 1.0f,  // FP8 K per-tensor dequant scale
+      ElementS* score_head_ptr = nullptr) {
     using namespace sycl::ext::oneapi::this_work_item;
 
     // Short dimension names:
@@ -296,6 +304,12 @@ struct FMHAFwdMainloop<
     Tensor cK_cache = make_identity_tensor(K_cache_2D.shape());   // (k,d)
     Tensor cV_cache = make_identity_tensor(V_cache_2D.shape());   // (v,k)
     Tensor cP = make_identity_tensor(take<0, 2>(TileShapeQK{}));  // (q,k)
+#if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
+    auto score_shape = make_shape(int(size<0>(Q_2D)), seq_len_kv_cache);
+    auto score_layout = make_layout(score_shape, make_stride(seq_len_kv_cache, Int<1>{}));
+    Tensor Score = make_tensor(make_gmem_ptr(score_head_ptr), score_layout);
+    Tensor cScore = make_identity_tensor(score_shape);  // (q,k)
+#endif
 
     /* Partition global tensors into workgroup tiles */
     Tensor gQ = local_tile(cQ, TileShapeQK{}, append(blk_qv, _), Step<_1, X, _1>{});          // (q,d,D)
@@ -306,6 +320,9 @@ struct FMHAFwdMainloop<
     Tensor gK_cache = local_tile(cK_cache, TileShapeQK{}, make_coord(_, _, _), Step<X, _1, _1>{});        // (k,d,K,D)
     Tensor gV_cache = local_tile(cV_cache, tile_shape_v, make_coord(get<1>(blk_qv), _));                  // (v,k,K)
     Tensor gV_cache_split = local_tile(gV_cache, TileShapePV{}, make_coord(_, _, 0), Step<X, _1, _1>{});  // (v,k,VV,K)
+#if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
+    Tensor gScore = local_tile(cScore, take<0, 2>(TileShapeQK{}), make_coord(get<0>(blk_qv), _));  // (q,k,K)
+#endif
 
     /* Create global -> register copies */
     TiledCopyQ copy_q{Q_2D};
@@ -317,6 +334,10 @@ struct FMHAFwdMainloop<
     /* Create MMAs */
     TiledMMAQK mma_qk{};
     TiledMMAPV mma_pv{};
+#if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
+    auto copy_score_store = make_block_2d_copy_D(mma_qk, Score);
+    auto copy_score_load = make_block_2d_copy_C(mma_qk, Score);
+#endif
 
     /* Slice TiledCopy/TiledMMA operations down to to work-item level */
     auto thr_copy_q = copy_q.get_slice(thr_id);
@@ -326,6 +347,10 @@ struct FMHAFwdMainloop<
     auto thr_copy_v_cache = copy_v_cache.get_slice(thr_id);
     auto thr_mma_qk = mma_qk.get_slice(thr_id);
     auto thr_mma_pv = mma_pv.get_slice(thr_id);
+#if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
+    auto thr_copy_score_store = copy_score_store.get_slice(thr_id);
+    auto thr_copy_score_load = copy_score_load.get_slice(thr_id);
+#endif
 
     /* Partition coordinate tensors for copy */
     auto tQgQ = thr_copy_q.partition_S(gQ);        // (atom_val,q',d',D)
@@ -343,6 +368,12 @@ struct FMHAFwdMainloop<
 
     auto tSrS = thr_mma_qk.partition_sg_fragment_C(cP);
     auto tArP = thr_mma_pv.partition_sg_fragment_A(cP);
+#if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
+    auto tScoreStoreR = thr_copy_score_store.partition_sg_fragment_S(gScore(_, _, 0));
+    auto tScoreStoreG = thr_copy_score_store.partition_D(gScore);
+    auto tScoreLoadG = thr_copy_score_load.partition_S(gScore);
+    auto tScoreLoadR = thr_copy_score_load.partition_sg_fragment_D(gScore(_, _, 0));
+#endif
 
     auto tVrV = thr_copy_v.partition_sg_fragment_D(gV_split(_, _, 0, 0));
     auto tArV = thr_mma_pv.partition_sg_fragment_B(gV_split(_, _, 0, 0));
@@ -373,11 +404,13 @@ struct FMHAFwdMainloop<
     if constexpr (PagedKV) {
       next_page_idx = get_physical_k_tile(blk_k0, l_coord, seq_len_kv_cache);
     }
-    for (int D = 0; D < size<3>(pQgQ); D++) {
-      prefetch(prefetch_q, pQgQ(_, _, _, D));
-    }
-    for (int D = 0; D < size<4>(pKgK); D++) {
-      prefetch(prefetch_k_cache, pKgK_cache(_, _, _, next_page_idx, D));
+    if constexpr (!(ScoreBlock2D && StaticScoreMode == 1)) {
+      for (int D = 0; D < size<3>(pQgQ); D++) {
+        prefetch(prefetch_q, pQgQ(_, _, _, D));
+      }
+      for (int D = 0; D < size<4>(pKgK); D++) {
+        prefetch(prefetch_k_cache, pKgK_cache(_, _, _, next_page_idx, D));
+      }
     }
     // Always initialize the per-WG accumulators: the caller (kernel) may pass
     // blk_k0 > 0 when sliding-window pruning skips leading K blocks, so we can
@@ -414,15 +447,22 @@ struct FMHAFwdMainloop<
         next_page_idx = get_physical_k_tile(next_page_idx, l_coord, seq_len_kv_cache);
       }
 
-      /* GEMM 1: S = K * Q */
-      clear(tSrS);
-      CUTLASS_PRAGMA_UNROLL
-      for (int D = 0; D < size<4>(tKgK); D++) {
-        copy(copy_q, tQgQ(_, _, _, D), tQrQ);
-        copy(copy_k_cache, tKgK_cache(_, _, _, page_idx, D), tKrK);
-        reorder(tQrQ, tSrQ);
-        reorder(tKrK, tSrK);
-        cute::gemm(mma_qk, tSrQ, tSrK, tSrS);
+      if constexpr (ScoreBlock2D && StaticScoreMode == 1) {
+#if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
+        copy(copy_score_load, tScoreLoadG(_, _, _, K), tScoreLoadR);
+        reorder(tScoreLoadR, tSrS);
+#endif
+      } else {
+        /* GEMM 1: S = K * Q */
+        clear(tSrS);
+        CUTLASS_PRAGMA_UNROLL
+        for (int D = 0; D < size<4>(tKgK); D++) {
+          copy(copy_q, tQgQ(_, _, _, D), tQrQ);
+          copy(copy_k_cache, tKgK_cache(_, _, _, page_idx, D), tKrK);
+          reorder(tQrQ, tSrQ);
+          reorder(tKrK, tSrK);
+          cute::gemm(mma_qk, tSrQ, tSrK, tSrS);
+        }
       }
 
       /* V prefetch for GEMM 2 */
@@ -432,7 +472,7 @@ struct FMHAFwdMainloop<
       }
 
       /* Causal masking */
-      if constexpr (CausalMask) {
+      if constexpr (CausalMask && !(ScoreBlock2D && StaticScoreMode == 1)) {
         if (need_causal) {
           /* Masking scalars */
           // TODO: use a more general code path for causal masking.
@@ -459,7 +499,7 @@ struct FMHAFwdMainloop<
       }
 
       /* Local/sliding window masking */
-      if constexpr (LocalMask) {
+      if constexpr (LocalMask && !(ScoreBlock2D && StaticScoreMode == 1)) {
         Tensor cPgP = make_identity_tensor(make_shape(seq_len, seq_len));
         Tensor gP = local_tile(cPgP, take<0, 2>(TileShapeQK{}), make_coord(get<0>(blk_qv), K));
         auto cS_thread = thr_mma_qk.partition_C(gP);
@@ -480,6 +520,8 @@ struct FMHAFwdMainloop<
       }
 
       /* k masking for remainder tiles */
+      // The block2D score store clips tail columns at seq_len, so load mode
+      // must mask the remainder again before softmax.
       if (check_remainder_k && K == total_blk - 1) {
         FragSCol k_rem_mask;
         int k_val = get<0>(tKgK_cache(0, 0, 0, K, 0));
@@ -494,8 +536,23 @@ struct FMHAFwdMainloop<
         }
       }
 
+#if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
+      if constexpr (ScoreBlock2D && StaticScoreMode == 0) {
+        reorder(tSrS, tScoreStoreR);
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < tScoreStoreR.size(); ++i) {
+          tScoreStoreR(i) *= qk_scale;
+        }
+        copy(copy_score_store, tScoreStoreR, tScoreStoreG(_, _, _, K));
+      }
+#endif
+
       /* Apply softmax and scaling (tA rescaling fused into GEMM2 VTile loop) */
-      auto rescale = softmax(K == blk_k0, tSrS, tA_max, tA_sum, qk_scale);
+      ElementS softmax_scale = qk_scale;
+      if constexpr (ScoreBlock2D && StaticScoreMode == 1) {
+        softmax_scale = ElementS(1);
+      }
+      auto rescale = softmax(K == blk_k0, tSrS, tA_max, tA_sum, softmax_scale);
       reorder(tSrS, tArP);
 
       /* GEMM 2: A += P * V, split in v dimension. */
@@ -513,8 +570,10 @@ struct FMHAFwdMainloop<
       }
 
       /* K prefetch */
-      for (int D = 0; D < size<4>(pKgK); D++) {
-        prefetch(prefetch_k_cache, pKgK_cache(_, _, _, next_page_idx, D));
+      if constexpr (!(ScoreBlock2D && StaticScoreMode == 1)) {
+        for (int D = 0; D < size<4>(pKgK); D++) {
+          prefetch(prefetch_k_cache, pKgK_cache(_, _, _, next_page_idx, D));
+        }
       }
 
       barrier_wait(ScopeWorkgroup);

--- a/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_mainloop.hpp
+++ b/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_mainloop.hpp
@@ -43,57 +43,19 @@
 #define FMHA_PREFILL_ENABLE_SCORE_BLOCK2D 0
 #endif
 
-#ifndef FMHA_PREFILL_ZIGZAG_D
-#define FMHA_PREFILL_ZIGZAG_D 1
-#endif
-
-#ifndef FMHA_PREFILL_INIT_PF_DEPTH
-#define FMHA_PREFILL_INIT_PF_DEPTH 8
-#endif
-
-#ifndef FMHA_PREFILL_PF_ZIGZAG
-#define FMHA_PREFILL_PF_ZIGZAG 1
-#endif
-
-#ifndef FMHA_PREFILL_NO_SPLIT_BARRIER
-#define FMHA_PREFILL_NO_SPLIT_BARRIER 2
-#endif
-
-#ifndef FMHA_PREFILL_D_SKEW
-#define FMHA_PREFILL_D_SKEW 1
-#endif
-
-#ifndef FMHA_PREFILL_V_PF_NEXT
-#define FMHA_PREFILL_V_PF_NEXT 2
-#endif
-
-#ifndef FMHA_PREFILL_SCORE_PF_AUTO
-#define FMHA_PREFILL_SCORE_PF_AUTO 1
-#endif
-
-#ifndef FMHA_PREFILL_SCORE_PF_AUTO_KB_LO
-#define FMHA_PREFILL_SCORE_PF_AUTO_KB_LO 29
-#endif
-
-#ifndef FMHA_PREFILL_SCORE_PF_AUTO_KB_HI
-#define FMHA_PREFILL_SCORE_PF_AUTO_KB_HI 44
-#endif
-
-#ifndef FMHA_PREFILL_SCORE_PF_AUTO_Q_MIN
-#define FMHA_PREFILL_SCORE_PF_AUTO_Q_MIN 2048
-#endif
-
-// Cap, in MiB, on the ScoreBlock2D score workspace. Above the cap the runner
-// slices the batch and reuses one slice-sized buffer across the launch pairs.
-// 0 disables slicing. FMHA_SCORE_WS_CAP_MB overrides this at runtime.
-#ifndef FMHA_PREFILL_SCORE_WS_CAP_MB
-#define FMHA_PREFILL_SCORE_WS_CAP_MB 1024
-#endif
-
 namespace cutlass::fmha {
 
 template <int Stages>
 class XeDefault {};  // Default FMHA mainloop, P in registers.
+
+struct ScoreBlock2DPolicy {
+  static constexpr bool ZigzagD = true;
+  static constexpr int DSkew = 1;
+  static constexpr int InitialPrefetchDepth = 8;
+  static constexpr int ScorePrefetchKBlockMin = 29;
+  static constexpr int ScorePrefetchKBlockMax = 44;
+  static constexpr int ScorePrefetchQMin = 2048;
+};
 
 };  // namespace cutlass::fmha
 
@@ -247,13 +209,9 @@ struct FMHAFwdMainloop<
   static constexpr bool LocalMask = LocalMask_;
   static constexpr bool PackGQA = PackGQA_;
   static constexpr bool ScoreBlock2D = FMHA_PREFILL_ENABLE_SCORE_BLOCK2D;
-  static constexpr bool ZigzagD = ScoreBlock2D && FMHA_PREFILL_ZIGZAG_D;
-  static constexpr int DSkew = ScoreBlock2D ? FMHA_PREFILL_D_SKEW : 0;
-  static constexpr bool PfZigzag = ScoreBlock2D && FMHA_PREFILL_PF_ZIGZAG;
-  static constexpr int InitPfDepth = ScoreBlock2D ? FMHA_PREFILL_INIT_PF_DEPTH : 0;
-  static constexpr int NoSplitBarrierMode = FMHA_PREFILL_NO_SPLIT_BARRIER;
-  static constexpr int VPfNextMode = FMHA_PREFILL_V_PF_NEXT;
-  static constexpr bool ScorePfAuto = ScoreBlock2D && FMHA_PREFILL_SCORE_PF_AUTO;
+  static constexpr bool ZigzagD = ScoreBlock2D && ScoreBlock2DPolicy::ZigzagD;
+  static constexpr int DSkew = ScoreBlock2D ? ScoreBlock2DPolicy::DSkew : 0;
+  static constexpr int InitPfDepth = ScoreBlock2D ? ScoreBlock2DPolicy::InitialPrefetchDepth : 0;
 
   // FP8 KV cache: enabled when the K element type is an 8-bit float. The fp8
   // K/V are dequantized (cast to ElementQ and multiplied by the per-tensor
@@ -522,16 +480,17 @@ struct FMHAFwdMainloop<
       qk_scale = params.scale * static_cast<ElementS>(scale_k);
     }
 
-    constexpr bool SkipSplitBarrier =
-        (NoSplitBarrierMode == 1) || (NoSplitBarrierMode == 2 && ScoreBlock2D && StaticScoreMode == 1);
-    constexpr bool VPfNext = (VPfNextMode == 1) || (VPfNextMode == 2 && ScoreBlock2D && StaticScoreMode == 1);
+    constexpr bool SkipSplitBarrier = ScoreBlock2D && StaticScoreMode == 1;
+    constexpr bool VPfNext = ScoreBlock2D && StaticScoreMode == 1;
 
 #if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
     int score_pf_dist = 0;
-    if constexpr (ScorePfAuto) {
+    if constexpr (ScoreBlock2D) {
       const int kb = kblocks_cache;
-      score_pf_dist =
-          (score_pf_q_ok && kb >= FMHA_PREFILL_SCORE_PF_AUTO_KB_LO && kb < FMHA_PREFILL_SCORE_PF_AUTO_KB_HI) ? 1 : 0;
+      score_pf_dist = (score_pf_q_ok && kb >= ScoreBlock2DPolicy::ScorePrefetchKBlockMin &&
+                       kb < ScoreBlock2DPolicy::ScorePrefetchKBlockMax)
+                          ? 1
+                          : 0;
     }
 #endif
 
@@ -703,7 +662,7 @@ struct FMHAFwdMainloop<
       if constexpr (!(ScoreBlock2D && StaticScoreMode == 1)) {
         if (ScoreBlock2D || K + 1 < k_end) {
           const int nPf = size<4>(pKgK);
-          const bool rev = PfZigzag && ZigzagD && ((K + 1) & 1);
+          const bool rev = ZigzagD && ((K + 1) & 1);
           const int pf_skew = (DSkew > 0) ? (int(thr_id / intel::sg_size) * DSkew) % nPf : 0;
           for (int Di = 0; Di < nPf; Di++) {
             int D = rev ? (nPf - 1 - Di) : Di;

--- a/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_mainloop.hpp
+++ b/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_mainloop.hpp
@@ -43,6 +43,53 @@
 #define FMHA_PREFILL_ENABLE_SCORE_BLOCK2D 0
 #endif
 
+#ifndef FMHA_PREFILL_ZIGZAG_D
+#define FMHA_PREFILL_ZIGZAG_D 1
+#endif
+
+#ifndef FMHA_PREFILL_INIT_PF_DEPTH
+#define FMHA_PREFILL_INIT_PF_DEPTH 8
+#endif
+
+#ifndef FMHA_PREFILL_PF_ZIGZAG
+#define FMHA_PREFILL_PF_ZIGZAG 1
+#endif
+
+#ifndef FMHA_PREFILL_NO_SPLIT_BARRIER
+#define FMHA_PREFILL_NO_SPLIT_BARRIER 2
+#endif
+
+#ifndef FMHA_PREFILL_D_SKEW
+#define FMHA_PREFILL_D_SKEW 1
+#endif
+
+#ifndef FMHA_PREFILL_V_PF_NEXT
+#define FMHA_PREFILL_V_PF_NEXT 2
+#endif
+
+#ifndef FMHA_PREFILL_SCORE_PF_AUTO
+#define FMHA_PREFILL_SCORE_PF_AUTO 1
+#endif
+
+#ifndef FMHA_PREFILL_SCORE_PF_AUTO_KB_LO
+#define FMHA_PREFILL_SCORE_PF_AUTO_KB_LO 29
+#endif
+
+#ifndef FMHA_PREFILL_SCORE_PF_AUTO_KB_HI
+#define FMHA_PREFILL_SCORE_PF_AUTO_KB_HI 44
+#endif
+
+#ifndef FMHA_PREFILL_SCORE_PF_AUTO_Q_MIN
+#define FMHA_PREFILL_SCORE_PF_AUTO_Q_MIN 2048
+#endif
+
+// Cap, in MiB, on the ScoreBlock2D score workspace. Above the cap the runner
+// slices the batch and reuses one slice-sized buffer across the launch pairs.
+// 0 disables slicing. FMHA_SCORE_WS_CAP_MB overrides this at runtime.
+#ifndef FMHA_PREFILL_SCORE_WS_CAP_MB
+#define FMHA_PREFILL_SCORE_WS_CAP_MB 1024
+#endif
+
 namespace cutlass::fmha {
 
 template <int Stages>
@@ -187,6 +234,7 @@ struct FMHAFwdMainloop<
   using FragSRow = decltype(reduce<1>(FragS{}, sycl::plus<void>{}));
   using FragSCol = decltype(reduce<0>(FragS{}, sycl::plus<void>{}));
   using ElementS = typename TiledMMAQK::ValTypeD;
+  using ElementScoreStore = half_t;
 
   using SingleFragA = FragC<TiledMMAPV>;                       // (atom val,q',v')
   using FragA = expand_sg_fragment_t<SingleFragA, 1, VTiles>;  // (atom val,q',v',VV)
@@ -199,6 +247,13 @@ struct FMHAFwdMainloop<
   static constexpr bool LocalMask = LocalMask_;
   static constexpr bool PackGQA = PackGQA_;
   static constexpr bool ScoreBlock2D = FMHA_PREFILL_ENABLE_SCORE_BLOCK2D;
+  static constexpr bool ZigzagD = ScoreBlock2D && FMHA_PREFILL_ZIGZAG_D;
+  static constexpr int DSkew = ScoreBlock2D ? FMHA_PREFILL_D_SKEW : 0;
+  static constexpr bool PfZigzag = ScoreBlock2D && FMHA_PREFILL_PF_ZIGZAG;
+  static constexpr int InitPfDepth = ScoreBlock2D ? FMHA_PREFILL_INIT_PF_DEPTH : 0;
+  static constexpr int NoSplitBarrierMode = FMHA_PREFILL_NO_SPLIT_BARRIER;
+  static constexpr int VPfNextMode = FMHA_PREFILL_V_PF_NEXT;
+  static constexpr bool ScorePfAuto = ScoreBlock2D && FMHA_PREFILL_SCORE_PF_AUTO;
 
   // FP8 KV cache: enabled when the K element type is an 8-bit float. The fp8
   // K/V are dequantized (cast to ElementQ and multiplied by the per-tensor
@@ -213,7 +268,9 @@ struct FMHAFwdMainloop<
     int max_num_pages_per_seq = 0;
     int window_size_left = -1;
     int window_size_right = -1;
-    ElementS* ptr_score = nullptr;
+#if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
+    ElementScoreStore* ptr_score = nullptr;
+#endif
   };
 
   // Kernel-facing parameters
@@ -240,7 +297,11 @@ struct FMHAFwdMainloop<
         args.max_num_pages_per_seq,
         args.window_size_left,
         args.window_size_right,
-        ScoreBlock2D ? reinterpret_cast<ElementS*>(workspace) : nullptr};
+#if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
+        ScoreBlock2D ? reinterpret_cast<ElementScoreStore*>(workspace) : nullptr};
+#else
+    };
+#endif
   }
 
   CUTLASS_HOST_DEVICE static bool can_implement(Arguments const&) {
@@ -282,8 +343,15 @@ struct FMHAFwdMainloop<
       int discard_seq_coord,
       TensorK_cache2D const& K_cache_2D = TensorK_cache2D{},
       TensorV_cache2D const& V_cache_2D = TensorV_cache2D{},
-      float scale_k = 1.0f,  // FP8 K per-tensor dequant scale
-      ElementS* score_head_ptr = nullptr) {
+      float scale_k = 1.0f  // FP8 K per-tensor dequant scale
+#if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
+      ,
+      ElementScoreStore* score_head_ptr = nullptr,
+      int score_region_cols = 0,
+      int score_blk_in_region = 0,
+      bool score_pf_q_ok = false
+#endif
+  ) {
     using namespace sycl::ext::oneapi::this_work_item;
 
     // Short dimension names:
@@ -305,8 +373,10 @@ struct FMHAFwdMainloop<
     Tensor cV_cache = make_identity_tensor(V_cache_2D.shape());   // (v,k)
     Tensor cP = make_identity_tensor(take<0, 2>(TileShapeQK{}));  // (q,k)
 #if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
-    auto score_shape = make_shape(int(size<0>(Q_2D)), seq_len_kv_cache);
-    auto score_layout = make_layout(score_shape, make_stride(seq_len_kv_cache, Int<1>{}));
+    const int score_rows = int(get<0>(TileShapeQK{}));
+    const int score_cols = score_region_cols > 0 ? score_region_cols : seq_len_kv_cache;
+    auto score_shape = make_shape(score_rows, score_cols);
+    auto score_layout = make_layout(score_shape, make_stride(score_cols, Int<1>{}));
     Tensor Score = make_tensor(make_gmem_ptr(score_head_ptr), score_layout);
     Tensor cScore = make_identity_tensor(score_shape);  // (q,k)
 #endif
@@ -321,7 +391,7 @@ struct FMHAFwdMainloop<
     Tensor gV_cache = local_tile(cV_cache, tile_shape_v, make_coord(get<1>(blk_qv), _));                  // (v,k,K)
     Tensor gV_cache_split = local_tile(gV_cache, TileShapePV{}, make_coord(_, _, 0), Step<X, _1, _1>{});  // (v,k,VV,K)
 #if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
-    Tensor gScore = local_tile(cScore, take<0, 2>(TileShapeQK{}), make_coord(get<0>(blk_qv), _));  // (q,k,K)
+    Tensor gScore = local_tile(cScore, take<0, 2>(TileShapeQK{}), make_coord(score_blk_in_region, _));  // (q,k,K)
 #endif
 
     /* Create global -> register copies */
@@ -337,6 +407,7 @@ struct FMHAFwdMainloop<
 #if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
     auto copy_score_store = make_block_2d_copy_D(mma_qk, Score);
     auto copy_score_load = make_block_2d_copy_C(mma_qk, Score);
+    auto prefetch_score = make_block_2d_prefetch(copy_score_load);
 #endif
 
     /* Slice TiledCopy/TiledMMA operations down to to work-item level */
@@ -373,6 +444,7 @@ struct FMHAFwdMainloop<
     auto tScoreStoreG = thr_copy_score_store.partition_D(gScore);
     auto tScoreLoadG = thr_copy_score_load.partition_S(gScore);
     auto tScoreLoadR = thr_copy_score_load.partition_sg_fragment_D(gScore(_, _, 0));
+    auto pScoreG = prefetch_score.get_slice(thr_id).partition_S(gScore);
 #endif
 
     auto tVrV = thr_copy_v.partition_sg_fragment_D(gV_split(_, _, 0, 0));
@@ -397,19 +469,38 @@ struct FMHAFwdMainloop<
     // ------
 
     /* Initialization steps for first block: Q/K prefetch, O init */
-    /* TODO: limit D prefetch for large head size, and reorder K prefetches */
     int kblocks_cache = ceil_div(seq_len_kv_cache, get<1>(TileShapeQK{}));
+    const int k_end = cute::min(blk_k1, kblocks_cache);
     int page_idx = blk_k0;
     int next_page_idx = blk_k0;
     if constexpr (PagedKV) {
       next_page_idx = get_physical_k_tile(blk_k0, l_coord, seq_len_kv_cache);
     }
     if constexpr (!(ScoreBlock2D && StaticScoreMode == 1)) {
-      for (int D = 0; D < size<3>(pQgQ); D++) {
+      const int nQpf = InitPfDepth > 0 ? cute::min(int(size<3>(pQgQ)), InitPfDepth) : int(size<3>(pQgQ));
+      const int nKpf = InitPfDepth > 0 ? cute::min(int(size<4>(pKgK)), InitPfDepth) : int(size<4>(pKgK));
+      const int sg = int(thr_id / intel::sg_size);
+      for (int Di = 0; Di < nQpf; Di++) {
+        int D = Di;
+        if constexpr (DSkew > 0) {
+          D += (sg * DSkew) % nQpf;
+          if (D >= nQpf) {
+            D -= nQpf;
+          }
+        }
         prefetch(prefetch_q, pQgQ(_, _, _, D));
       }
-      for (int D = 0; D < size<4>(pKgK); D++) {
-        prefetch(prefetch_k_cache, pKgK_cache(_, _, _, next_page_idx, D));
+      if (blk_k0 < k_end) {
+        for (int Di = 0; Di < nKpf; Di++) {
+          int D = Di;
+          if constexpr (DSkew > 0) {
+            D += (sg * DSkew) % nKpf;
+            if (D >= nKpf) {
+              D -= nKpf;
+            }
+          }
+          prefetch(prefetch_k_cache, pKgK_cache(_, _, _, next_page_idx, D));
+        }
       }
     }
     // Always initialize the per-WG accumulators: the caller (kernel) may pass
@@ -431,10 +522,24 @@ struct FMHAFwdMainloop<
       qk_scale = params.scale * static_cast<ElementS>(scale_k);
     }
 
+    constexpr bool SkipSplitBarrier =
+        (NoSplitBarrierMode == 1) || (NoSplitBarrierMode == 2 && ScoreBlock2D && StaticScoreMode == 1);
+    constexpr bool VPfNext = (VPfNextMode == 1) || (VPfNextMode == 2 && ScoreBlock2D && StaticScoreMode == 1);
+
+#if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
+    int score_pf_dist = 0;
+    if constexpr (ScorePfAuto) {
+      const int kb = kblocks_cache;
+      score_pf_dist =
+          (score_pf_q_ok && kb >= FMHA_PREFILL_SCORE_PF_AUTO_KB_LO && kb < FMHA_PREFILL_SCORE_PF_AUTO_KB_HI) ? 1 : 0;
+    }
+#endif
+
     /* Main loop, blocked in k. */
-    for (int K = blk_k0; K < blk_k1 && K < kblocks_cache; K++) {
-      /* Split barrier to keep threads together */
-      barrier_arrive(ScopeWorkgroup);
+    for (int K = blk_k0; K < k_end; K++) {
+      if constexpr (!ScoreBlock2D && !SkipSplitBarrier) {
+        barrier_arrive(ScopeWorkgroup);
+      }
 
       bool need_causal = false;
       if constexpr (CausalMask) {
@@ -442,21 +547,26 @@ struct FMHAFwdMainloop<
       }
 
       page_idx = next_page_idx;
-      next_page_idx = K + 1;
-      if constexpr (PagedKV) {
-        next_page_idx = get_physical_k_tile(next_page_idx, l_coord, seq_len_kv_cache);
+      if constexpr (!ScoreBlock2D) {
+        next_page_idx = K + 1;
+        if constexpr (PagedKV) {
+          next_page_idx = get_physical_k_tile(next_page_idx, l_coord, seq_len_kv_cache);
+        }
       }
 
-      if constexpr (ScoreBlock2D && StaticScoreMode == 1) {
-#if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
-        copy(copy_score_load, tScoreLoadG(_, _, _, K), tScoreLoadR);
-        reorder(tScoreLoadR, tSrS);
-#endif
-      } else {
+      if constexpr (!(ScoreBlock2D && StaticScoreMode == 1)) {
         /* GEMM 1: S = K * Q */
         clear(tSrS);
+        const int d_tiles = size<4>(tKgK);
         CUTLASS_PRAGMA_UNROLL
-        for (int D = 0; D < size<4>(tKgK); D++) {
+        for (int Di = 0; Di < d_tiles; Di++) {
+          int D = (ZigzagD && (K & 1)) ? (d_tiles - 1 - Di) : Di;
+          if constexpr (DSkew > 0) {
+            D += (int(thr_id / intel::sg_size) * DSkew) % d_tiles;
+            if (D >= d_tiles) {
+              D -= d_tiles;
+            }
+          }
           copy(copy_q, tQgQ(_, _, _, D), tQrQ);
           copy(copy_k_cache, tKgK_cache(_, _, _, page_idx, D), tKrK);
           reorder(tQrQ, tSrQ);
@@ -465,10 +575,36 @@ struct FMHAFwdMainloop<
         }
       }
 
+      /* Split barrier to keep threads together */
+      if constexpr (ScoreBlock2D && !SkipSplitBarrier) {
+        barrier_arrive(ScopeWorkgroup);
+      }
+
+      if constexpr (ScoreBlock2D) {
+        next_page_idx = cute::min(K + 1, k_end - 1);
+        if constexpr (PagedKV) {
+          next_page_idx = get_physical_k_tile(next_page_idx, l_coord, seq_len_kv_cache);
+        }
+      }
+
+      if constexpr (ScoreBlock2D && StaticScoreMode == 1) {
+#if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
+        if (score_pf_dist > 0) {
+          prefetch(prefetch_score, pScoreG(_, _, _, cute::min(K + score_pf_dist, k_end - 1)));
+        }
+        copy(copy_score_load, tScoreLoadG(_, _, _, K), tScoreLoadR);
+        reorder(tScoreLoadR, tSrS);
+#endif
+      }
+
       /* V prefetch for GEMM 2 */
+      int v_pf_idx = page_idx;
+      if constexpr (VPfNext) {
+        v_pf_idx = next_page_idx;
+      }
       CUTLASS_PRAGMA_UNROLL
       for (int VV = 0; VV < VTiles; VV++) {
-        prefetch(prefetch_v_cache, pVgV_cache(_, _, _, VV, page_idx));
+        prefetch(prefetch_v_cache, pVgV_cache(_, _, _, VV, v_pf_idx));
       }
 
       /* Causal masking */
@@ -538,21 +674,15 @@ struct FMHAFwdMainloop<
 
 #if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
       if constexpr (ScoreBlock2D && StaticScoreMode == 0) {
+        // Store raw logits in fp16. Applying qk_scale after the reload keeps the
+        // narrowing error out of the exponent's unscaled input.
         reorder(tSrS, tScoreStoreR);
-        CUTLASS_PRAGMA_UNROLL
-        for (int i = 0; i < tScoreStoreR.size(); ++i) {
-          tScoreStoreR(i) *= qk_scale;
-        }
         copy(copy_score_store, tScoreStoreR, tScoreStoreG(_, _, _, K));
       }
 #endif
 
       /* Apply softmax and scaling (tA rescaling fused into GEMM2 VTile loop) */
-      ElementS softmax_scale = qk_scale;
-      if constexpr (ScoreBlock2D && StaticScoreMode == 1) {
-        softmax_scale = ElementS(1);
-      }
-      auto rescale = softmax(K == blk_k0, tSrS, tA_max, tA_sum, softmax_scale);
+      auto rescale = softmax(K == blk_k0, tSrS, tA_max, tA_sum, qk_scale);
       reorder(tSrS, tArP);
 
       /* GEMM 2: A += P * V, split in v dimension. */
@@ -571,12 +701,26 @@ struct FMHAFwdMainloop<
 
       /* K prefetch */
       if constexpr (!(ScoreBlock2D && StaticScoreMode == 1)) {
-        for (int D = 0; D < size<4>(pKgK); D++) {
-          prefetch(prefetch_k_cache, pKgK_cache(_, _, _, next_page_idx, D));
+        if (ScoreBlock2D || K + 1 < k_end) {
+          const int nPf = size<4>(pKgK);
+          const bool rev = PfZigzag && ZigzagD && ((K + 1) & 1);
+          const int pf_skew = (DSkew > 0) ? (int(thr_id / intel::sg_size) * DSkew) % nPf : 0;
+          for (int Di = 0; Di < nPf; Di++) {
+            int D = rev ? (nPf - 1 - Di) : Di;
+            if constexpr (DSkew > 0) {
+              D += pf_skew;
+              if (D >= nPf) {
+                D -= nPf;
+              }
+            }
+            prefetch(prefetch_k_cache, pKgK_cache(_, _, _, next_page_idx, D));
+          }
         }
       }
 
-      barrier_wait(ScopeWorkgroup);
+      if constexpr (!SkipSplitBarrier) {
+        barrier_wait(ScopeWorkgroup);
+      }
     }
   }
 

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
@@ -233,19 +233,22 @@ class XeFMHAFwdKernel {
     return CollectiveMainloop::can_implement(args.mainloop) && CollectiveEpilogue::can_implement(args.epilogue);
   }
 
-  static int get_workspace_size(Arguments const& args) {
+  static size_t get_workspace_size(Arguments const& args) {
     if constexpr (CollectiveMainloop::ScoreBlock2D) {
-      int score_q_extent;
-      int score_k_extent;
+      size_t score_q_extent;
+      size_t score_k_extent;
       if constexpr (is_var_len) {
-        score_q_extent = int(args.kernel.shape.seq_len_qo.max_length);
-        score_k_extent = int(args.kernel.shape.seq_len_kv_cache.max_length);
+        score_q_extent = size_t(args.kernel.shape.seq_len_qo.max_length);
+        score_k_extent = size_t(args.kernel.shape.seq_len_kv_cache.max_length);
       } else {
-        score_q_extent = int(args.kernel.shape.seq_len_qo);
-        score_k_extent = int(args.kernel.shape.seq_len_kv_cache);
+        score_q_extent = size_t(args.kernel.shape.seq_len_qo);
+        score_k_extent = size_t(args.kernel.shape.seq_len_kv_cache);
       }
-      return int(args.kernel.shape.batch) * int(args.kernel.shape.num_heads_q) * score_q_extent * score_k_extent *
-             int(sizeof(typename CollectiveMainloop::ElementS));
+      const size_t score_rows_per_wg = size_t(get<0>(TileShapeQK{}));
+      const size_t q_tiles = cute::ceil_div(score_q_extent, score_rows_per_wg);
+      score_k_extent = cute::round_up(score_k_extent, size_t(get<1>(TileShapeQK{})));
+      return size_t(args.kernel.shape.batch) * size_t(args.kernel.shape.num_heads_q) * q_tiles * score_rows_per_wg *
+             score_k_extent * sizeof(typename CollectiveMainloop::ElementScoreStore);
     }
     return 0;
   }
@@ -442,7 +445,10 @@ class XeFMHAFwdKernel {
       // With PackGQA the Q/O head dimension is indexed by the KV head; otherwise
       // by the (un-grouped) query head.
       int q_head_idx = PackGQA_ ? head : head_q;
-      typename CollectiveMainloop::ElementS* score_head_ptr = nullptr;
+#if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
+      typename CollectiveMainloop::ElementScoreStore* score_head_ptr = nullptr;
+      int score_region_cols = 0;
+      bool score_pf_q_ok = false;
       if constexpr (CollectiveMainloop::ScoreBlock2D) {
         int score_q_extent;
         int score_k_extent;
@@ -456,9 +462,14 @@ class XeFMHAFwdKernel {
           score_k_extent = int(s.seq_len_kv_cache);
           score_batch = l_coord;
         }
-        score_head_ptr =
-            params.mainloop.ptr_score + (score_batch * s.num_heads_q + q_head_idx) * score_q_extent * score_k_extent;
+        score_k_extent = cute::round_up(score_k_extent, int(get<1>(TileShapeQK{})));
+        score_region_cols = score_k_extent;
+        score_pf_q_ok = score_q_extent >= FMHA_PREFILL_SCORE_PF_AUTO_Q_MIN;
+        const int q_tiles = cute::ceil_div(score_q_extent, int(get<0>(TileShapeQK{})));
+        const size_t wg_slot = (size_t(score_batch) * s.num_heads_q + q_head_idx) * q_tiles + size_t(blk_q);
+        score_head_ptr = params.mainloop.ptr_score + wg_slot * size_t(get<0>(TileShapeQK{})) * size_t(score_k_extent);
       }
+#endif
       // FP8 KV: the per-tensor dequant scale baked into KernelArguments is
       // passed as a float function argument (scale_k) to the mainloop GEMM1.
       // It defaults to 1.0f for non-fp8 KV; the fp8 dequant scalar is read
@@ -469,6 +480,7 @@ class XeFMHAFwdKernel {
         scale_k = *p.scale_k_ptr;
       }
       CollectiveMainloop mainloop(params.mainloop, shared_storage.mainloop);
+#if FMHA_PREFILL_ENABLE_SCORE_BLOCK2D
       mainloop.template operator()<StaticScoreMode_>(
           Q(_, _, q_head_idx, l_coord),
           K_cache(_, _, head, l_coord),
@@ -490,7 +502,33 @@ class XeFMHAFwdKernel {
           K_cache(_, _, head, l_coord),
           V_cache(_, _, head, l_coord),
           scale_k,
-          score_head_ptr);
+          score_head_ptr,
+          score_region_cols,
+          0,
+          score_pf_q_ok);
+#else
+      mainloop(
+          Q(_, _, q_head_idx, l_coord),
+          K_cache(_, _, head, l_coord),
+          V_cache(_, _, head, l_coord),
+          tArA,
+          tA_max,
+          tA_sum,
+          blk_qv,
+          blk_k0,
+          blk_k1,
+          k_blocks,
+          k_blocks_causal,
+          thr_id,
+          seq_len,
+          seq_len_kv_cache,
+          idx_b,
+          full_tile_offset,
+          discard_seq_coord,
+          K_cache(_, _, head, l_coord),
+          V_cache(_, _, head, l_coord),
+          scale_k);
+#endif
 
       if constexpr (!is_empty_v<MainloopSharedStorage> && !is_empty_v<EpilogueSharedStorage>) {
         sycl::group_barrier(get_work_group<3>());

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
@@ -464,7 +464,7 @@ class XeFMHAFwdKernel {
         }
         score_k_extent = cute::round_up(score_k_extent, int(get<1>(TileShapeQK{})));
         score_region_cols = score_k_extent;
-        score_pf_q_ok = score_q_extent >= FMHA_PREFILL_SCORE_PF_AUTO_Q_MIN;
+        score_pf_q_ok = score_q_extent >= cutlass::fmha::ScoreBlock2DPolicy::ScorePrefetchQMin;
         const int q_tiles = cute::ceil_div(score_q_extent, int(get<0>(TileShapeQK{})));
         const size_t wg_slot = (size_t(score_batch) * s.num_heads_q + q_head_idx) * q_tiles + size_t(blk_q);
         score_head_ptr = params.mainloop.ptr_score + wg_slot * size_t(get<0>(TileShapeQK{})) * size_t(score_k_extent);

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
@@ -71,7 +71,8 @@ template <
     // decode step. Only enabled by the decode runner for the plain attention
     // case (no causal/local mask, no sink); prefill keeps the default (false)
     // and is therefore unaffected.
-    bool PackGQA_ = false>
+    bool PackGQA_ = false,
+    int StaticScoreMode_ = -1>
 class XeFMHAFwdKernel {
  public:
   //
@@ -80,6 +81,20 @@ class XeFMHAFwdKernel {
   using ProblemShape = ProblemShape_;
   using VariableLength = cutlass::fmha::collective::VariableLength;
   static constexpr bool is_var_len = cutlass::fmha::collective::is_variable_length_v<typename ProblemShape::SeqLenType>;
+
+  template <int ScoreMode>
+  using WithStaticScoreMode = XeFMHAFwdKernel<
+      ProblemShape_,
+      CollectiveMainloop_,
+      CollectiveEpilogue_,
+      TileScheduler_,
+      VarLenQLayoutStep_,
+      VarLenKLayoutStep_,
+      VarLenVLayoutStep_,
+      VarLenOLayoutStep_,
+      PackGQA_,
+      ScoreMode>;
+
   // Mainloop derived types
   using CollectiveMainloop = CollectiveMainloop_;
   using MainloopArguments = typename CollectiveMainloop::Arguments;
@@ -179,15 +194,39 @@ class XeFMHAFwdKernel {
   // Methods
   //
 
-  static Params to_underlying_arguments(Arguments const& args, void* workspace) {
+  template <class ArgumentsT>
+  static Params to_underlying_arguments(ArgumentsT const& args, void* workspace) {
     // When packing GQA into M, grid over KV heads instead of Q heads by reusing
     // the scheduler's num_heads_kv path (num_kv_splits == 1, no actual split).
     const int sched_num_kv_splits = PackGQA_ ? 1 : -1;
+    KernelParams kernel_params{
+        args.kernel.shape,
+        args.kernel.Q,
+        args.kernel.dQ,
+        args.kernel.K,
+        args.kernel.dK,
+        args.kernel.V,
+        args.kernel.dV,
+        args.kernel.O,
+        args.kernel.dO,
+        args.kernel.K_cache,
+        args.kernel.dK_cache,
+        args.kernel.V_cache,
+        args.kernel.dV_cache,
+        args.kernel.sm_sink,
+        args.kernel.skip_batch_mask,
+        args.kernel.scale_k_ptr,
+        args.kernel.scale_v_ptr};
+    auto scheduler_params =
+        TileScheduler::to_underlying_arguments(args.kernel.shape, args.hw_info, TileShapeO{}, sched_num_kv_splits);
+    if constexpr (CollectiveMainloop::ScoreBlock2D && StaticScoreMode_ >= 0) {
+      scheduler_params.grid.x = 1;
+    }
     return {
-        args.kernel,
+        kernel_params,
         CollectiveMainloop::to_underlying_arguments(args.mainloop, workspace),
         CollectiveEpilogue::to_underlying_arguments(args.epilogue, workspace),
-        TileScheduler::to_underlying_arguments(args.kernel.shape, args.hw_info, TileShapeO{}, sched_num_kv_splits)};
+        scheduler_params};
   }
 
   static bool can_implement(Arguments const& args) {
@@ -195,6 +234,19 @@ class XeFMHAFwdKernel {
   }
 
   static int get_workspace_size(Arguments const& args) {
+    if constexpr (CollectiveMainloop::ScoreBlock2D) {
+      int score_q_extent;
+      int score_k_extent;
+      if constexpr (is_var_len) {
+        score_q_extent = int(args.kernel.shape.seq_len_qo.max_length);
+        score_k_extent = int(args.kernel.shape.seq_len_kv_cache.max_length);
+      } else {
+        score_q_extent = int(args.kernel.shape.seq_len_qo);
+        score_k_extent = int(args.kernel.shape.seq_len_kv_cache);
+      }
+      return int(args.kernel.shape.batch) * int(args.kernel.shape.num_heads_q) * score_q_extent * score_k_extent *
+             int(sizeof(typename CollectiveMainloop::ElementS));
+    }
     return 0;
   }
 
@@ -268,6 +320,10 @@ class XeFMHAFwdKernel {
       auto [blk_q, blk_v, head_q, idx_b, unused] = tile_scheduler.get_block_coord();  // (Q,V,h,b)
       // Mix-batch dispatch: skip batches not owned by this kernel launch.
       if (p.skip_batch_mask != nullptr && p.skip_batch_mask[idx_b]) continue;
+      if constexpr (CollectiveMainloop::ScoreBlock2D) {
+        static_assert(StaticScoreMode_ == 0 || StaticScoreMode_ == 1);
+        blk_v = StaticScoreMode_;
+      }
       auto blk_qv = make_coord(blk_q, blk_v);
       // PackGQA: the scheduler grids over KV heads, so head_q already is the KV
       // head index and the head_group_q query heads are folded into the M tile.
@@ -386,6 +442,23 @@ class XeFMHAFwdKernel {
       // With PackGQA the Q/O head dimension is indexed by the KV head; otherwise
       // by the (un-grouped) query head.
       int q_head_idx = PackGQA_ ? head : head_q;
+      typename CollectiveMainloop::ElementS* score_head_ptr = nullptr;
+      if constexpr (CollectiveMainloop::ScoreBlock2D) {
+        int score_q_extent;
+        int score_k_extent;
+        int score_batch;
+        if constexpr (is_var_len) {
+          score_q_extent = int(s.seq_len_qo.max_length);
+          score_k_extent = int(s.seq_len_kv_cache.max_length);
+          score_batch = idx_b;
+        } else {
+          score_q_extent = int(s.seq_len_qo);
+          score_k_extent = int(s.seq_len_kv_cache);
+          score_batch = l_coord;
+        }
+        score_head_ptr =
+            params.mainloop.ptr_score + (score_batch * s.num_heads_q + q_head_idx) * score_q_extent * score_k_extent;
+      }
       // FP8 KV: the per-tensor dequant scale baked into KernelArguments is
       // passed as a float function argument (scale_k) to the mainloop GEMM1.
       // It defaults to 1.0f for non-fp8 KV; the fp8 dequant scalar is read
@@ -396,7 +469,7 @@ class XeFMHAFwdKernel {
         scale_k = *p.scale_k_ptr;
       }
       CollectiveMainloop mainloop(params.mainloop, shared_storage.mainloop);
-      mainloop(
+      mainloop.template operator()<StaticScoreMode_>(
           Q(_, _, q_head_idx, l_coord),
           K_cache(_, _, head, l_coord),
           V_cache(_, _, head, l_coord),
@@ -416,7 +489,8 @@ class XeFMHAFwdKernel {
           discard_seq_coord,
           K_cache(_, _, head, l_coord),
           V_cache(_, _, head, l_coord),
-          scale_k);
+          scale_k,
+          score_head_ptr);
 
       if constexpr (!is_empty_v<MainloopSharedStorage> && !is_empty_v<EpilogueSharedStorage>) {
         sycl::group_barrier(get_work_group<3>());

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_kernel.cpp.in
@@ -32,6 +32,10 @@
 // Template parameters: HEAD_DIM=@HEAD_DIM@, TILED_Q=@TILED_Q@, TILED_KV=@TILED_KV@, NUM_SG=@NUM_SG@
 #define SYCL_INTEL_TARGET 20
 
+#if @ENABLE_SCORE_BLOCK2D@
+#define FMHA_PREFILL_ENABLE_SCORE_BLOCK2D 1
+#endif
+
 #include "sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp"
 
 namespace prefill {

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_nopage_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_nopage_kernel.cpp.in
@@ -30,13 +30,17 @@
  *
  **************************************************************************************************/
 // Auto-generated from xe_fmha_fwd_prefill_nopage_kernel.cpp.in
-// Template parameters: HEAD_DIM=@HEAD_DIM@ (non-paged / no_page attention)
+// Template parameters: HEAD_DIM=@HEAD_DIM@, TILED_OUT_NP=@TILED_OUT_NP@ (non-paged / no_page attention)
 //
 // The non-paged (contiguous ragged) KV-cache prefill path is compiled into its
 // own translation unit / runner type (FmhaPrefillNpRunner) so its kernel
 // instantiations land in shared libraries separate from the paged prefill path.
 // Non-paged prefill supports bf16/fp16 queries only (no fp8 KV cache).
 #define SYCL_INTEL_TARGET 20
+
+#if @ENABLE_SCORE_BLOCK2D@
+#define FMHA_PREFILL_ENABLE_SCORE_BLOCK2D 1
+#endif
 
 #include "sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp"
 
@@ -51,7 +55,7 @@ __attribute__((visibility("default"))) void FmhaPrefillNpRunner<@HEAD_DIM@>::ope
       "No-page attention does not support sink logits (softmax_sink_ptr must be null)");
   using TileShapeQK = cute::Shape<cute::Int<@TILED_Q_NP@>, cute::Int<@TILED_KV_NP@>, cute::_32>;
   using TileShapePV = cute::Shape<cute::Int<@TILED_Q_NP@>, cute::_32, cute::Int<@TILED_KV_NP@>>;
-  using TileShapeOutput = cute::Shape<cute::Int<@TILED_Q_NP@>, cute::Int<((@HEAD_DIM@ + 31) / 32) * 32>>;
+  using TileShapeOutput = cute::Shape<cute::Int<@TILED_Q_NP@>, cute::Int<@TILED_OUT_NP@>>;
   using SubgroupLayoutQK = cute::
       Layout<cute::Shape<cute::Int<@NUM_SG_NP@>, cute::_1, cute::_1>, cute::Stride<cute::_1, cute::_1, cute::_1>>;
   // No sink support for no_page path; always use Sink=false

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -196,6 +196,8 @@ using LayoutO = cutlass::layout::RowMajor;
 
 template <class FMHAPrefillKernel, bool isVarLen = false>
 struct PrefillRunner {
+  static constexpr int DefaultScoreWorkspaceCapMiB = 1024;
+
   using StrideQ = typename FMHAPrefillKernel::StrideQ;
   using StrideK = typename FMHAPrefillKernel::StrideK;
   using StrideV = typename FMHAPrefillKernel::StrideV;
@@ -359,7 +361,7 @@ struct PrefillRunner {
         if (const char* env = std::getenv("FMHA_SCORE_WS_CAP_MB")) {
           return std::atoi(env);
         }
-        return int(FMHA_PREFILL_SCORE_WS_CAP_MB);
+        return DefaultScoreWorkspaceCapMiB;
       }();
       if (cap_mb > 0 && batch_total > 1) {
         const size_t cap_bytes = size_t(cap_mb) << 20;

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -327,19 +327,25 @@ struct PrefillRunner {
     // Define device-global scratch memory
     size_t workspace_size = FMHAPrefillKernel::get_workspace_size(arguments);
     auto workspace = torch::empty(workspace_size, params.tensor_opts);
+    void* workspace_ptr = workspace.data_ptr();
 
     if (!FMHAPrefillKernel::can_implement(arguments)) {
       return cutlass::Status::kErrorInvalidProblem;
     }
 
     // Initialize the workspace
-    FMHAPrefillKernel::initialize_workspace(arguments, workspace.data_ptr());
-
-    // Convert host-side arguments to device-side arguments to be passed to the kernel
-    auto kernel_params = FMHAPrefillKernel::to_underlying_arguments(arguments, workspace.data_ptr());
+    FMHAPrefillKernel::initialize_workspace(arguments, workspace_ptr);
 
     // Run
-    launch<FMHAPrefillKernel>(kernel_params);
+    if constexpr (CollectiveMainloop::ScoreBlock2D) {
+      using ScoreStoreKernel = typename FMHAPrefillKernel::template WithStaticScoreMode<0>;
+      using ScoreLoadKernel = typename FMHAPrefillKernel::template WithStaticScoreMode<1>;
+
+      launch<ScoreStoreKernel>(ScoreStoreKernel::to_underlying_arguments(arguments, workspace_ptr));
+      launch<ScoreLoadKernel>(ScoreLoadKernel::to_underlying_arguments(arguments, workspace_ptr));
+    } else {
+      launch<FMHAPrefillKernel>(FMHAPrefillKernel::to_underlying_arguments(arguments, workspace_ptr));
+    }
     return cutlass::Status::kSuccess;
   }
 };

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -35,6 +35,8 @@
 #include <c10/xpu/XPUStream.h>
 #include <torch/all.h>
 
+#include <cstdio>
+#include <cstdlib>
 #include <cute/tensor.hpp>
 #include <random>
 
@@ -290,6 +292,32 @@ struct PrefillRunner {
     return shape;
   }
 
+  // Rebase one kernel launch onto [batch_lo, batch_lo + batch_len). Paged
+  // prefill uses absolute offsets in its cumulative-length arrays, so the data
+  // pointers stay unchanged while the per-batch metadata advances.
+  template <class Kernel>
+  typename Kernel::Arguments slice_arguments(typename Kernel::Arguments args, int batch_lo, int batch_len) const {
+    args.kernel.shape.batch = batch_len;
+    if constexpr (isVarLen) {
+      if (args.kernel.shape.seq_len_qo.cumulative_length != nullptr) {
+        args.kernel.shape.seq_len_qo.cumulative_length += batch_lo;
+      }
+      if (args.kernel.shape.seq_len_kv.cumulative_length != nullptr) {
+        args.kernel.shape.seq_len_kv.cumulative_length += batch_lo;
+      }
+      if (args.kernel.shape.seq_len_kv_cache.cumulative_length != nullptr) {
+        args.kernel.shape.seq_len_kv_cache.cumulative_length += batch_lo;
+      }
+    }
+    if (args.mainloop.ptr_page_table != nullptr) {
+      args.mainloop.ptr_page_table += size_t(batch_lo) * size_t(args.mainloop.max_num_pages_per_seq);
+    }
+    if (args.kernel.skip_batch_mask != nullptr) {
+      args.kernel.skip_batch_mask += batch_lo;
+    }
+    return args;
+  }
+
   cutlass::Status run(const Arguments& params, const cutlass::KernelHardwareInfo& hw_info) {
     ProblemShapeType shape = initialize(params);
 
@@ -324,8 +352,41 @@ struct PrefillRunner {
         {},
         hw_info};
 
-    // Define device-global scratch memory
-    size_t workspace_size = FMHAPrefillKernel::get_workspace_size(arguments);
+    const int batch_total = params.b;
+    int batch_slice = batch_total;
+    if constexpr (CollectiveMainloop::ScoreBlock2D) {
+      static const int cap_mb = [] {
+        if (const char* env = std::getenv("FMHA_SCORE_WS_CAP_MB")) {
+          return std::atoi(env);
+        }
+        return int(FMHA_PREFILL_SCORE_WS_CAP_MB);
+      }();
+      if (cap_mb > 0 && batch_total > 1) {
+        const size_t cap_bytes = size_t(cap_mb) << 20;
+        auto one_batch = slice_arguments<FMHAPrefillKernel>(arguments, 0, 1);
+        const size_t per_batch = FMHAPrefillKernel::get_workspace_size(one_batch);
+        if (per_batch > 0 && per_batch * size_t(batch_total) > cap_bytes) {
+          batch_slice = int(cute::max(size_t(1), cap_bytes / per_batch));
+        }
+      }
+    }
+    const int num_slices = cute::ceil_div(batch_total, batch_slice);
+
+    // Every slice reuses the same device-global score buffer.
+    auto workspace_shape = num_slices > 1 ? slice_arguments<FMHAPrefillKernel>(arguments, 0, batch_slice) : arguments;
+    size_t workspace_size = FMHAPrefillKernel::get_workspace_size(workspace_shape);
+    if constexpr (CollectiveMainloop::ScoreBlock2D) {
+      if (std::getenv("FMHA_SCORE_WS_VERBOSE") != nullptr) {
+        std::fprintf(
+            stderr,
+            "[fmha] score workspace: batch=%d slice=%d slices=%d bytes=%zu (%.1f MiB)\n",
+            batch_total,
+            batch_slice,
+            num_slices,
+            workspace_size,
+            double(workspace_size) / (1024.0 * 1024.0));
+      }
+    }
     auto workspace = torch::empty(workspace_size, params.tensor_opts);
     void* workspace_ptr = workspace.data_ptr();
 
@@ -341,8 +402,12 @@ struct PrefillRunner {
       using ScoreStoreKernel = typename FMHAPrefillKernel::template WithStaticScoreMode<0>;
       using ScoreLoadKernel = typename FMHAPrefillKernel::template WithStaticScoreMode<1>;
 
-      launch<ScoreStoreKernel>(ScoreStoreKernel::to_underlying_arguments(arguments, workspace_ptr));
-      launch<ScoreLoadKernel>(ScoreLoadKernel::to_underlying_arguments(arguments, workspace_ptr));
+      for (int batch_lo = 0; batch_lo < batch_total; batch_lo += batch_slice) {
+        const int batch_len = cute::min(batch_slice, batch_total - batch_lo);
+        auto slice = slice_arguments<FMHAPrefillKernel>(arguments, batch_lo, batch_len);
+        launch<ScoreStoreKernel>(ScoreStoreKernel::to_underlying_arguments(slice, workspace_ptr));
+        launch<ScoreLoadKernel>(ScoreLoadKernel::to_underlying_arguments(slice, workspace_ptr));
+      }
     } else {
       launch<FMHAPrefillKernel>(FMHAPrefillKernel::to_underlying_arguments(arguments, workspace_ptr));
     }


### PR DESCRIPTION
## Summary

- port the paged FMHA score-reuse optimization for `HEAD_DIM=512` from CUTLASS-SYCL
- store scaled QK scores in a block2D workspace and reuse them for the second output tile
- preserve remainder-K masking for non-aligned KV lengths, including local-window attention
- keep the existing bf16-only paged prefill dispatch unchanged
- add `FMHA_PREFILL_ENABLE_SCORE_BLOCK2D_512`, enabled by default
- cap the score workspace at 1 GiB by slicing the batch and reusing the same workspace

## Correctness

Tested bf16 on Intel Arc Pro B60 with reverse page tables.

`B=1, SQ=127, SK=250, Hq/Hkv=4/2, D=512`:

| mask | max error | bad elements |
| --- | ---: | ---: |
| full | 0.001964 | 0 |
| causal | 0.002082 | 0 |
| local `(63,17)` | 0.003994 | 0 |

Also tested `B=2` with KV lengths `[250, 193]`, reverse page tables, and local `(63,17)` attention: max error `0.003724`, bad elements `0`.

Additional integration validation:

- full default-feature build: `1485/1485`
- `tests/test_flash_attention.py`: `1725 passed, 660 skipped`
- K-tail, causal GQA, and score-prefetch boundary cases: max absolute error `0.000174-0.000364`, no elements above `0.01`

## Performance

### Original kernel case

Intel Arc Pro B60, bf16, page size 64, reverse page table, `B=1, SQ=512, SK=4096, Hq/Hkv=16/8, D=512`:

| workload | baseline | optimized | improvement |
| --- | ---: | ---: | ---: |
| full attention | 2.754 ms | 2.203 ms | 20.0% |
| Gemma4 global attention (causal) | 2.615 ms | 2.138 ms | 18.2% |

### Large production shape

Intel Arc Pro B60, bf16, page size 128, `B=16, SQ=SK=4096, Hq/Hkv=16/16, D=512`. The baseline is the saved pre-PR wheel; both wheels used the same benchmark script on GPU 1 with `triton.testing.do_bench`, `warmup=1000 ms`, and `rep=5000 ms`.

| workload | baseline | optimized | latency improvement | baseline TOPS | optimized TOPS |
| --- | ---: | ---: | ---: | ---: | ---: |
| full attention | 297.427 ms | 175.081 ms | 41.1% (`1.70x`) | 29.57 | 50.24 |
| causal attention | 153.899 ms | 95.652 ms | 37.8% (`1.61x`) | 28.58 effective | 45.99 effective |

For this shape, batch slicing reduces the score workspace from 8 GiB to 1 GiB (`batch_slice=2`, 8 sequential slices).

### Gemma4 31B TP=4 E2E

Gemma4 31B, Intel XPU attention, GPUs 4/5/6/7, `TP=4`, random input/output lengths `4096/1024`, concurrency 1, one warmup request, radix cache disabled, chunked prefill disabled, and profiler disabled. The baseline and optimized runs used the same SGLang worktree and server/client arguments; only the `sgl_kernel` wheel changed.

| metric | baseline wheel | optimized wheel | change |
| --- | ---: | ---: | ---: |
| TTFT | 1522.11 ms | 1490.95 ms | -2.05% |
| E2E latency | 109.46 s | 107.50 s | -1.79% |
| TPOT | 105.51 ms | 103.63 ms | -1.79% |
| mean ITL | 105.61 ms | 103.73 ms | -1.78% |
| output throughput | 9.35 token/s | 9.52 token/s | +1.83% |
| total throughput | 46.76 token/s | 47.61 token/s | +1.83% |