### PR TITLE
[sycl] Support plain row-major UE8M0 scale output in per-token-group …

### DIFF
--- a/src/sycl/per_token_group_quant_8bit.cpp
+++ b/src/sycl/per_token_group_quant_8bit.cpp
@@ -111,8 +111,11 @@ struct PerTokenGroupQuant8bitKernel : public __SYCL_KER_CONFIG_CONVENTION__ {
       scale_output = reinterpret_cast<scale_element_t*>(output_s) +
                      (col_idx * scale_stride * num_elems_per_pack + row_idx * num_elems_per_pack + pack_idx);
     } else {
-      static_assert(!SCALE_UE8M0);
-      scale_output = output_s + global_group_id;
+      // Plain row-major scale layout. Supports float scales (non-UE8M0) and, when
+      // the kernel is instantiated with scale_packed_t=uint8_t, the UE8M0 byte
+      // written contiguously at the group index -- a plain [tokens, K/group] uint8
+      // scale (consumed directly by e.g. torch._scaled_mm BlockWise1x32).
+      scale_output = reinterpret_cast<scale_element_t*>(output_s) + global_group_id;
     }
 
     using vec_type = vec_t<T, VEC_SIZE>;
@@ -272,49 +275,62 @@ void sgl_per_token_group_quant_8bit(
   sycl::range<1> global_range(num_blocks * num_threads);
   sycl::range<1> local_range(num_threads);
 
-#define LAUNCH_KERNEL_WITH_GROUP_SIZE(T, DST_DTYPE, GS)                            \
-  do {                                                                             \
-    if (is_column_major) {                                                         \
-      if (scale_ue8m0) {                                                           \
-        auto kernel = PerTokenGroupQuant8bitKernel<T, DST_DTYPE, GS, true, true>(  \
-            static_cast<const T*>(input.data_ptr()),                               \
-            output_q.data_ptr(),                                                   \
-            static_cast<uint32_t*>(output_s.data_ptr()),                           \
-            num_groups,                                                            \
-            groups_per_block,                                                      \
-            static_cast<float>(eps),                                               \
-            static_cast<float>(min_8bit),                                          \
-            static_cast<float>(max_8bit),                                          \
-            num_groups_per_row,                                                    \
-            scale_stride);                                                         \
-        sycl_kernel_submit(global_range, local_range, queue, kernel);              \
-      } else {                                                                     \
-        auto kernel = PerTokenGroupQuant8bitKernel<T, DST_DTYPE, GS, true, false>( \
-            static_cast<const T*>(input.data_ptr()),                               \
-            output_q.data_ptr(),                                                   \
-            static_cast<float*>(output_s.data_ptr()),                              \
-            num_groups,                                                            \
-            groups_per_block,                                                      \
-            static_cast<float>(eps),                                               \
-            static_cast<float>(min_8bit),                                          \
-            static_cast<float>(max_8bit),                                          \
-            num_groups_per_row,                                                    \
-            scale_stride);                                                         \
-        sycl_kernel_submit(global_range, local_range, queue, kernel);              \
-      }                                                                            \
-    } else {                                                                       \
-      assert(!scale_ue8m0);                                                        \
-      auto kernel = PerTokenGroupQuant8bitKernel<T, DST_DTYPE, GS, false>(         \
-          static_cast<const T*>(input.data_ptr()),                                 \
-          output_q.data_ptr(),                                                     \
-          static_cast<float*>(output_s.data_ptr()),                                \
-          num_groups,                                                              \
-          groups_per_block,                                                        \
-          static_cast<float>(eps),                                                 \
-          static_cast<float>(min_8bit),                                            \
-          static_cast<float>(max_8bit));                                           \
-      sycl_kernel_submit(global_range, local_range, queue, kernel);                \
-    }                                                                              \
+#define LAUNCH_KERNEL_WITH_GROUP_SIZE(T, DST_DTYPE, GS)                                   \
+  do {                                                                                    \
+    if (is_column_major) {                                                                \
+      if (scale_ue8m0) {                                                                  \
+        auto kernel = PerTokenGroupQuant8bitKernel<T, DST_DTYPE, GS, true, true>(         \
+            static_cast<const T*>(input.data_ptr()),                                      \
+            output_q.data_ptr(),                                                          \
+            static_cast<uint32_t*>(output_s.data_ptr()),                                  \
+            num_groups,                                                                   \
+            groups_per_block,                                                             \
+            static_cast<float>(eps),                                                      \
+            static_cast<float>(min_8bit),                                                 \
+            static_cast<float>(max_8bit),                                                 \
+            num_groups_per_row,                                                           \
+            scale_stride);                                                                \
+        sycl_kernel_submit(global_range, local_range, queue, kernel);                     \
+      } else {                                                                            \
+        auto kernel = PerTokenGroupQuant8bitKernel<T, DST_DTYPE, GS, true, false>(        \
+            static_cast<const T*>(input.data_ptr()),                                      \
+            output_q.data_ptr(),                                                          \
+            static_cast<float*>(output_s.data_ptr()),                                     \
+            num_groups,                                                                   \
+            groups_per_block,                                                             \
+            static_cast<float>(eps),                                                      \
+            static_cast<float>(min_8bit),                                                 \
+            static_cast<float>(max_8bit),                                                 \
+            num_groups_per_row,                                                           \
+            scale_stride);                                                                \
+        sycl_kernel_submit(global_range, local_range, queue, kernel);                     \
+      }                                                                                   \
+    } else if (scale_ue8m0) {                                                             \
+      /* Plain row-major UE8M0: scale_packed_t=uint8_t, output_s is uint8 [M,K/g] */      \
+      auto kernel = PerTokenGroupQuant8bitKernel<T, DST_DTYPE, GS, false, true, uint8_t>( \
+          static_cast<const T*>(input.data_ptr()),                                        \
+          output_q.data_ptr(),                                                            \
+          static_cast<uint8_t*>(output_s.data_ptr()),                                     \
+          num_groups,                                                                     \
+          groups_per_block,                                                               \
+          static_cast<float>(eps),                                                        \
+          static_cast<float>(min_8bit),                                                   \
+          static_cast<float>(max_8bit),                                                   \
+          num_groups_per_row,                                                             \
+          scale_stride);                                                                  \
+      sycl_kernel_submit(global_range, local_range, queue, kernel);                       \
+    } else {                                                                              \
+      auto kernel = PerTokenGroupQuant8bitKernel<T, DST_DTYPE, GS, false>(                \
+          static_cast<const T*>(input.data_ptr()),                                        \
+          output_q.data_ptr(),                                                            \
+          static_cast<float*>(output_s.data_ptr()),                                       \
+          num_groups,                                                                     \
+          groups_per_block,                                                               \
+          static_cast<float>(eps),                                                        \
+          static_cast<float>(min_8bit),                                                   \
+          static_cast<float>(max_8bit));                                                  \
+      sycl_kernel_submit(global_range, local_range, queue, kernel);                       \
+    }                                                                                     \
   } while (0)
 
 #define LAUNCH_KERNEL(T, DST_DTYPE)                                                                             \

--- a/src/sycl/per_token_group_quant_8bit_v2.cpp
+++ b/src/sycl/per_token_group_quant_8bit_v2.cpp
@@ -221,8 +221,10 @@ struct MainKernel {
                       hidden_idx_packed * scale_hidden_stride * num_elems_per_pack +
                       output_token_idx * scale_token_stride * num_elems_per_pack + pack_idx);
     } else {
-      static_assert(!SCALE_UE8M0);
-      scale_output = output_s + offset_num_groups;
+      // Plain row-major scale layout. Supports float scales (non-UE8M0) and, when
+      // instantiated with scale_packed_t=uint8_t, the UE8M0 byte written
+      // contiguously at the group index -- a plain [tokens, K/group] uint8 scale.
+      scale_output = reinterpret_cast<scale_element_t*>(output_s) + offset_num_groups;
     }
 
     // TMA alignment padding for column-major mode
@@ -794,7 +796,13 @@ void sgl_per_token_group_quant_8bit_v2(
         LAUNCH_KERNEL_INNER(NaiveScheduler, GROUP_SIZE, THREADS_PER_SUBWARP, T, DST_DTYPE, float, true);            \
       }                                                                                                             \
     } else {                                                                                                        \
-      LAUNCH_KERNEL_INNER(NaiveScheduler, GROUP_SIZE, THREADS_PER_SUBWARP, T, DST_DTYPE, float, false);             \
+      if (scale_ue8m0) {                                                                                            \
+        /* Plain row-major UE8M0: output_s is uint8 [tokens, K/group] */                                            \
+        LAUNCH_KERNEL_INNER(                                                                                        \
+            NaiveScheduler, GROUP_SIZE, THREADS_PER_SUBWARP, T, DST_DTYPE, uint8_t, false, true, false, uint8_t);   \
+      } else {                                                                                                      \
+        LAUNCH_KERNEL_INNER(NaiveScheduler, GROUP_SIZE, THREADS_PER_SUBWARP, T, DST_DTYPE, float, false);           \
+      }                                                                                                             \
     }                                                                                                               \
   } while (0)
 

--- a/tests/test_per_token_group_quant_8bit.py
+++ b/tests/test_per_token_group_quant_8bit.py
@@ -354,6 +354,68 @@ class TestPerTokenGroupQuantXPU:
         assert x_q.shape == x.shape
         assert (scales > 0).all() and torch.isfinite(scales).all()
 
+    @pytest.mark.parametrize(
+        "num_tokens,hidden_dim,group_size",
+        [
+            (128, 1024, 128),
+            (64, 512, 64),
+            (32, 256, 32),
+            (5, 2048, 128),
+            (256, 4096, 32),
+        ],
+    )
+    def test_plain_row_major_ue8m0(self, num_tokens, hidden_dim, group_size):
+        """Plain row-major UE8M0 scale output (scale_ue8m0=True, non column-major).
+
+        Exercises the row-major UE8M0 path in which the kernel writes one
+        float8_e8m0fnu (uint8, exponent + 127) byte per block into a plain
+        contiguous [tokens, hidden/group] scale tensor. This is the layout
+        consumed directly by e.g. torch._scaled_mm's BlockWise1x32 recipe, as
+        opposed to the column-major uint32-packed layout used by the fused GEMM
+        path. The op selects it simply from a row-major uint8 output_s.
+        """
+        torch.manual_seed(0)
+        x_cpu = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16)
+        x_xpu = x_cpu.to(self.device)
+
+        num_groups = hidden_dim // group_size
+        fp8_max = torch.finfo(torch.float8_e4m3fn).max
+
+        # Plain, contiguous [tokens, hidden/group] uint8 scale -> row-major
+        # (stride(0) > stride(1)), so the kernel takes the non column-major path.
+        x_s = torch.empty(
+            (num_tokens, num_groups), device=self.device, dtype=torch.uint8
+        )
+        x_q = torch.empty(
+            (num_tokens, hidden_dim), device=self.device, dtype=torch.float8_e4m3fn
+        )
+        torch.ops.sgl_kernel.sgl_per_token_group_quant_8bit.default(
+            x_xpu, x_q, x_s, group_size, self.eps, -fp8_max, fp8_max, True
+        )
+
+        assert x_s.shape == (num_tokens, num_groups)
+        assert x_s.dtype == torch.uint8
+
+        # Reference UE8M0 byte per (token, group):
+        #   exp = ceil(log2(max(amax / 448, 1e-10))); byte = exp + 127
+        xv = x_cpu.view(num_tokens, num_groups, group_size).float()
+        amax = xv.abs().amax(dim=2).clamp(min=self.eps)
+        exp_s = torch.ceil(torch.log2((amax / fp8_max).clamp(min=1e-10)))
+        byte_ref = (exp_s.to(torch.int32) + 127).to(torch.uint8)
+        torch.testing.assert_close(x_s.cpu(), byte_ref, rtol=0, atol=0)
+
+        # Round-trip: dequantize with the emitted UE8M0 scales and confirm the
+        # quantization preserved the signal (high cosine similarity).
+        scale = torch.pow(2.0, (x_s.cpu().to(torch.int32) - 127).float())
+        x_dq = (
+            x_q.cpu().view(num_tokens, num_groups, group_size).float()
+            * scale.unsqueeze(2)
+        ).view(num_tokens, hidden_dim)
+        cos = torch.nn.functional.cosine_similarity(
+            x_dq.flatten(), x_cpu.float().flatten(), dim=0
+        ).item()
+        assert cos >= 0.99, f"dequant cosine too low: {cos}"
+
 
 @triton.jit
 def _per_token_group_quant_fp8(

--- a/tests/test_per_token_group_quant_8bit_v2.py
+++ b/tests/test_per_token_group_quant_8bit_v2.py
@@ -839,5 +839,68 @@ def test_per_token_group_quant_with_column_major(
         raise
 
 
+@pytest.mark.parametrize(
+    "num_tokens, hidden_dim, group_size",
+    [
+        (128, 1024, 128),
+        (64, 512, 128),
+        (32, 512, 64),
+        (5, 2048, 128),
+        (256, 2048, 128),
+    ],
+)
+def test_plain_row_major_ue8m0_v2(num_tokens, hidden_dim, group_size):
+    """Plain row-major UE8M0 scale output for the v2 kernel.
+
+    scale_ue8m0=True with a plain, contiguous [tokens, hidden/group] uint8
+    scale tensor (row-major, non column-major, no fuse_silu_and_mul, no
+    masked layout). The kernel writes one float8_e8m0fnu byte (exponent + 127)
+    per block, the layout consumed directly by torch._scaled_mm BlockWise1x32,
+    instead of the column-major uint32-packed layout used by the fused path.
+    """
+    device = torch.device("xpu")
+    torch.manual_seed(0)
+    x = torch.randn(num_tokens, hidden_dim, device=device, dtype=torch.bfloat16)
+
+    num_groups = hidden_dim // group_size
+    fp8_max_ = torch.finfo(fp8_dtype).max
+    eps = 1e-10
+
+    # row-major uint8 scale -> stride(-2) > stride(-1): non column-major path
+    x_s = torch.empty((num_tokens, num_groups), device=device, dtype=torch.uint8)
+    x_q = torch.empty((num_tokens, hidden_dim), device=device, dtype=fp8_dtype)
+
+    torch.ops.sgl_kernel.sgl_per_token_group_quant_8bit_v2.default(
+        x,
+        x_q,
+        x_s,
+        group_size,
+        eps,
+        -fp8_max_,
+        fp8_max_,
+        True,  # scale_ue8m0
+        False,  # fuse_silu_and_mul
+        None,  # masked_m
+    )
+
+    assert x_s.shape == (num_tokens, num_groups)
+    assert x_s.dtype == torch.uint8
+
+    # Reference UE8M0 byte: exp = ceil(log2(max(amax / 448, 1e-10))); byte = exp + 127
+    xv = x.cpu().view(num_tokens, num_groups, group_size).float()
+    amax = xv.abs().amax(dim=2).clamp(min=eps)
+    exp_s = torch.ceil(torch.log2((amax / fp8_max_).clamp(min=1e-10)))
+    byte_ref = (exp_s.to(torch.int32) + 127).to(torch.uint8)
+    torch.testing.assert_close(x_s.cpu(), byte_ref, rtol=0, atol=0)
+
+    # Dequant round-trip sanity.
+    scale = torch.pow(2.0, (x_s.cpu().to(torch.int32) - 127).float())
+    x_dq = (
+        x_q.cpu().view(num_tokens, num_groups, group_size).float() * scale.unsqueeze(2)
+    ).view(num_tokens, hidden_dim)
+    cos = F.cosine_similarity(x_dq.flatten(), x.cpu().float().flatten(), dim=0).item()
+    assert cos >= 0.99, f"dequant cosine too low: {cos}"
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
The per_token_group_quant_8bit kernels (v1 and v2) previously only emitted UE8M0 (float8_e8m0fnu) block scales in the column-major, uint32-packed / swizzled layout used by the fused GEMM path. The plain row-major branch hard-asserted `!SCALE_UE8M0`, so callers that need a contiguous `[tokens, K/group]` uint8 scale (e.g. torch._scaled_mm with the BlockWise1x32 recipe, which expects an unswizzled per-block scale) could not use the fused activation-quant kernel and had to fall back to a pure-torch quantizer.

This adds a plain row-major UE8M0 code path in both kernels:

  * Kernel row-major branch: write the UE8M0 byte contiguously at the group index via scale_packed_t=uint8_t (scale_element_t=uint8_t), instead of static_asserting it away. Semantically identical to the existing float row-major store, just byte-typed.
  * Dispatch: when scale_ue8m0 is requested on a row-major (non column-major) output, instantiate the kernel with <..., IS_COLUMN_MAJOR=false, SCALE_UE8M0=true, scale_packed_t=uint8_t> and cast output_s to uint8_t*. The v2 launch passes the packed type explicitly so it does not default to uint32_t.

Existing paths are unchanged: column-major uint32-packed UE8M0 and plain float scales dispatch exactly as before. No public API / signature change -- callers select this path simply by passing a uint8 `[tokens, K/group]` scale tensor with scale_ue8m0=true.

Tests: add test_plain_row_major_ue8m0 (v1) and test_plain_row_major_ue8m0_v2 covering this layout, which was previously unreachable (the existing scale_ue8m0 helper asserts column-major + tma-aligned). Each checks the emitted UE8M0 byte per block is exactly ceil(log2(amax/448)) + 127 and that the dequant round-trip cosine >= 0.99.

Verified: clang-format + pre-commit clean; icpx -fsycl compiles both kernels for the intel_gpu_cri device; the v1 test passes on the CRI simulator across 5 shapes; and the reference byte math matches a bit-faithful CPU emulation of the kernel.