### PR TITLE
[CI] Disable bench_fused_qk_norm_rope.py to unblock XPU PR tests

### DIFF
--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -95,7 +95,7 @@ jobs:
               python3 bench_merge_states_v2.py 2>&1 | tee merge_states.py.log && \
               python3 bench_mrope.py 2>&1 | tee mrope.py.log && \
               python3 bench_swiglu_alpha_limit.py 2>&1 | tee swiglu_alpha_limit.py.log && \
-              python3 bench_fused_qk_norm_rope.py 2>&1 | tee fused_qk_norm_rope.py.log && \
+              echo 'Skipping bench_fused_qk_norm_rope.py (XPU OOM in reference path wedges the device and times the step out; re-enable once fixed)' && \
               python3 bench_fused_qk_rope_with_cache.py 2>&1 | tee bench_fused_qk_rope_with_cache.py.log && \
               echo 'Skipping bench_per_token_group_quant_8bit.py (disabled to unblock other benchmarks; see PR #256)' && \
               python3 bench_per_token_group_quant_mxfp4.py 2>&1 | tee per_token_group_quant_mxfp4.py.log && \


### PR DESCRIPTION
## Summary
- `bench_fused_qk_norm_rope.py` is failing on every recent PR test on `pr-test-xpu.yml`. Its reference path allocates multi-GB tensors on the largest configs (DeepSeek-V3-style 128 Q / 128 K / 128 V heads at `bsz=8, seq=1024`, plus an fp32 upcast for the FP8 reference), the XPU Level Zero backend returns `UR_RESULT_ERROR_OUT_OF_RESOURCES (40)` from `torch.cat` in `fused_qk_norm_rope_reference` (line 176), the device wedges, and the whole `Run Sglang Kernel Benchmarks` step is then killed by the 40-minute GHA timeout.
- Same traceback on four unrelated PRs' runs: `30516674427`, `30520069595`, `30525365024`, `30530124724` — all fail at `bench_fused_qk_norm_rope.py:176`, so this is a shared CI issue, not a per-PR regression.
- Skip this benchmark for now, following the pattern already used for `bench_per_token_group_quant_8bit.py` on the line just below.

## Follow-ups (not in this PR)
- Release intermediates in `fused_qk_norm_rope_reference` (`del` + `torch.xpu.empty_cache()` between iterations).
- Trim the sweep for the `(128,128,128,128)` head config, or run each benchmark script in its own CI step so one bad script cannot burn the full 40-minute budget.

## Test plan
- [ ] Confirm `Run Sglang Kernel Benchmarks` no longer times out on this PR.
- [ ] Confirm the surrounding benchmarks (`bench_swiglu_alpha_limit.py`, `bench_fused_qk_rope_with_cache.py`, ...) still run.
- [ ] Re-enable once the underlying reference-path OOM is fixed.