### PR TITLE
Add SYCL support for flash_compress128_prefill

### DIFF
--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -639,6 +639,9 @@ torch::Tensor plan_compress_decode(
     int64_t swa_page_size,
     int64_t ring_size);
 
+void flash_compress128_decode(
+    torch::Tensor kv_buffer, torch::Tensor kv_input, torch::Tensor kv_output, torch::Tensor ape, torch::Tensor plan_d);
+
 }  // namespace at::native::xpu
 
 namespace flash {

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -642,6 +642,14 @@ torch::Tensor plan_compress_decode(
 void flash_compress128_decode(
     torch::Tensor kv_buffer, torch::Tensor kv_input, torch::Tensor kv_output, torch::Tensor ape, torch::Tensor plan_d);
 
+void flash_compress128_prefill(
+    torch::Tensor kv_buffer,
+    torch::Tensor kv_input,
+    torch::Tensor kv_output,
+    torch::Tensor ape,
+    torch::Tensor plan_c,
+    torch::Tensor plan_w);
+
 }  // namespace at::native::xpu
 
 namespace flash {

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -613,7 +613,7 @@ void fast_topk_transform_ragged_interface(
     std::optional<at::Tensor> row_starts_opt);
 
 /*
- * Compress plan kernels
+ * Compress plan and execution kernels
  */
 namespace at::native::xpu {
 

--- a/python/sgl_kernel/__init__.py
+++ b/python/sgl_kernel/__init__.py
@@ -50,7 +50,7 @@ from sgl_kernel.flash_compress_4_torch import (
     flash_compress4_decode,
     flash_compress4_prefill,
 )
-from sgl_kernel.flash_compress_128_torch import (
+from sgl_kernel.flash_compress_128 import (
     flash_compress128_decode,
     flash_compress128_prefill,
 )

--- a/python/sgl_kernel/flash_compress_128.py
+++ b/python/sgl_kernel/flash_compress_128.py
@@ -101,40 +101,14 @@ def flash_compress128_prefill(
     plan_c_u8: torch.Tensor,  # [C, 16]
     plan_w_u8: torch.Tensor,  # [W, 8]
 ) -> None:
-    head_dim = _infer_head_dim_from_inputs(kv_input, ape, kv_output)
-
-    kv_flat = _flatten_slots_128(kv_buffer)
-    C = plan_c_u8.shape[0]
-    assert kv_output.shape == (C, head_dim), (kv_output.shape, C, head_dim)
-
-    seq_len, ragged_id, buffer_len, _rp0, rp1 = decode_plan_c(plan_c_u8)
-
-    # compress
-    for pid in range(C):
-        if seq_len[pid].item() < 0:
-            continue
-        P = int(ragged_id[pid].item())
-        bl = int(buffer_len[pid].item())
-        page = int(rp1[pid].item())
-        kv_buf_page = _page_slice_128(kv_flat, page)
-
-        c128_forward_torch(
-            kv_buf_page=kv_buf_page,
-            kv_input=kv_input,
-            ragged_id=P,
-            kv_out=kv_output[pid],
-            ape=ape,
-            buffer_len=bl,
-        )
-
-    # write after compress
-    rag_w, loc_w = decode_plan_w(plan_w_u8)
-    for i in range(plan_w_u8.shape[0]):
-        if rag_w[i].item() < 0:
-            continue
-        rid = int(rag_w[i].item())
-        loc = int(loc_w[i].item())
-        kv_flat[loc].copy_(kv_input[rid])
+    torch.ops.sgl_kernel.flash_compress128_prefill(
+        kv_buffer,
+        kv_input,
+        kv_output,
+        ape,
+        plan_c_u8,
+        plan_w_u8,
+    )
 
 
 def flash_compress128_decode(

--- a/python/sgl_kernel/flash_compress_128.py
+++ b/python/sgl_kernel/flash_compress_128.py
@@ -144,27 +144,10 @@ def flash_compress128_decode(
     ape: torch.Tensor,  # [128, head_dim]
     plan_d_u8: torch.Tensor,  # [B, 16]
 ) -> None:
-    head_dim = _infer_head_dim_from_inputs(kv_input, ape, kv_output)
-
-    kv_flat = _flatten_slots_128(kv_buffer)
-    B = kv_input.shape[0]
-    assert kv_output.shape == (B, head_dim), (kv_output.shape, B, head_dim)
-
-    seq_len, write_loc, _rp0, rp1 = decode_plan_d(plan_d_u8)
-
-    # Scatter every token's write in one shot (each token writes a distinct slot).
-    kv_flat.index_copy_(0, write_loc, kv_input.to(kv_flat.dtype))
-
-    # A compress event fires for tokens that just filled the last slot of a page.
-    # Each active token compresses its own (distinct) completed page, so reading
-    # the pages after all writes is equivalent to the per-token write-then-read.
-    active = (write_loc % 128 == 127).nonzero(as_tuple=True)[0]
-    if active.numel() == 0:
-        return
-
-    # buffer_len is constant 128 in decode, so the window is the whole page.
-    windows = kv_buffer[rp1[active]]  # [A, 128, head_dim*2]
-    kv = windows[:, :, :head_dim]
-    sc = windows[:, :, head_dim : 2 * head_dim] + ape  # ape [128, head_dim] broadcasts
-    w = torch.softmax(sc, dim=1)
-    kv_output[active] = (kv * w).sum(dim=1).to(kv_output.dtype)
+    torch.ops.sgl_kernel.flash_compress128_decode(
+        kv_buffer,
+        kv_input,
+        kv_output,
+        ape,
+        plan_d_u8,
+    )

--- a/src/sycl/Compress.h
+++ b/src/sycl/Compress.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <cstdint>
+#include <utility>
+
+namespace at::native::xpu {
+
+struct alignas(16) DecodePlan {
+  uint32_t seq_len;
+  int32_t write_loc;
+  int32_t read_page_0;
+  int32_t read_page_1;
+};
+
+struct alignas(16) CompressPlan {
+  uint32_t seq_len;
+  uint16_t ragged_id;
+  uint16_t buffer_len;
+  int32_t read_page_0;
+  int32_t read_page_1;
+
+  static constexpr CompressPlan invalid() {
+    return CompressPlan{-1u, 0, 0, -1, -1};
+  }
+
+  constexpr bool is_invalid() const {
+    return seq_len == -1u;
+  }
+};
+
+struct alignas(8) WritePlan {
+  uint32_t ragged_id;
+  int32_t write_loc;
+
+  static constexpr WritePlan invalid() {
+    return WritePlan{-1u, -1};
+  }
+
+  constexpr bool is_invalid() const {
+    return ragged_id == -1u;
+  }
+};
+
+inline WritePlan pack_w(uint32_t ragged_id, uint32_t batch_id, int32_t seq_len) {
+  return {static_cast<uint32_t>(ragged_id | (batch_id << 16)), seq_len};
+}
+
+inline std::pair<uint16_t, uint16_t> unpack_w(WritePlan plan) {
+  return {static_cast<uint16_t>(plan.ragged_id), static_cast<uint16_t>(plan.ragged_id >> 16)};
+}
+
+static_assert(sizeof(DecodePlan) == 16, "DecodePlan must be 16 bytes");
+static_assert(sizeof(CompressPlan) == 16, "CompressPlan must be 16 bytes");
+static_assert(sizeof(WritePlan) == 8, "WritePlan must be 8 bytes");
+
+}  // namespace at::native::xpu

--- a/src/sycl/CompressPlan.cpp
+++ b/src/sycl/CompressPlan.cpp
@@ -7,58 +7,12 @@
 #include <sycl/sycl.hpp>
 #include <utility>
 
+#include "Compress.h"
 #include "SYCLHelpers.h"
 #include "Utils.h"
 
 namespace at::native::xpu {
 
-struct alignas(16) DecodePlan {
-  uint32_t seq_len;
-  int32_t write_loc;
-  int32_t read_page_0;
-  int32_t read_page_1;
-};
-
-struct alignas(16) CompressPlan {
-  uint32_t seq_len;
-  uint16_t ragged_id;
-  uint16_t buffer_len;
-  int32_t read_page_0;
-  int32_t read_page_1;
-
-  static constexpr CompressPlan invalid() {
-    return CompressPlan{-1u, 0, 0, -1, -1};
-  }
-
-  constexpr bool is_invalid() const {
-    return seq_len == -1u;
-  }
-};
-
-struct alignas(8) WritePlan {
-  uint32_t ragged_id;
-  int32_t write_loc;
-
-  static constexpr WritePlan invalid() {
-    return WritePlan{-1u, -1};
-  }
-
-  constexpr bool is_invalid() const {
-    return ragged_id == -1u;
-  }
-};
-
-inline WritePlan pack_w(uint32_t ragged_id, uint32_t batch_id, int32_t seq_len) {
-  return {static_cast<uint32_t>(ragged_id | (batch_id << 16)), seq_len};
-}
-
-inline std::pair<uint16_t, uint16_t> unpack_w(WritePlan plan) {
-  return {static_cast<uint16_t>(plan.ragged_id), static_cast<uint16_t>(plan.ragged_id >> 16)};
-}
-
-static_assert(sizeof(DecodePlan) == 16, "DecodePlan must be 16 bytes");
-static_assert(sizeof(CompressPlan) == 16, "CompressPlan must be 16 bytes");
-static_assert(sizeof(WritePlan) == 8, "WritePlan must be 8 bytes");
 constexpr uint32_t kStage0BlockSize = 256;
 constexpr uint32_t kStage0SubGroupSize = 32;
 constexpr uint32_t kStage0NumSubGroups = kStage0BlockSize / kStage0SubGroupSize;

--- a/src/sycl/FlashCompress128.cpp
+++ b/src/sycl/FlashCompress128.cpp
@@ -42,12 +42,12 @@ struct FlashCompress128DecodeKernel {
       kv_dst[head_dim_ + h] = static_cast<buffer_t>(kv_src[head_dim_ + h]);
     }
 
-    item.barrier(sycl::access::fence_space::global_and_local);
-
     // Compress only when a 128-token chunk is completed.
     if ((plan.write_loc % 128) != 127) {
       return;
     }
+
+    item.barrier(sycl::access::fence_space::global_and_local);
 
     // Last split may be partial when head_dim is not divisible by kTileDim.
     if (h >= head_dim_) {

--- a/src/sycl/FlashCompress128.cpp
+++ b/src/sycl/FlashCompress128.cpp
@@ -1,0 +1,138 @@
+#include <ATen/ATen.h>
+#include <c10/xpu/XPUStream.h>
+#include <torch/all.h>
+
+#include <limits>
+#include <sycl/sycl.hpp>
+
+#include "Compress.h"
+#include "Utils.h"
+
+namespace at::native::xpu {
+
+namespace {
+
+template <typename buffer_t, typename input_t, typename out_t>
+struct FlashCompress128DecodeKernel {
+  void operator()(sycl::nd_item<1> item) const {
+    const uint32_t bid = static_cast<uint32_t>(item.get_global_id(0));
+    if (bid >= batch_size_) {
+      return;
+    }
+
+    const DecodePlan plan = plan_d_[bid];
+    const int64_t write_loc = static_cast<int64_t>(plan.write_loc);
+    buffer_t* kv_dst = kv_buffer_ + write_loc * elem_size_;
+    const input_t* kv_src = kv_input_ + static_cast<int64_t>(bid) * elem_size_;
+
+    for (int64_t i = 0; i < elem_size_; ++i) {
+      kv_dst[i] = static_cast<buffer_t>(kv_src[i]);
+    }
+
+    if ((plan.write_loc % 128) != 127) {
+      return;
+    }
+
+    const int64_t page = static_cast<int64_t>(plan.read_page_1);
+    const buffer_t* kv_page = kv_buffer_ + page * page_elem_size_;
+    out_t* out_row = kv_output_ + static_cast<int64_t>(bid) * head_dim_;
+
+    for (int64_t h = 0; h < head_dim_; ++h) {
+      float max_score = -std::numeric_limits<float>::infinity();
+      for (int64_t t = 0; t < 128; ++t) {
+        const int64_t row_off = t * elem_size_;
+        const float score =
+            static_cast<float>(kv_page[row_off + head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
+        max_score = sycl::fmax(max_score, score);
+      }
+
+      float exp_sum = 0.0f;
+      float weighted_sum = 0.0f;
+      for (int64_t t = 0; t < 128; ++t) {
+        const int64_t row_off = t * elem_size_;
+        const float score =
+            static_cast<float>(kv_page[row_off + head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
+        const float w = sycl::exp(score - max_score);
+        exp_sum += w;
+        weighted_sum += static_cast<float>(kv_page[row_off + h]) * w;
+      }
+
+      out_row[h] = static_cast<out_t>(weighted_sum / exp_sum);
+    }
+  }
+
+  buffer_t* kv_buffer_;
+  const input_t* kv_input_;
+  out_t* kv_output_;
+  const input_t* ape_;
+  const DecodePlan* plan_d_;
+  uint32_t batch_size_;
+  int64_t head_dim_;
+  int64_t elem_size_;
+  int64_t page_elem_size_;
+};
+
+}  // namespace
+
+void flash_compress128_decode(
+    torch::Tensor kv_buffer, torch::Tensor kv_input, torch::Tensor kv_output, torch::Tensor ape, torch::Tensor plan_d) {
+  TORCH_CHECK(
+      kv_buffer.is_xpu() && kv_buffer.dim() == 3 && kv_buffer.is_contiguous(),
+      "kv_buffer must be a contiguous 3D XPU tensor");
+  TORCH_CHECK(
+      kv_input.is_xpu() && kv_input.dim() == 2 && kv_input.is_contiguous(),
+      "kv_input must be a contiguous 2D XPU tensor");
+  TORCH_CHECK(
+      kv_output.is_xpu() && kv_output.dim() == 2 && kv_output.is_contiguous(),
+      "kv_output must be a contiguous 2D XPU tensor");
+  TORCH_CHECK(ape.is_xpu() && ape.dim() == 2 && ape.is_contiguous(), "ape must be a contiguous 2D XPU tensor");
+  TORCH_CHECK(
+      plan_d.is_xpu() && plan_d.dim() == 2 && plan_d.dtype() == torch::kUInt8 && plan_d.is_contiguous(),
+      "plan_d must be a contiguous 2D XPU uint8 tensor");
+  TORCH_CHECK(kv_input.dtype() == kv_output.dtype(), "kv_input and kv_output must have the same dtype");
+  TORCH_CHECK(kv_input.dtype() == ape.dtype(), "kv_input and ape must have same dtype");
+
+  const int64_t batch_size = kv_input.size(0);
+  const int64_t elem_size = kv_input.size(1);
+  const int64_t head_dim = kv_output.size(1);
+  TORCH_CHECK(elem_size == 2 * head_dim, "kv_input last dim must be 2 * head_dim");
+  TORCH_CHECK(
+      kv_buffer.size(1) == 128 && kv_buffer.size(2) == elem_size,
+      "kv_buffer shape must be [num_pages, 128, 2*head_dim]");
+  TORCH_CHECK(kv_output.size(0) == batch_size, "kv_output batch must match kv_input batch");
+  TORCH_CHECK(ape.size(0) == 128 && ape.size(1) == head_dim, "ape shape must be [128, head_dim]");
+  TORCH_CHECK(
+      plan_d.size(0) == batch_size && plan_d.size(1) == static_cast<int64_t>(sizeof(DecodePlan)),
+      "plan_d shape must be [B, 16]");
+
+  if (batch_size == 0) {
+    return;
+  }
+
+  const int64_t page_elem_size = 128 * elem_size;
+  auto queue = c10::xpu::getCurrentXPUStream().queue();
+
+  SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_input.scalar_type(), "FlashCompress128Decode", [&]() {
+    using input_t = scalar_t;
+    using output_t = scalar_t;
+    SYCL_DISPATCH_WEIGHT_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress128Decode", [&]() {
+      queue.submit([&](sycl::handler& cgh) {
+        FlashCompress128DecodeKernel<weight_t, input_t, output_t> kernel{
+            kv_buffer.data_ptr<weight_t>(),
+            kv_input.data_ptr<input_t>(),
+            kv_output.data_ptr<output_t>(),
+            ape.data_ptr<input_t>(),
+            reinterpret_cast<const DecodePlan*>(plan_d.data_ptr<uint8_t>()),
+            static_cast<uint32_t>(batch_size),
+            head_dim,
+            elem_size,
+            page_elem_size};
+        constexpr int32_t kLocalSize = 64;
+        const uint32_t global_size = ((static_cast<uint32_t>(batch_size) + kLocalSize - 1) / kLocalSize) * kLocalSize;
+        cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
+      });
+    });
+  });
+}
+
+}  // namespace at::native::xpu

--- a/src/sycl/FlashCompress128.cpp
+++ b/src/sycl/FlashCompress128.cpp
@@ -11,6 +11,8 @@
 namespace at::native::xpu {
 
 constexpr int64_t kTileDim = 64;
+constexpr int64_t kTokenGroups = 8;
+constexpr int64_t kTokensPerGroup = 128 / kTokenGroups;  // 16
 
 namespace FlashCompress128Impl {
 
@@ -112,7 +114,9 @@ struct FlashCompress128PrefillCompressKernel {
       return;
     }
 
-    const int64_t h = split_offset + static_cast<int64_t>(lid);
+    const int64_t h_lane = static_cast<int64_t>(lid % static_cast<uint32_t>(kTileDim));
+    const int64_t tg = static_cast<int64_t>(lid / static_cast<uint32_t>(kTileDim));
+    const int64_t h = split_offset + h_lane;
     if (h >= head_dim_) {
       return;
     }
@@ -120,48 +124,76 @@ struct FlashCompress128PrefillCompressKernel {
     const int64_t ragged_id = static_cast<int64_t>(plan.ragged_id);
     const int64_t buffer_len = static_cast<int64_t>(plan.buffer_len);
     const int64_t fresh_start = ragged_id - 127 + buffer_len;
-
     const int64_t page = static_cast<int64_t>(plan.read_page_1);
     const buffer_t* kv_page = kv_buffer_ + page * page_elem_size_;
-    out_t* out_row = kv_output_ + static_cast<int64_t>(pid) * head_dim_;
 
-    // Numerically stable softmax: first pass computes max(logits).
-    float max_score = -std::numeric_limits<float>::infinity();
-    for (int64_t t = 0; t < 128; ++t) {
-      float score;
+    const int64_t t_start = tg * kTokensPerGroup;
+
+    // Load all kTokensPerGroup tokens into registers.
+    float kv_reg[kTokensPerGroup];
+    float score_reg[kTokensPerGroup];
+
+    for (int64_t i = 0; i < kTokensPerGroup; ++i) {
+      const int64_t t = t_start + i;
       if (t < buffer_len) {
         const buffer_t* row_ptr = kv_page + t * elem_size_;
-        score = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
+        kv_reg[i] = static_cast<float>(row_ptr[h]);
+        score_reg[i] = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
       } else {
         const int64_t src_row = fresh_start + (t - buffer_len);
         const input_t* row_ptr = kv_input_ + src_row * elem_size_;
-        score = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
+        kv_reg[i] = static_cast<float>(row_ptr[h]);
+        score_reg[i] = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
       }
-      max_score = sycl::fmax(max_score, score);
     }
 
-    // Second pass computes exp-sum and weighted value sum in fp32.
-    float exp_sum = 0.0f;
-    float weighted_sum = 0.0f;
-    for (int64_t t = 0; t < 128; ++t) {
-      float kv_val;
-      float score;
-      if (t < buffer_len) {
-        const buffer_t* row_ptr = kv_page + t * elem_size_;
-        kv_val = static_cast<float>(row_ptr[h]);
-        score = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
-      } else {
-        const int64_t src_row = fresh_start + (t - buffer_len);
-        const input_t* row_ptr = kv_input_ + src_row * elem_size_;
-        kv_val = static_cast<float>(row_ptr[h]);
-        score = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
-      }
-      const float w = sycl::exp(score - max_score);
-      exp_sum += w;
-      weighted_sum += kv_val * w;
+    // Pass 1: compute local max over kTokensPerGroup scores.
+    float local_max = score_reg[0];
+    for (int64_t i = 1; i < kTokensPerGroup; ++i) {
+      local_max = sycl::fmax(local_max, score_reg[i]);
     }
 
-    out_row[h] = static_cast<out_t>(weighted_sum / exp_sum);
+    // Pass 2: compute partial exp_sum and weighted_sum.
+    float local_exp_sum = 0.0f;
+    float local_weighted_sum = 0.0f;
+    for (int64_t i = 0; i < kTokensPerGroup; ++i) {
+      const float exp_score = sycl::exp(score_reg[i] - local_max);
+      local_exp_sum += exp_score;
+      local_weighted_sum += kv_reg[i] * exp_score;
+    }
+
+    // Shared memory layout (3 sections, each [kTokenGroups][kTileDim]):
+    //   section 0: local_max           [tg * kTileDim + h_lane]
+    //   section 1: scaled exp_sum      [kSmemSection + ...]
+    //   section 2: scaled weighted_sum [2*kSmemSection + ...]
+    const size_t kSmemSection = static_cast<size_t>(kTokenGroups * kTileDim);
+    const size_t smem_idx = static_cast<size_t>(tg * kTileDim + h_lane);
+
+    shared_[smem_idx] = local_max;
+    item.barrier(sycl::access::fence_space::local_space);
+
+    // Compute global max across all token groups for this h_lane.
+    float global_max = local_max;
+    for (int64_t g = 0; g < kTokenGroups; ++g) {
+      global_max = sycl::fmax(global_max, shared_[static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)]);
+    }
+
+    // Rescale this group's partial sums to the global max and store.
+    const float rescale_to_global = sycl::exp(local_max - global_max);
+    shared_[kSmemSection + smem_idx] = local_exp_sum * rescale_to_global;
+    shared_[2 * kSmemSection + smem_idx] = local_weighted_sum * rescale_to_global;
+    item.barrier(sycl::access::fence_space::local_space);
+
+    // Token group 0 reduces all scaled partial sums and writes the final output.
+    if (tg == 0) {
+      float exp_sum = 0.0f;
+      float weighted_sum = 0.0f;
+      for (int64_t g = 0; g < kTokenGroups; ++g) {
+        exp_sum += shared_[kSmemSection + static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)];
+        weighted_sum += shared_[2 * kSmemSection + static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)];
+      }
+      kv_output_[static_cast<int64_t>(pid) * head_dim_ + h] = static_cast<out_t>(weighted_sum / exp_sum);
+    }
   }
 
   buffer_t* kv_buffer_;
@@ -174,6 +206,7 @@ struct FlashCompress128PrefillCompressKernel {
   int64_t elem_size_;
   int64_t page_elem_size_;
   uint32_t num_split_;
+  sycl::local_accessor<float, 1> shared_;
 };
 
 template <typename buffer_t, typename input_t>
@@ -338,6 +371,9 @@ void flash_compress128_prefill(
     SYCL_DISPATCH_WEIGHT_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress128Prefill", [&]() {
       if (num_compress > 0) {
         queue.submit([&](sycl::handler& cgh) {
+          // Shared memory: 3 sections × [kTokenGroups × kTileDim] floats.
+          const size_t kSmemElems = static_cast<size_t>(3 * kTokenGroups * kTileDim);
+          sycl::local_accessor<float, 1> shared(sycl::range<1>(kSmemElems), cgh);
           FlashCompress128Impl::FlashCompress128PrefillCompressKernel<weight_t, input_t, output_t> kernel{
               kv_buffer.data_ptr<weight_t>(),
               kv_input.data_ptr<input_t>(),
@@ -348,10 +384,11 @@ void flash_compress128_prefill(
               head_dim,
               elem_size,
               page_elem_size,
-              num_split};
-          constexpr uint32_t kLocalSize = 64;
-          const uint32_t global_size = static_cast<uint32_t>(num_compress) * num_split * kLocalSize;
-          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
+              num_split,
+              shared};
+          constexpr uint32_t kLocalSizeCompress = static_cast<uint32_t>(kTileDim * kTokenGroups);  // 512
+          const uint32_t global_size = static_cast<uint32_t>(num_compress) * num_split * kLocalSizeCompress;
+          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSizeCompress)), kernel);
         });
       }
 

--- a/src/sycl/FlashCompress128.cpp
+++ b/src/sycl/FlashCompress128.cpp
@@ -94,6 +94,130 @@ struct FlashCompress128DecodeKernel {
   uint32_t num_split_;
 };
 
+template <typename buffer_t, typename input_t, typename out_t>
+struct FlashCompress128PrefillCompressKernel {
+  [[sycl::reqd_sub_group_size(16)]]
+  void operator()(sycl::nd_item<1> item) const {
+    const uint32_t gid = static_cast<uint32_t>(item.get_group(0));
+    const uint32_t lid = static_cast<uint32_t>(item.get_local_id(0));
+    const uint32_t pid = gid / num_split_;
+    const int64_t split_offset = static_cast<int64_t>(gid % num_split_) * kTileDim;
+
+    if (pid >= num_compress_) {
+      return;
+    }
+
+    const CompressPlan plan = plan_c_[pid];
+    if (plan.is_invalid()) {
+      return;
+    }
+
+    const int64_t h = split_offset + static_cast<int64_t>(lid);
+    if (h >= head_dim_) {
+      return;
+    }
+
+    const int64_t ragged_id = static_cast<int64_t>(plan.ragged_id);
+    const int64_t buffer_len = static_cast<int64_t>(plan.buffer_len);
+    const int64_t fresh_start = ragged_id - 127 + buffer_len;
+
+    const int64_t page = static_cast<int64_t>(plan.read_page_1);
+    const buffer_t* kv_page = kv_buffer_ + page * page_elem_size_;
+    out_t* out_row = kv_output_ + static_cast<int64_t>(pid) * head_dim_;
+
+    // Numerically stable softmax: first pass computes max(logits).
+    float max_score = -std::numeric_limits<float>::infinity();
+    for (int64_t t = 0; t < 128; ++t) {
+      float score;
+      if (t < buffer_len) {
+        const buffer_t* row_ptr = kv_page + t * elem_size_;
+        score = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
+      } else {
+        const int64_t src_row = fresh_start + (t - buffer_len);
+        const input_t* row_ptr = kv_input_ + src_row * elem_size_;
+        score = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
+      }
+      max_score = sycl::fmax(max_score, score);
+    }
+
+    // Second pass computes exp-sum and weighted value sum in fp32.
+    float exp_sum = 0.0f;
+    float weighted_sum = 0.0f;
+    for (int64_t t = 0; t < 128; ++t) {
+      float kv_val;
+      float score;
+      if (t < buffer_len) {
+        const buffer_t* row_ptr = kv_page + t * elem_size_;
+        kv_val = static_cast<float>(row_ptr[h]);
+        score = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
+      } else {
+        const int64_t src_row = fresh_start + (t - buffer_len);
+        const input_t* row_ptr = kv_input_ + src_row * elem_size_;
+        kv_val = static_cast<float>(row_ptr[h]);
+        score = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
+      }
+      const float w = sycl::exp(score - max_score);
+      exp_sum += w;
+      weighted_sum += kv_val * w;
+    }
+
+    out_row[h] = static_cast<out_t>(weighted_sum / exp_sum);
+  }
+
+  buffer_t* kv_buffer_;
+  const input_t* kv_input_;
+  out_t* kv_output_;
+  const input_t* ape_;
+  const CompressPlan* plan_c_;
+  uint32_t num_compress_;
+  int64_t head_dim_;
+  int64_t elem_size_;
+  int64_t page_elem_size_;
+  uint32_t num_split_;
+};
+
+template <typename buffer_t, typename input_t>
+struct FlashCompress128PrefillWriteKernel {
+  [[sycl::reqd_sub_group_size(16)]]
+  void operator()(sycl::nd_item<1> item) const {
+    const uint32_t gid = static_cast<uint32_t>(item.get_group(0));
+    const uint32_t lid = static_cast<uint32_t>(item.get_local_id(0));
+    const uint32_t pid = gid / num_split_;
+    const int64_t split_offset = static_cast<int64_t>(gid % num_split_) * kTileDim;
+
+    if (pid >= num_write_) {
+      return;
+    }
+
+    const WritePlan plan = plan_w_[pid];
+    if (plan.is_invalid()) {
+      return;
+    }
+
+    const int64_t h = split_offset + static_cast<int64_t>(lid);
+    if (h >= head_dim_) {
+      return;
+    }
+
+    const int64_t write_loc = static_cast<int64_t>(plan.write_loc);
+    const int64_t ragged_id = static_cast<int64_t>(plan.ragged_id);
+
+    buffer_t* kv_dst = kv_buffer_ + write_loc * elem_size_;
+    const input_t* kv_src = kv_input_ + ragged_id * elem_size_;
+
+    kv_dst[h] = static_cast<buffer_t>(kv_src[h]);
+    kv_dst[head_dim_ + h] = static_cast<buffer_t>(kv_src[head_dim_ + h]);
+  }
+
+  buffer_t* kv_buffer_;
+  const input_t* kv_input_;
+  const WritePlan* plan_w_;
+  uint32_t num_write_;
+  int64_t head_dim_;
+  int64_t elem_size_;
+  uint32_t num_split_;
+};
+
 }  // namespace FlashCompress128Impl
 
 void flash_compress128_decode(
@@ -155,6 +279,97 @@ void flash_compress128_decode(
         const uint32_t global_size = static_cast<uint32_t>(batch_size) * num_split * kLocalSize;
         cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
       });
+    });
+  });
+}
+
+void flash_compress128_prefill(
+    torch::Tensor kv_buffer,
+    torch::Tensor kv_input,
+    torch::Tensor kv_output,
+    torch::Tensor ape,
+    torch::Tensor plan_c,
+    torch::Tensor plan_w) {
+  TORCH_CHECK(
+      kv_buffer.is_xpu() && kv_buffer.dim() == 3 && kv_buffer.is_contiguous(),
+      "kv_buffer must be a contiguous 3D XPU tensor");
+  TORCH_CHECK(
+      kv_input.is_xpu() && kv_input.dim() == 2 && kv_input.is_contiguous(),
+      "kv_input must be a contiguous 2D XPU tensor");
+  TORCH_CHECK(
+      kv_output.is_xpu() && kv_output.dim() == 2 && kv_output.is_contiguous(),
+      "kv_output must be a contiguous 2D XPU tensor");
+  TORCH_CHECK(ape.is_xpu() && ape.dim() == 2 && ape.is_contiguous(), "ape must be a contiguous 2D XPU tensor");
+  TORCH_CHECK(
+      plan_c.is_xpu() && plan_c.dim() == 2 && plan_c.dtype() == torch::kUInt8 && plan_c.is_contiguous(),
+      "plan_c must be a contiguous 2D XPU uint8 tensor");
+  TORCH_CHECK(
+      plan_w.is_xpu() && plan_w.dim() == 2 && plan_w.dtype() == torch::kUInt8 && plan_w.is_contiguous(),
+      "plan_w must be a contiguous 2D XPU uint8 tensor");
+  TORCH_CHECK(kv_input.dtype() == kv_output.dtype(), "kv_input and kv_output must have the same dtype");
+  TORCH_CHECK(kv_input.dtype() == ape.dtype(), "kv_input and ape must have same dtype");
+
+  const int64_t elem_size = kv_input.size(1);
+  const int64_t head_dim = kv_output.size(1);
+  const int64_t num_compress = kv_output.size(0);
+  const int64_t num_write = plan_w.size(0);
+
+  TORCH_CHECK(elem_size == 2 * head_dim, "kv_input last dim must be 2 * head_dim");
+  TORCH_CHECK(
+      kv_buffer.size(1) == 128 && kv_buffer.size(2) == elem_size,
+      "kv_buffer shape must be [num_pages, 128, 2*head_dim]");
+  TORCH_CHECK(ape.size(0) == 128 && ape.size(1) == head_dim, "ape shape must be [128, head_dim]");
+  TORCH_CHECK(
+      plan_c.size(0) == num_compress && plan_c.size(1) == static_cast<int64_t>(sizeof(CompressPlan)),
+      "plan_c shape must be [C, 16]");
+  TORCH_CHECK(plan_w.size(1) == static_cast<int64_t>(sizeof(WritePlan)), "plan_w shape must be [W, 8]");
+
+  if (num_compress == 0 && num_write == 0) {
+    return;
+  }
+
+  const int64_t page_elem_size = 128 * elem_size;
+  const uint32_t num_split = static_cast<uint32_t>((head_dim + kTileDim - 1) / kTileDim);
+  auto queue = c10::xpu::getCurrentXPUStream().queue();
+
+  SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_input.scalar_type(), "FlashCompress128Prefill", [&]() {
+    using input_t = scalar_t;
+    using output_t = scalar_t;
+    SYCL_DISPATCH_WEIGHT_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress128Prefill", [&]() {
+      if (num_compress > 0) {
+        queue.submit([&](sycl::handler& cgh) {
+          FlashCompress128Impl::FlashCompress128PrefillCompressKernel<weight_t, input_t, output_t> kernel{
+              kv_buffer.data_ptr<weight_t>(),
+              kv_input.data_ptr<input_t>(),
+              kv_output.data_ptr<output_t>(),
+              ape.data_ptr<input_t>(),
+              reinterpret_cast<const CompressPlan*>(plan_c.data_ptr<uint8_t>()),
+              static_cast<uint32_t>(num_compress),
+              head_dim,
+              elem_size,
+              page_elem_size,
+              num_split};
+          constexpr uint32_t kLocalSize = 64;
+          const uint32_t global_size = static_cast<uint32_t>(num_compress) * num_split * kLocalSize;
+          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
+        });
+      }
+
+      if (num_write > 0) {
+        queue.submit([&](sycl::handler& cgh) {
+          FlashCompress128Impl::FlashCompress128PrefillWriteKernel<weight_t, input_t> kernel{
+              kv_buffer.data_ptr<weight_t>(),
+              kv_input.data_ptr<input_t>(),
+              reinterpret_cast<const WritePlan*>(plan_w.data_ptr<uint8_t>()),
+              static_cast<uint32_t>(num_write),
+              head_dim,
+              elem_size,
+              num_split};
+          constexpr uint32_t kLocalSize = 64;
+          const uint32_t global_size = static_cast<uint32_t>(num_write) * num_split * kLocalSize;
+          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
+        });
+      }
     });
   });
 }

--- a/src/sycl/FlashCompress128.cpp
+++ b/src/sycl/FlashCompress128.cpp
@@ -10,26 +10,47 @@
 
 namespace at::native::xpu {
 
-namespace {
+constexpr int64_t kTileDim = 64;
+
+namespace FlashCompress128Impl {
 
 template <typename buffer_t, typename input_t, typename out_t>
 struct FlashCompress128DecodeKernel {
+  [[sycl::reqd_sub_group_size(16)]]
   void operator()(sycl::nd_item<1> item) const {
-    const uint32_t bid = static_cast<uint32_t>(item.get_global_id(0));
+    const uint32_t gid = static_cast<uint32_t>(item.get_group(0));
+    const uint32_t lid = static_cast<uint32_t>(item.get_local_id(0));
+    const uint32_t bid = gid / num_split_;
+    const int64_t split_offset = static_cast<int64_t>(gid % num_split_) * kTileDim;
+
     if (bid >= batch_size_) {
       return;
     }
 
     const DecodePlan plan = plan_d_[bid];
+    if (plan.seq_len == 0 || plan.write_loc < 0) {
+      return;
+    }
+
     const int64_t write_loc = static_cast<int64_t>(plan.write_loc);
     buffer_t* kv_dst = kv_buffer_ + write_loc * elem_size_;
     const input_t* kv_src = kv_input_ + static_cast<int64_t>(bid) * elem_size_;
 
-    for (int64_t i = 0; i < elem_size_; ++i) {
-      kv_dst[i] = static_cast<buffer_t>(kv_src[i]);
+    const int64_t h = split_offset + static_cast<int64_t>(lid);
+    if (h < head_dim_) {
+      kv_dst[h] = static_cast<buffer_t>(kv_src[h]);
+      kv_dst[head_dim_ + h] = static_cast<buffer_t>(kv_src[head_dim_ + h]);
     }
 
+    item.barrier(sycl::access::fence_space::global_and_local);
+
+    // Compress only when a 128-token chunk is completed.
     if ((plan.write_loc % 128) != 127) {
+      return;
+    }
+
+    // Last split may be partial when head_dim is not divisible by kTileDim.
+    if (h >= head_dim_) {
       return;
     }
 
@@ -37,28 +58,28 @@ struct FlashCompress128DecodeKernel {
     const buffer_t* kv_page = kv_buffer_ + page * page_elem_size_;
     out_t* out_row = kv_output_ + static_cast<int64_t>(bid) * head_dim_;
 
-    for (int64_t h = 0; h < head_dim_; ++h) {
-      float max_score = -std::numeric_limits<float>::infinity();
-      for (int64_t t = 0; t < 128; ++t) {
-        const int64_t row_off = t * elem_size_;
-        const float score =
-            static_cast<float>(kv_page[row_off + head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
-        max_score = sycl::fmax(max_score, score);
-      }
-
-      float exp_sum = 0.0f;
-      float weighted_sum = 0.0f;
-      for (int64_t t = 0; t < 128; ++t) {
-        const int64_t row_off = t * elem_size_;
-        const float score =
-            static_cast<float>(kv_page[row_off + head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
-        const float w = sycl::exp(score - max_score);
-        exp_sum += w;
-        weighted_sum += static_cast<float>(kv_page[row_off + h]) * w;
-      }
-
-      out_row[h] = static_cast<out_t>(weighted_sum / exp_sum);
+    // Numerically stable softmax: first pass computes max(logits).
+    float max_score = -std::numeric_limits<float>::infinity();
+    for (int64_t t = 0; t < 128; ++t) {
+      const int64_t row_off = t * elem_size_;
+      const float score =
+          static_cast<float>(kv_page[row_off + head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
+      max_score = sycl::fmax(max_score, score);
     }
+
+    // Second pass computes exp-sum and weighted value sum in fp32.
+    float exp_sum = 0.0f;
+    float weighted_sum = 0.0f;
+    for (int64_t t = 0; t < 128; ++t) {
+      const int64_t row_off = t * elem_size_;
+      const float score =
+          static_cast<float>(kv_page[row_off + head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
+      const float w = sycl::exp(score - max_score);
+      exp_sum += w;
+      weighted_sum += static_cast<float>(kv_page[row_off + h]) * w;
+    }
+
+    out_row[h] = static_cast<out_t>(weighted_sum / exp_sum);
   }
 
   buffer_t* kv_buffer_;
@@ -70,9 +91,10 @@ struct FlashCompress128DecodeKernel {
   int64_t head_dim_;
   int64_t elem_size_;
   int64_t page_elem_size_;
+  uint32_t num_split_;
 };
 
-}  // namespace
+}  // namespace FlashCompress128Impl
 
 void flash_compress128_decode(
     torch::Tensor kv_buffer, torch::Tensor kv_input, torch::Tensor kv_output, torch::Tensor ape, torch::Tensor plan_d) {
@@ -110,6 +132,7 @@ void flash_compress128_decode(
   }
 
   const int64_t page_elem_size = 128 * elem_size;
+  const uint32_t num_split = static_cast<uint32_t>((head_dim + kTileDim - 1) / kTileDim);
   auto queue = c10::xpu::getCurrentXPUStream().queue();
 
   SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_input.scalar_type(), "FlashCompress128Decode", [&]() {
@@ -117,7 +140,7 @@ void flash_compress128_decode(
     using output_t = scalar_t;
     SYCL_DISPATCH_WEIGHT_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress128Decode", [&]() {
       queue.submit([&](sycl::handler& cgh) {
-        FlashCompress128DecodeKernel<weight_t, input_t, output_t> kernel{
+        FlashCompress128Impl::FlashCompress128DecodeKernel<weight_t, input_t, output_t> kernel{
             kv_buffer.data_ptr<weight_t>(),
             kv_input.data_ptr<input_t>(),
             kv_output.data_ptr<output_t>(),
@@ -126,9 +149,10 @@ void flash_compress128_decode(
             static_cast<uint32_t>(batch_size),
             head_dim,
             elem_size,
-            page_elem_size};
-        constexpr int32_t kLocalSize = 64;
-        const uint32_t global_size = ((static_cast<uint32_t>(batch_size) + kLocalSize - 1) / kLocalSize) * kLocalSize;
+            page_elem_size,
+            num_split};
+        constexpr uint32_t kLocalSize = 64;
+        const uint32_t global_size = static_cast<uint32_t>(batch_size) * num_split * kLocalSize;
         cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
       });
     });

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -356,6 +356,11 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "flash_compress128_decode(Tensor! kv_buffer, Tensor kv_input, Tensor! kv_output, Tensor ape, Tensor plan_d) "
       "-> ()");
   m.impl("flash_compress128_decode", torch::kXPU, &at::native::xpu::flash_compress128_decode);
+
+    m.def(
+            "flash_compress128_prefill(Tensor! kv_buffer, Tensor kv_input, Tensor! kv_output, Tensor ape, Tensor plan_c, "
+            "Tensor plan_w) -> ()");
+    m.impl("flash_compress128_prefill", torch::kXPU, &at::native::xpu::flash_compress128_prefill);
 }
 
 REGISTER_EXTENSION(common_ops)

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -357,10 +357,10 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "-> ()");
   m.impl("flash_compress128_decode", torch::kXPU, &at::native::xpu::flash_compress128_decode);
 
-    m.def(
-            "flash_compress128_prefill(Tensor! kv_buffer, Tensor kv_input, Tensor! kv_output, Tensor ape, Tensor plan_c, "
-            "Tensor plan_w) -> ()");
-    m.impl("flash_compress128_prefill", torch::kXPU, &at::native::xpu::flash_compress128_prefill);
+  m.def(
+      "flash_compress128_prefill(Tensor! kv_buffer, Tensor kv_input, Tensor! kv_output, Tensor ape, Tensor plan_c, "
+      "Tensor plan_w) -> ()");
+  m.impl("flash_compress128_prefill", torch::kXPU, &at::native::xpu::flash_compress128_prefill);
 }
 
 REGISTER_EXTENSION(common_ops)

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -351,6 +351,11 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "plan_compress_decode(Tensor req_pool_indices, Tensor req_to_token, Tensor full_to_state, "
       "Tensor seq_lens, int compress_ratio, int swa_page_size, int ring_size) -> Tensor");
   m.impl("plan_compress_decode", torch::kXPU, &at::native::xpu::plan_compress_decode);
+
+  m.def(
+      "flash_compress128_decode(Tensor! kv_buffer, Tensor kv_input, Tensor! kv_output, Tensor ape, Tensor plan_d) "
+      "-> ()");
+  m.impl("flash_compress128_decode", torch::kXPU, &at::native::xpu::flash_compress128_decode);
 }
 
 REGISTER_EXTENSION(common_ops)

--- a/tests/test_c128_v2.py
+++ b/tests/test_c128_v2.py
@@ -22,8 +22,11 @@ Context = Union[LegacyContext, PagedContext]
 # c128 input row layout: | kv | score |  each [head_dim]
 HEAD_DIM = 512
 RATIO = 128
-ATOL = 5e-3
-RTOL = 5e-3
+
+precision = {
+    torch.bfloat16: 1e-2,
+    torch.float32: 5e-3,
+}
 
 
 def _gt_compress(
@@ -95,7 +98,8 @@ def _run_decode(
 
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("seq_len", [128, 256, 512])
-def test_prefill_no_context(mode: str, seq_len: int) -> None:
+@pytest.mark.parametrize("input_dtype", [torch.float32, torch.bfloat16])
+def test_prefill_no_context(mode: str, seq_len: int, input_dtype: torch.dtype) -> None:
     """Single-shot prefill, no prefix. Every compress event must match fp64 GT."""
     if mode == "legacy":
         ctx: Context = make_legacy_context(
@@ -111,8 +115,8 @@ def test_prefill_no_context(mode: str, seq_len: int) -> None:
     out = _run_prefill(
         ctx,
         pool,
-        kv_in_cpu.to(get_device()),
-        ape_cpu.to(get_device()),
+        kv_in_cpu.to(get_device(), dtype=input_dtype),
+        ape_cpu.to(get_device(), dtype=input_dtype),
         seq_lens_cpu,
         extend_lens_cpu,
     )
@@ -120,12 +124,20 @@ def test_prefill_no_context(mode: str, seq_len: int) -> None:
     # Compact prefill output: row per compress plan, in CPU-planner order.
     for plan_id, P in enumerate(range(RATIO - 1, seq_len, RATIO)):
         gt = _gt_compress(kv_in_cpu, ape_cpu, P=P, head_dim=ctx.head_dim)
-        triton.testing.assert_close(out[plan_id].cpu(), gt, atol=ATOL, rtol=RTOL)
+        triton.testing.assert_close(
+            out[plan_id].cpu(),
+            gt,
+            atol=precision[input_dtype],
+            rtol=precision[input_dtype],
+        )
 
 
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("prefix_len", [0, 128, 256])
-def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
+@pytest.mark.parametrize("input_dtype", [torch.float32, torch.bfloat16])
+def test_prefill_then_decode(
+    mode: str, prefix_len: int, input_dtype: torch.dtype
+) -> None:
     """Prefill ``prefix_len`` tokens, then decode through to the next 128 boundary."""
     seq_len = prefix_len + RATIO  # one full compress chunk after prefix
 
@@ -146,8 +158,8 @@ def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
         _run_prefill(
             ctx,
             pool,
-            kv_full_cpu[:prefix_len].to(get_device()),
-            ape_cpu.to(get_device()),
+            kv_full_cpu[:prefix_len].to(get_device(), dtype=input_dtype),
+            ape_cpu.to(get_device(), dtype=input_dtype),
             seq_lens_cpu,
             extend_lens_cpu,
         )
@@ -158,21 +170,37 @@ def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
         seq_lens_gpu = torch.tensor(
             [cur_seq_len], dtype=torch.int64, device=get_device()
         )
-        kv_step = kv_full_cpu[prefix_len + k : prefix_len + k + 1].to(get_device())
-        out = _run_decode(ctx, pool, kv_step, ape_cpu.to(get_device()), seq_lens_gpu)
+        kv_step = kv_full_cpu[prefix_len + k : prefix_len + k + 1].to(
+            get_device(), dtype=input_dtype
+        )
+        out = _run_decode(
+            ctx,
+            pool,
+            kv_step,
+            ape_cpu.to(get_device(), dtype=input_dtype),
+            seq_lens_gpu,
+        )
         if cur_seq_len % RATIO == 0:
             final_out = out
 
     P = seq_len - 1
     gt = _gt_compress(kv_full_cpu, ape_cpu, P=P, head_dim=ctx.head_dim)
     assert final_out is not None
-    triton.testing.assert_close(final_out[0].cpu(), gt, atol=ATOL, rtol=RTOL)
+    triton.testing.assert_close(
+        final_out[0].cpu(),
+        gt,
+        atol=precision[input_dtype],
+        rtol=precision[input_dtype],
+    )
 
 
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("prefix_len", [128, 120, 256])
 @pytest.mark.parametrize("extend_len", [128, 256])
-def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> None:
+@pytest.mark.parametrize("input_dtype", [torch.float32, torch.bfloat16])
+def test_prefill_then_extend(
+    mode: str, prefix_len: int, extend_len: int, input_dtype: torch.dtype
+) -> None:
     """Prefill once, then a second prefill that extends across compress event(s).
 
     A prefix that is not a multiple of the ratio (e.g. 120) makes the first
@@ -196,8 +224,8 @@ def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> Non
     _run_prefill(
         ctx,
         pool,
-        kv_full_cpu[:prefix_len].to(get_device()),
-        ape_cpu.to(get_device()),
+        kv_full_cpu[:prefix_len].to(get_device(), dtype=input_dtype),
+        ape_cpu.to(get_device(), dtype=input_dtype),
         seq_lens_cpu,
         extend_lens_cpu,
     )
@@ -206,8 +234,8 @@ def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> Non
     out = _run_prefill(
         ctx,
         pool,
-        kv_full_cpu[prefix_len:].to(get_device()),
-        ape_cpu.to(get_device()),
+        kv_full_cpu[prefix_len:].to(get_device(), dtype=input_dtype),
+        ape_cpu.to(get_device(), dtype=input_dtype),
         seq_lens_cpu,
         extend_lens_cpu,
     )
@@ -217,7 +245,11 @@ def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> Non
     for plan_id, P in enumerate(range(first_event, seq_len, RATIO)):
         gt = _gt_compress(kv_full_cpu, ape_cpu, P=P, head_dim=ctx.head_dim)
         triton.testing.assert_close(
-            out[plan_id].cpu(), gt, atol=ATOL, rtol=RTOL, err_msg=f"{plan_id=}, {P=}"
+            out[plan_id].cpu(),
+            gt,
+            atol=precision[input_dtype],
+            rtol=precision[input_dtype],
+            err_msg=f"{plan_id=}, {P=}",
         )
 
 
@@ -263,8 +295,8 @@ def test_prefill_multibatch(mode: str) -> None:
             triton.testing.assert_close(
                 out[plan_id].cpu(),
                 gt,
-                atol=ATOL,
-                rtol=RTOL,
+                atol=precision[torch.float32],
+                rtol=precision[torch.float32],
             )
             plan_id += 1
         base += ext


### PR DESCRIPTION
### Motivation
Adds an SYCL implementation of `flash_compress128_prefill `and wires it through the C++/Torch extension so the Python API uses the native op instead of a Torch fallback implementation.

Modifications
Register `flash_compress128_prefill `as an XPU op in the SYCL torch extension.
Add a new SYCL kernel implementation for `flash_compress128_prefill`.
Update the Python wrapper to call `torch.ops.sgl_kernel.flash_compress128_prefill`.

Performance
The SYCL implementation significantly improves the performance of `flash_compress128_prefill `on XPU.
case | bs | seq_lens | extend_lens | num_q | head_dim | sycl time(us) | PyTorch time(us) | speedup
-- | -- | -- | -- | -- | -- | -- | -- | --
c128_prefill_no_ctx_seq128_hd512_f32_paged | 1 | 128 | 128 | 128 | 512 | 17.081 | 3404.403 | 199.3x
c128_prefill_no_ctx_seq256_hd512_f32_paged | 1 | 256 | 256 | 256 | 512 | 29.545 | 6272.480 | 212.3x
c128_prefill_no_ctx_seq512_hd512_f32_paged | 1 | 512 | 512 | 512 | 512 | 55.860 | 12053.408 | 215.8x
c128_prefill_prefix128_hd512_f32_paged | 1 | 128 | 128 | 128 | 512 | 17.097 | 3375.173 | 197.4x
c128_prefill_prefix256_hd512_f32_paged | 1 | 256 | 256 | 256 | 512 | 29.538 | 6328.063 | 214.2x
c128_prefill_extend_prefix128_ext128_hd512_f32_paged | 1 | 256 | 128 | 128 | 512 | 17.113 | 3523.497 | 205.9x
c128_prefill_extend_prefix120_ext128_hd512_f32_paged | 1 | 248 | 128 | 128 | 512 | 19.846 | 7232.083 | 364.4x
c128_prefill_extend_prefix256_ext128_hd512_f32_paged | 1 | 384 | 128 | 128 | 512 | 17.080 | 3430.602 | 200.8x
c128_prefill_extend_prefix128_ext256_hd512_f32_paged | 1 | 384 | 256 | 256 | 512 | 29.655 | 6518.344 | 219.8x
c128_prefill_extend_prefix120_ext256_hd512_f32_paged | 1 | 376 | 256 | 256 | 512 | 32.447 | 10152.896 | 312.9x
c128_prefill_extend_prefix256_ext256_hd512_f32_paged | 1 | 512 | 256 | 256 | 512 | 29.639 | 6401.999 | 215.9x
