### PR TITLE
Add SYCL support for flash_compress128_prefill

### DIFF
--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -751,7 +751,7 @@ void fast_topk_transform_ragged_interface(
     std::optional<at::Tensor> row_starts_opt);
 
 /*
- * Compress plan kernels
+ * Compress plan and execution kernels
  */
 namespace at::native::xpu {
 

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -780,6 +780,14 @@ torch::Tensor plan_compress_decode(
 void flash_compress128_decode(
     torch::Tensor kv_buffer, torch::Tensor kv_input, torch::Tensor kv_output, torch::Tensor ape, torch::Tensor plan_d);
 
+void flash_compress128_prefill(
+    torch::Tensor kv_buffer,
+    torch::Tensor kv_input,
+    torch::Tensor kv_output,
+    torch::Tensor ape,
+    torch::Tensor plan_c,
+    torch::Tensor plan_w);
+
 }  // namespace at::native::xpu
 
 namespace flash {

--- a/python/sgl_kernel/flash_compress_128.py
+++ b/python/sgl_kernel/flash_compress_128.py
@@ -101,40 +101,14 @@ def flash_compress128_prefill(
     plan_c_u8: torch.Tensor,  # [C, 16]
     plan_w_u8: torch.Tensor,  # [W, 8]
 ) -> None:
-    head_dim = _infer_head_dim_from_inputs(kv_input, ape, kv_output)
-
-    kv_flat = _flatten_slots_128(kv_buffer)
-    C = plan_c_u8.shape[0]
-    assert kv_output.shape == (C, head_dim), (kv_output.shape, C, head_dim)
-
-    seq_len, ragged_id, buffer_len, _rp0, rp1 = decode_plan_c(plan_c_u8)
-
-    # compress
-    for pid in range(C):
-        if seq_len[pid].item() < 0:
-            continue
-        P = int(ragged_id[pid].item())
-        bl = int(buffer_len[pid].item())
-        page = int(rp1[pid].item())
-        kv_buf_page = _page_slice_128(kv_flat, page)
-
-        c128_forward_torch(
-            kv_buf_page=kv_buf_page,
-            kv_input=kv_input,
-            ragged_id=P,
-            kv_out=kv_output[pid],
-            ape=ape,
-            buffer_len=bl,
-        )
-
-    # write after compress
-    rag_w, loc_w = decode_plan_w(plan_w_u8)
-    for i in range(plan_w_u8.shape[0]):
-        if rag_w[i].item() < 0:
-            continue
-        rid = int(rag_w[i].item())
-        loc = int(loc_w[i].item())
-        kv_flat[loc].copy_(kv_input[rid])
+    torch.ops.sgl_kernel.flash_compress128_prefill(
+        kv_buffer,
+        kv_input,
+        kv_output,
+        ape,
+        plan_c_u8,
+        plan_w_u8,
+    )
 
 
 def flash_compress128_decode(

--- a/src/sycl/FlashCompress128.cpp
+++ b/src/sycl/FlashCompress128.cpp
@@ -16,6 +16,77 @@ constexpr int64_t kTokensPerGroup = 128 / kTokenGroups;  // 16
 
 namespace FlashCompress128Impl {
 
+// Load + online softmax + weighted reduction shared by decode and prefill compress.
+// For decode, pass buffer_len=128 so all tokens load from kv_page.
+template <typename buffer_t, typename input_t, typename out_t>
+inline void c128_forward(
+    const buffer_t* kv_page,
+    const input_t* kv_input,
+    const input_t* ape,
+    int64_t fresh_start,
+    int64_t buffer_len,
+    int64_t t_start,
+    int64_t head_dim,
+    int64_t elem_size,
+    int64_t h,
+    int64_t tg,
+    int64_t h_lane,
+    out_t* kv_out_row,
+    sycl::nd_item<1> item,
+    sycl::local_accessor<float, 1> shared) {
+  float kv_reg[kTokensPerGroup];
+  float score_reg[kTokensPerGroup];
+  for (int64_t i = 0; i < kTokensPerGroup; ++i) {
+    const int64_t t = t_start + i;
+    if (t < buffer_len) {
+      const buffer_t* row_ptr = kv_page + t * elem_size;
+      kv_reg[i] = static_cast<float>(row_ptr[h]);
+      score_reg[i] = static_cast<float>(row_ptr[head_dim + h]) + static_cast<float>(ape[t * head_dim + h]);
+    } else {
+      const input_t* row_ptr = kv_input + (fresh_start + (t - buffer_len)) * elem_size;
+      kv_reg[i] = static_cast<float>(row_ptr[h]);
+      score_reg[i] = static_cast<float>(row_ptr[head_dim + h]) + static_cast<float>(ape[t * head_dim + h]);
+    }
+  }
+
+  float local_max = score_reg[0];
+  for (int64_t i = 1; i < kTokensPerGroup; ++i)
+    local_max = sycl::fmax(local_max, score_reg[i]);
+
+  float local_exp_sum = 0.0f;
+  float local_weighted_sum = 0.0f;
+  for (int64_t i = 0; i < kTokensPerGroup; ++i) {
+    const float exp_score = sycl::exp(score_reg[i] - local_max);
+    local_exp_sum += exp_score;
+    local_weighted_sum += kv_reg[i] * exp_score;
+  }
+
+  // Shared memory layout (3 sections, each [kTokenGroups][kTileDim]).
+  const size_t kSmemSection = static_cast<size_t>(kTokenGroups * kTileDim);
+  const size_t smem_idx = static_cast<size_t>(tg * kTileDim + h_lane);
+  shared[smem_idx] = local_max;
+  item.barrier(sycl::access::fence_space::local_space);
+
+  float global_max = local_max;
+  for (int64_t g = 0; g < kTokenGroups; ++g)
+    global_max = sycl::fmax(global_max, shared[static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)]);
+
+  const float rescale = sycl::exp(local_max - global_max);
+  shared[kSmemSection + smem_idx] = local_exp_sum * rescale;
+  shared[2 * kSmemSection + smem_idx] = local_weighted_sum * rescale;
+  item.barrier(sycl::access::fence_space::local_space);
+
+  if (tg == 0) {
+    float exp_sum = 0.0f;
+    float weighted_sum = 0.0f;
+    for (int64_t g = 0; g < kTokenGroups; ++g) {
+      exp_sum += shared[kSmemSection + static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)];
+      weighted_sum += shared[2 * kSmemSection + static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)];
+    }
+    kv_out_row[h] = static_cast<out_t>(weighted_sum / exp_sum);
+  }
+}
+
 template <typename buffer_t, typename input_t, typename out_t>
 struct FlashCompress128DecodeKernel {
   [[sycl::reqd_sub_group_size(16)]]
@@ -54,65 +125,22 @@ struct FlashCompress128DecodeKernel {
 
     item.barrier(sycl::access::fence_space::global_and_local);
 
-    const buffer_t* kv_page = kv_buffer_ + static_cast<int64_t>(plan.read_page_1) * page_elem_size_;
-    const int64_t t_start = tg * kTokensPerGroup;
-
-    // Load all kTokensPerGroup tokens into registers.
-    float kv_reg[kTokensPerGroup];
-    float score_reg[kTokensPerGroup];
-    for (int64_t i = 0; i < kTokensPerGroup; ++i) {
-      const int64_t t = t_start + i;
-      const buffer_t* row_ptr = kv_page + t * elem_size_;
-      kv_reg[i] = static_cast<float>(row_ptr[h]);
-      score_reg[i] = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
-    }
-
-    // Pass 1: compute local max over kTokensPerGroup scores.
-    float local_max = score_reg[0];
-    for (int64_t i = 1; i < kTokensPerGroup; ++i) {
-      local_max = sycl::fmax(local_max, score_reg[i]);
-    }
-
-    // Pass 2: compute partial exp_sum and weighted_sum.
-    float local_exp_sum = 0.0f;
-    float local_weighted_sum = 0.0f;
-    for (int64_t i = 0; i < kTokensPerGroup; ++i) {
-      const float exp_score = sycl::exp(score_reg[i] - local_max);
-      local_exp_sum += exp_score;
-      local_weighted_sum += kv_reg[i] * exp_score;
-    }
-
-    // Shared memory layout (3 sections, each [kTokenGroups][kTileDim]):
-    //   section 0: local_max           [tg * kTileDim + h_lane]
-    //   section 1: scaled exp_sum      [kSmemSection + ...]
-    //   section 2: scaled weighted_sum [2*kSmemSection + ...]
-    const size_t kSmemSection = static_cast<size_t>(kTokenGroups * kTileDim);
-    const size_t smem_idx = static_cast<size_t>(tg * kTileDim + h_lane);
-    shared_[smem_idx] = local_max;
-    item.barrier(sycl::access::fence_space::local_space);
-
-    // Compute global max across all token groups for this h_lane.
-    float global_max = local_max;
-    for (int64_t g = 0; g < kTokenGroups; ++g) {
-      global_max = sycl::fmax(global_max, shared_[static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)]);
-    }
-
-    // Rescale this group's partial sums to the global max and store.
-    const float rescale = sycl::exp(local_max - global_max);
-    shared_[kSmemSection + smem_idx] = local_exp_sum * rescale;
-    shared_[2 * kSmemSection + smem_idx] = local_weighted_sum * rescale;
-    item.barrier(sycl::access::fence_space::local_space);
-
-    // Token group 0 reduces all scaled partial sums and writes the final output.
-    if (tg == 0) {
-      float exp_sum = 0.0f;
-      float weighted_sum = 0.0f;
-      for (int64_t g = 0; g < kTokenGroups; ++g) {
-        exp_sum += shared_[kSmemSection + static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)];
-        weighted_sum += shared_[2 * kSmemSection + static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)];
-      }
-      kv_output_[static_cast<int64_t>(bid) * head_dim_ + h] = static_cast<out_t>(weighted_sum / exp_sum);
-    }
+    // buffer_len=128: all tokens come from kv_page, kv_input/fresh_start unused.
+    c128_forward(
+        kv_buffer_ + static_cast<int64_t>(plan.read_page_1) * page_elem_size_,
+        kv_input_,
+        ape_,
+        0,
+        128,
+        tg * kTokensPerGroup,
+        head_dim_,
+        elem_size_,
+        h,
+        tg,
+        h_lane,
+        kv_output_ + static_cast<int64_t>(bid) * head_dim_,
+        item,
+        shared_);
   }
 
   buffer_t* kv_buffer_;
@@ -152,72 +180,22 @@ struct FlashCompress128PrefillCompressKernel {
     const int64_t h = split_offset + h_lane;
     const int64_t buffer_len = static_cast<int64_t>(plan.buffer_len);
     const int64_t fresh_start = static_cast<int64_t>(plan.ragged_id) - 127 + buffer_len;
-    const buffer_t* kv_page = kv_buffer_ + static_cast<int64_t>(plan.read_page_1) * page_elem_size_;
-    const int64_t t_start = tg * kTokensPerGroup;
 
-    // Load all kTokensPerGroup tokens into registers.
-    float kv_reg[kTokensPerGroup];
-    float score_reg[kTokensPerGroup];
-    for (int64_t i = 0; i < kTokensPerGroup; ++i) {
-      const int64_t t = t_start + i;
-      if (t < buffer_len) {
-        const buffer_t* row_ptr = kv_page + t * elem_size_;
-        kv_reg[i] = static_cast<float>(row_ptr[h]);
-        score_reg[i] = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
-      } else {
-        const int64_t src_row = fresh_start + (t - buffer_len);
-        const input_t* row_ptr = kv_input_ + src_row * elem_size_;
-        kv_reg[i] = static_cast<float>(row_ptr[h]);
-        score_reg[i] = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
-      }
-    }
-
-    // Pass 1: compute local max over kTokensPerGroup scores.
-    float local_max = score_reg[0];
-    for (int64_t i = 1; i < kTokensPerGroup; ++i) {
-      local_max = sycl::fmax(local_max, score_reg[i]);
-    }
-
-    // Pass 2: compute partial exp_sum and weighted_sum.
-    float local_exp_sum = 0.0f;
-    float local_weighted_sum = 0.0f;
-    for (int64_t i = 0; i < kTokensPerGroup; ++i) {
-      const float exp_score = sycl::exp(score_reg[i] - local_max);
-      local_exp_sum += exp_score;
-      local_weighted_sum += kv_reg[i] * exp_score;
-    }
-
-    // Shared memory layout (3 sections, each [kTokenGroups][kTileDim]):
-    //   section 0: local_max           [tg * kTileDim + h_lane]
-    //   section 1: scaled exp_sum      [kSmemSection + ...]
-    //   section 2: scaled weighted_sum [2*kSmemSection + ...]
-    const size_t kSmemSection = static_cast<size_t>(kTokenGroups * kTileDim);
-    const size_t smem_idx = static_cast<size_t>(tg * kTileDim + h_lane);
-    shared_[smem_idx] = local_max;
-    item.barrier(sycl::access::fence_space::local_space);
-
-    // Compute global max across all token groups for this h_lane.
-    float global_max = local_max;
-    for (int64_t g = 0; g < kTokenGroups; ++g) {
-      global_max = sycl::fmax(global_max, shared_[static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)]);
-    }
-
-    // Rescale this group's partial sums to the global max and store.
-    const float rescale_to_global = sycl::exp(local_max - global_max);
-    shared_[kSmemSection + smem_idx] = local_exp_sum * rescale_to_global;
-    shared_[2 * kSmemSection + smem_idx] = local_weighted_sum * rescale_to_global;
-    item.barrier(sycl::access::fence_space::local_space);
-
-    // Token group 0 reduces all scaled partial sums and writes the final output.
-    if (tg == 0) {
-      float exp_sum = 0.0f;
-      float weighted_sum = 0.0f;
-      for (int64_t g = 0; g < kTokenGroups; ++g) {
-        exp_sum += shared_[kSmemSection + static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)];
-        weighted_sum += shared_[2 * kSmemSection + static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)];
-      }
-      kv_output_[static_cast<int64_t>(pid) * head_dim_ + h] = static_cast<out_t>(weighted_sum / exp_sum);
-    }
+    c128_forward(
+        kv_buffer_ + static_cast<int64_t>(plan.read_page_1) * page_elem_size_,
+        kv_input_,
+        ape_,
+        fresh_start,
+        buffer_len,
+        tg * kTokensPerGroup,
+        head_dim_,
+        elem_size_,
+        h,
+        tg,
+        h_lane,
+        kv_output_ + static_cast<int64_t>(pid) * head_dim_,
+        item,
+        shared_);
   }
 
   buffer_t* kv_buffer_;

--- a/src/sycl/FlashCompress128.cpp
+++ b/src/sycl/FlashCompress128.cpp
@@ -11,6 +11,8 @@
 namespace at::native::xpu {
 
 constexpr int64_t kTileDim = 64;
+constexpr int64_t kTokenGroups = 8;
+constexpr int64_t kTokensPerGroup = 128 / kTokenGroups;  // 16
 
 namespace FlashCompress128Impl {
 
@@ -112,7 +114,9 @@ struct FlashCompress128PrefillCompressKernel {
       return;
     }
 
-    const int64_t h = split_offset + static_cast<int64_t>(lid);
+    const int64_t h_lane = static_cast<int64_t>(lid % static_cast<uint32_t>(kTileDim));
+    const int64_t tg = static_cast<int64_t>(lid / static_cast<uint32_t>(kTileDim));
+    const int64_t h = split_offset + h_lane;
     if (h >= head_dim_) {
       return;
     }
@@ -120,48 +124,76 @@ struct FlashCompress128PrefillCompressKernel {
     const int64_t ragged_id = static_cast<int64_t>(plan.ragged_id);
     const int64_t buffer_len = static_cast<int64_t>(plan.buffer_len);
     const int64_t fresh_start = ragged_id - 127 + buffer_len;
-
     const int64_t page = static_cast<int64_t>(plan.read_page_1);
     const buffer_t* kv_page = kv_buffer_ + page * page_elem_size_;
-    out_t* out_row = kv_output_ + static_cast<int64_t>(pid) * head_dim_;
 
-    // Numerically stable softmax: first pass computes max(logits).
-    float max_score = -std::numeric_limits<float>::infinity();
-    for (int64_t t = 0; t < 128; ++t) {
-      float score;
+    const int64_t t_start = tg * kTokensPerGroup;
+
+    // Load all kTokensPerGroup tokens into registers.
+    float kv_reg[kTokensPerGroup];
+    float score_reg[kTokensPerGroup];
+
+    for (int64_t i = 0; i < kTokensPerGroup; ++i) {
+      const int64_t t = t_start + i;
       if (t < buffer_len) {
         const buffer_t* row_ptr = kv_page + t * elem_size_;
-        score = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
+        kv_reg[i] = static_cast<float>(row_ptr[h]);
+        score_reg[i] = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
       } else {
         const int64_t src_row = fresh_start + (t - buffer_len);
         const input_t* row_ptr = kv_input_ + src_row * elem_size_;
-        score = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
+        kv_reg[i] = static_cast<float>(row_ptr[h]);
+        score_reg[i] = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
       }
-      max_score = sycl::fmax(max_score, score);
     }
 
-    // Second pass computes exp-sum and weighted value sum in fp32.
-    float exp_sum = 0.0f;
-    float weighted_sum = 0.0f;
-    for (int64_t t = 0; t < 128; ++t) {
-      float kv_val;
-      float score;
-      if (t < buffer_len) {
-        const buffer_t* row_ptr = kv_page + t * elem_size_;
-        kv_val = static_cast<float>(row_ptr[h]);
-        score = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
-      } else {
-        const int64_t src_row = fresh_start + (t - buffer_len);
-        const input_t* row_ptr = kv_input_ + src_row * elem_size_;
-        kv_val = static_cast<float>(row_ptr[h]);
-        score = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
-      }
-      const float w = sycl::exp(score - max_score);
-      exp_sum += w;
-      weighted_sum += kv_val * w;
+    // Pass 1: compute local max over kTokensPerGroup scores.
+    float local_max = score_reg[0];
+    for (int64_t i = 1; i < kTokensPerGroup; ++i) {
+      local_max = sycl::fmax(local_max, score_reg[i]);
     }
 
-    out_row[h] = static_cast<out_t>(weighted_sum / exp_sum);
+    // Pass 2: compute partial exp_sum and weighted_sum.
+    float local_exp_sum = 0.0f;
+    float local_weighted_sum = 0.0f;
+    for (int64_t i = 0; i < kTokensPerGroup; ++i) {
+      const float exp_score = sycl::exp(score_reg[i] - local_max);
+      local_exp_sum += exp_score;
+      local_weighted_sum += kv_reg[i] * exp_score;
+    }
+
+    // Shared memory layout (3 sections, each [kTokenGroups][kTileDim]):
+    //   section 0: local_max           [tg * kTileDim + h_lane]
+    //   section 1: scaled exp_sum      [kSmemSection + ...]
+    //   section 2: scaled weighted_sum [2*kSmemSection + ...]
+    const size_t kSmemSection = static_cast<size_t>(kTokenGroups * kTileDim);
+    const size_t smem_idx = static_cast<size_t>(tg * kTileDim + h_lane);
+
+    shared_[smem_idx] = local_max;
+    item.barrier(sycl::access::fence_space::local_space);
+
+    // Compute global max across all token groups for this h_lane.
+    float global_max = local_max;
+    for (int64_t g = 0; g < kTokenGroups; ++g) {
+      global_max = sycl::fmax(global_max, shared_[static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)]);
+    }
+
+    // Rescale this group's partial sums to the global max and store.
+    const float rescale_to_global = sycl::exp(local_max - global_max);
+    shared_[kSmemSection + smem_idx] = local_exp_sum * rescale_to_global;
+    shared_[2 * kSmemSection + smem_idx] = local_weighted_sum * rescale_to_global;
+    item.barrier(sycl::access::fence_space::local_space);
+
+    // Token group 0 reduces all scaled partial sums and writes the final output.
+    if (tg == 0) {
+      float exp_sum = 0.0f;
+      float weighted_sum = 0.0f;
+      for (int64_t g = 0; g < kTokenGroups; ++g) {
+        exp_sum += shared_[kSmemSection + static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)];
+        weighted_sum += shared_[2 * kSmemSection + static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)];
+      }
+      kv_output_[static_cast<int64_t>(pid) * head_dim_ + h] = static_cast<out_t>(weighted_sum / exp_sum);
+    }
   }
 
   buffer_t* kv_buffer_;
@@ -174,6 +206,7 @@ struct FlashCompress128PrefillCompressKernel {
   int64_t elem_size_;
   int64_t page_elem_size_;
   uint32_t num_split_;
+  sycl::local_accessor<float, 1> shared_;
 };
 
 template <typename buffer_t, typename input_t>
@@ -338,6 +371,9 @@ void flash_compress128_prefill(
     SYCL_DISPATCH_WEIGHT_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress128Prefill", [&]() {
       if (num_compress > 0) {
         queue.submit([&](sycl::handler& cgh) {
+          // Shared memory: 3 sections × [kTokenGroups × kTileDim] floats.
+          const size_t kSmemElems = static_cast<size_t>(3 * kTokenGroups * kTileDim);
+          sycl::local_accessor<float, 1> shared(sycl::range<1>(kSmemElems), cgh);
           FlashCompress128Impl::FlashCompress128PrefillCompressKernel<weight_t, input_t, output_t> kernel{
               kv_buffer.data_ptr<weight_t>(),
               kv_input.data_ptr<input_t>(),
@@ -348,10 +384,11 @@ void flash_compress128_prefill(
               head_dim,
               elem_size,
               page_elem_size,
-              num_split};
-          constexpr uint32_t kLocalSize = 64;
-          const uint32_t global_size = static_cast<uint32_t>(num_compress) * num_split * kLocalSize;
-          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
+              num_split,
+              shared};
+          constexpr uint32_t kLocalSizeCompress = static_cast<uint32_t>(kTileDim * kTokenGroups);  // 512
+          const uint32_t global_size = static_cast<uint32_t>(num_compress) * num_split * kLocalSizeCompress;
+          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSizeCompress)), kernel);
         });
       }
 

--- a/src/sycl/FlashCompress128.cpp
+++ b/src/sycl/FlashCompress128.cpp
@@ -94,6 +94,130 @@ struct FlashCompress128DecodeKernel {
   uint32_t num_split_;
 };
 
+template <typename buffer_t, typename input_t, typename out_t>
+struct FlashCompress128PrefillCompressKernel {
+  [[sycl::reqd_sub_group_size(16)]]
+  void operator()(sycl::nd_item<1> item) const {
+    const uint32_t gid = static_cast<uint32_t>(item.get_group(0));
+    const uint32_t lid = static_cast<uint32_t>(item.get_local_id(0));
+    const uint32_t pid = gid / num_split_;
+    const int64_t split_offset = static_cast<int64_t>(gid % num_split_) * kTileDim;
+
+    if (pid >= num_compress_) {
+      return;
+    }
+
+    const CompressPlan plan = plan_c_[pid];
+    if (plan.is_invalid()) {
+      return;
+    }
+
+    const int64_t h = split_offset + static_cast<int64_t>(lid);
+    if (h >= head_dim_) {
+      return;
+    }
+
+    const int64_t ragged_id = static_cast<int64_t>(plan.ragged_id);
+    const int64_t buffer_len = static_cast<int64_t>(plan.buffer_len);
+    const int64_t fresh_start = ragged_id - 127 + buffer_len;
+
+    const int64_t page = static_cast<int64_t>(plan.read_page_1);
+    const buffer_t* kv_page = kv_buffer_ + page * page_elem_size_;
+    out_t* out_row = kv_output_ + static_cast<int64_t>(pid) * head_dim_;
+
+    // Numerically stable softmax: first pass computes max(logits).
+    float max_score = -std::numeric_limits<float>::infinity();
+    for (int64_t t = 0; t < 128; ++t) {
+      float score;
+      if (t < buffer_len) {
+        const buffer_t* row_ptr = kv_page + t * elem_size_;
+        score = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
+      } else {
+        const int64_t src_row = fresh_start + (t - buffer_len);
+        const input_t* row_ptr = kv_input_ + src_row * elem_size_;
+        score = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
+      }
+      max_score = sycl::fmax(max_score, score);
+    }
+
+    // Second pass computes exp-sum and weighted value sum in fp32.
+    float exp_sum = 0.0f;
+    float weighted_sum = 0.0f;
+    for (int64_t t = 0; t < 128; ++t) {
+      float kv_val;
+      float score;
+      if (t < buffer_len) {
+        const buffer_t* row_ptr = kv_page + t * elem_size_;
+        kv_val = static_cast<float>(row_ptr[h]);
+        score = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
+      } else {
+        const int64_t src_row = fresh_start + (t - buffer_len);
+        const input_t* row_ptr = kv_input_ + src_row * elem_size_;
+        kv_val = static_cast<float>(row_ptr[h]);
+        score = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
+      }
+      const float w = sycl::exp(score - max_score);
+      exp_sum += w;
+      weighted_sum += kv_val * w;
+    }
+
+    out_row[h] = static_cast<out_t>(weighted_sum / exp_sum);
+  }
+
+  buffer_t* kv_buffer_;
+  const input_t* kv_input_;
+  out_t* kv_output_;
+  const input_t* ape_;
+  const CompressPlan* plan_c_;
+  uint32_t num_compress_;
+  int64_t head_dim_;
+  int64_t elem_size_;
+  int64_t page_elem_size_;
+  uint32_t num_split_;
+};
+
+template <typename buffer_t, typename input_t>
+struct FlashCompress128PrefillWriteKernel {
+  [[sycl::reqd_sub_group_size(16)]]
+  void operator()(sycl::nd_item<1> item) const {
+    const uint32_t gid = static_cast<uint32_t>(item.get_group(0));
+    const uint32_t lid = static_cast<uint32_t>(item.get_local_id(0));
+    const uint32_t pid = gid / num_split_;
+    const int64_t split_offset = static_cast<int64_t>(gid % num_split_) * kTileDim;
+
+    if (pid >= num_write_) {
+      return;
+    }
+
+    const WritePlan plan = plan_w_[pid];
+    if (plan.is_invalid()) {
+      return;
+    }
+
+    const int64_t h = split_offset + static_cast<int64_t>(lid);
+    if (h >= head_dim_) {
+      return;
+    }
+
+    const int64_t write_loc = static_cast<int64_t>(plan.write_loc);
+    const int64_t ragged_id = static_cast<int64_t>(plan.ragged_id);
+
+    buffer_t* kv_dst = kv_buffer_ + write_loc * elem_size_;
+    const input_t* kv_src = kv_input_ + ragged_id * elem_size_;
+
+    kv_dst[h] = static_cast<buffer_t>(kv_src[h]);
+    kv_dst[head_dim_ + h] = static_cast<buffer_t>(kv_src[head_dim_ + h]);
+  }
+
+  buffer_t* kv_buffer_;
+  const input_t* kv_input_;
+  const WritePlan* plan_w_;
+  uint32_t num_write_;
+  int64_t head_dim_;
+  int64_t elem_size_;
+  uint32_t num_split_;
+};
+
 }  // namespace FlashCompress128Impl
 
 void flash_compress128_decode(
@@ -155,6 +279,97 @@ void flash_compress128_decode(
         const uint32_t global_size = static_cast<uint32_t>(batch_size) * num_split * kLocalSize;
         cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
       });
+    });
+  });
+}
+
+void flash_compress128_prefill(
+    torch::Tensor kv_buffer,
+    torch::Tensor kv_input,
+    torch::Tensor kv_output,
+    torch::Tensor ape,
+    torch::Tensor plan_c,
+    torch::Tensor plan_w) {
+  TORCH_CHECK(
+      kv_buffer.is_xpu() && kv_buffer.dim() == 3 && kv_buffer.is_contiguous(),
+      "kv_buffer must be a contiguous 3D XPU tensor");
+  TORCH_CHECK(
+      kv_input.is_xpu() && kv_input.dim() == 2 && kv_input.is_contiguous(),
+      "kv_input must be a contiguous 2D XPU tensor");
+  TORCH_CHECK(
+      kv_output.is_xpu() && kv_output.dim() == 2 && kv_output.is_contiguous(),
+      "kv_output must be a contiguous 2D XPU tensor");
+  TORCH_CHECK(ape.is_xpu() && ape.dim() == 2 && ape.is_contiguous(), "ape must be a contiguous 2D XPU tensor");
+  TORCH_CHECK(
+      plan_c.is_xpu() && plan_c.dim() == 2 && plan_c.dtype() == torch::kUInt8 && plan_c.is_contiguous(),
+      "plan_c must be a contiguous 2D XPU uint8 tensor");
+  TORCH_CHECK(
+      plan_w.is_xpu() && plan_w.dim() == 2 && plan_w.dtype() == torch::kUInt8 && plan_w.is_contiguous(),
+      "plan_w must be a contiguous 2D XPU uint8 tensor");
+  TORCH_CHECK(kv_input.dtype() == kv_output.dtype(), "kv_input and kv_output must have the same dtype");
+  TORCH_CHECK(kv_input.dtype() == ape.dtype(), "kv_input and ape must have same dtype");
+
+  const int64_t elem_size = kv_input.size(1);
+  const int64_t head_dim = kv_output.size(1);
+  const int64_t num_compress = kv_output.size(0);
+  const int64_t num_write = plan_w.size(0);
+
+  TORCH_CHECK(elem_size == 2 * head_dim, "kv_input last dim must be 2 * head_dim");
+  TORCH_CHECK(
+      kv_buffer.size(1) == 128 && kv_buffer.size(2) == elem_size,
+      "kv_buffer shape must be [num_pages, 128, 2*head_dim]");
+  TORCH_CHECK(ape.size(0) == 128 && ape.size(1) == head_dim, "ape shape must be [128, head_dim]");
+  TORCH_CHECK(
+      plan_c.size(0) == num_compress && plan_c.size(1) == static_cast<int64_t>(sizeof(CompressPlan)),
+      "plan_c shape must be [C, 16]");
+  TORCH_CHECK(plan_w.size(1) == static_cast<int64_t>(sizeof(WritePlan)), "plan_w shape must be [W, 8]");
+
+  if (num_compress == 0 && num_write == 0) {
+    return;
+  }
+
+  const int64_t page_elem_size = 128 * elem_size;
+  const uint32_t num_split = static_cast<uint32_t>((head_dim + kTileDim - 1) / kTileDim);
+  auto queue = c10::xpu::getCurrentXPUStream().queue();
+
+  SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_input.scalar_type(), "FlashCompress128Prefill", [&]() {
+    using input_t = scalar_t;
+    using output_t = scalar_t;
+    SYCL_DISPATCH_WEIGHT_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress128Prefill", [&]() {
+      if (num_compress > 0) {
+        queue.submit([&](sycl::handler& cgh) {
+          FlashCompress128Impl::FlashCompress128PrefillCompressKernel<weight_t, input_t, output_t> kernel{
+              kv_buffer.data_ptr<weight_t>(),
+              kv_input.data_ptr<input_t>(),
+              kv_output.data_ptr<output_t>(),
+              ape.data_ptr<input_t>(),
+              reinterpret_cast<const CompressPlan*>(plan_c.data_ptr<uint8_t>()),
+              static_cast<uint32_t>(num_compress),
+              head_dim,
+              elem_size,
+              page_elem_size,
+              num_split};
+          constexpr uint32_t kLocalSize = 64;
+          const uint32_t global_size = static_cast<uint32_t>(num_compress) * num_split * kLocalSize;
+          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
+        });
+      }
+
+      if (num_write > 0) {
+        queue.submit([&](sycl::handler& cgh) {
+          FlashCompress128Impl::FlashCompress128PrefillWriteKernel<weight_t, input_t> kernel{
+              kv_buffer.data_ptr<weight_t>(),
+              kv_input.data_ptr<input_t>(),
+              reinterpret_cast<const WritePlan*>(plan_w.data_ptr<uint8_t>()),
+              static_cast<uint32_t>(num_write),
+              head_dim,
+              elem_size,
+              num_split};
+          constexpr uint32_t kLocalSize = 64;
+          const uint32_t global_size = static_cast<uint32_t>(num_write) * num_split * kLocalSize;
+          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
+        });
+      }
     });
   });
 }

--- a/src/sycl/FlashCompress128.cpp
+++ b/src/sycl/FlashCompress128.cpp
@@ -34,54 +34,85 @@ struct FlashCompress128DecodeKernel {
       return;
     }
 
-    const int64_t write_loc = static_cast<int64_t>(plan.write_loc);
-    buffer_t* kv_dst = kv_buffer_ + write_loc * elem_size_;
-    const input_t* kv_src = kv_input_ + static_cast<int64_t>(bid) * elem_size_;
+    // lid decomposition: tg = token group (0..7), h_lane = column within split (0..63)
+    const int64_t h_lane = static_cast<int64_t>(lid % static_cast<uint32_t>(kTileDim));
+    const int64_t tg = static_cast<int64_t>(lid / static_cast<uint32_t>(kTileDim));
+    const int64_t h = split_offset + h_lane;
 
-    const int64_t h = split_offset + static_cast<int64_t>(lid);
-    if (h < head_dim_) {
+    // Only tg=0 writes: all tg groups share the same h columns, avoid duplicate stores.
+    if (tg == 0 && h < head_dim_) {
+      buffer_t* kv_dst = kv_buffer_ + static_cast<int64_t>(plan.write_loc) * elem_size_;
+      const input_t* kv_src = kv_input_ + static_cast<int64_t>(bid) * elem_size_;
       kv_dst[h] = static_cast<buffer_t>(kv_src[h]);
       kv_dst[head_dim_ + h] = static_cast<buffer_t>(kv_src[head_dim_ + h]);
     }
 
     // Compress only when a 128-token chunk is completed.
-    if ((plan.write_loc % 128) != 127) {
+    if (plan.seq_len % 128 != 0) {
       return;
     }
 
     item.barrier(sycl::access::fence_space::global_and_local);
 
-    // Last split may be partial when head_dim is not divisible by kTileDim.
-    if (h >= head_dim_) {
-      return;
+    const buffer_t* kv_page = kv_buffer_ + static_cast<int64_t>(plan.read_page_1) * page_elem_size_;
+    const int64_t t_start = tg * kTokensPerGroup;
+
+    // Load all kTokensPerGroup tokens into registers.
+    float kv_reg[kTokensPerGroup];
+    float score_reg[kTokensPerGroup];
+    for (int64_t i = 0; i < kTokensPerGroup; ++i) {
+      const int64_t t = t_start + i;
+      const buffer_t* row_ptr = kv_page + t * elem_size_;
+      kv_reg[i] = static_cast<float>(row_ptr[h]);
+      score_reg[i] = static_cast<float>(row_ptr[head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
     }
 
-    const int64_t page = static_cast<int64_t>(plan.read_page_1);
-    const buffer_t* kv_page = kv_buffer_ + page * page_elem_size_;
-    out_t* out_row = kv_output_ + static_cast<int64_t>(bid) * head_dim_;
-
-    // Numerically stable softmax: first pass computes max(logits).
-    float max_score = -std::numeric_limits<float>::infinity();
-    for (int64_t t = 0; t < 128; ++t) {
-      const int64_t row_off = t * elem_size_;
-      const float score =
-          static_cast<float>(kv_page[row_off + head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
-      max_score = sycl::fmax(max_score, score);
+    // Pass 1: compute local max over kTokensPerGroup scores.
+    float local_max = score_reg[0];
+    for (int64_t i = 1; i < kTokensPerGroup; ++i) {
+      local_max = sycl::fmax(local_max, score_reg[i]);
     }
 
-    // Second pass computes exp-sum and weighted value sum in fp32.
-    float exp_sum = 0.0f;
-    float weighted_sum = 0.0f;
-    for (int64_t t = 0; t < 128; ++t) {
-      const int64_t row_off = t * elem_size_;
-      const float score =
-          static_cast<float>(kv_page[row_off + head_dim_ + h]) + static_cast<float>(ape_[t * head_dim_ + h]);
-      const float w = sycl::exp(score - max_score);
-      exp_sum += w;
-      weighted_sum += static_cast<float>(kv_page[row_off + h]) * w;
+    // Pass 2: compute partial exp_sum and weighted_sum.
+    float local_exp_sum = 0.0f;
+    float local_weighted_sum = 0.0f;
+    for (int64_t i = 0; i < kTokensPerGroup; ++i) {
+      const float exp_score = sycl::exp(score_reg[i] - local_max);
+      local_exp_sum += exp_score;
+      local_weighted_sum += kv_reg[i] * exp_score;
     }
 
-    out_row[h] = static_cast<out_t>(weighted_sum / exp_sum);
+    // Shared memory layout (3 sections, each [kTokenGroups][kTileDim]):
+    //   section 0: local_max           [tg * kTileDim + h_lane]
+    //   section 1: scaled exp_sum      [kSmemSection + ...]
+    //   section 2: scaled weighted_sum [2*kSmemSection + ...]
+    const size_t kSmemSection = static_cast<size_t>(kTokenGroups * kTileDim);
+    const size_t smem_idx = static_cast<size_t>(tg * kTileDim + h_lane);
+    shared_[smem_idx] = local_max;
+    item.barrier(sycl::access::fence_space::local_space);
+
+    // Compute global max across all token groups for this h_lane.
+    float global_max = local_max;
+    for (int64_t g = 0; g < kTokenGroups; ++g) {
+      global_max = sycl::fmax(global_max, shared_[static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)]);
+    }
+
+    // Rescale this group's partial sums to the global max and store.
+    const float rescale = sycl::exp(local_max - global_max);
+    shared_[kSmemSection + smem_idx] = local_exp_sum * rescale;
+    shared_[2 * kSmemSection + smem_idx] = local_weighted_sum * rescale;
+    item.barrier(sycl::access::fence_space::local_space);
+
+    // Token group 0 reduces all scaled partial sums and writes the final output.
+    if (tg == 0) {
+      float exp_sum = 0.0f;
+      float weighted_sum = 0.0f;
+      for (int64_t g = 0; g < kTokenGroups; ++g) {
+        exp_sum += shared_[kSmemSection + static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)];
+        weighted_sum += shared_[2 * kSmemSection + static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)];
+      }
+      kv_output_[static_cast<int64_t>(bid) * head_dim_ + h] = static_cast<out_t>(weighted_sum / exp_sum);
+    }
   }
 
   buffer_t* kv_buffer_;
@@ -94,6 +125,7 @@ struct FlashCompress128DecodeKernel {
   int64_t elem_size_;
   int64_t page_elem_size_;
   uint32_t num_split_;
+  sycl::local_accessor<float, 1> shared_;
 };
 
 template <typename buffer_t, typename input_t, typename out_t>
@@ -114,25 +146,18 @@ struct FlashCompress128PrefillCompressKernel {
       return;
     }
 
+    // lid decomposition: tg = token group (0..7), h_lane = column within split (0..63)
     const int64_t h_lane = static_cast<int64_t>(lid % static_cast<uint32_t>(kTileDim));
     const int64_t tg = static_cast<int64_t>(lid / static_cast<uint32_t>(kTileDim));
     const int64_t h = split_offset + h_lane;
-    if (h >= head_dim_) {
-      return;
-    }
-
-    const int64_t ragged_id = static_cast<int64_t>(plan.ragged_id);
     const int64_t buffer_len = static_cast<int64_t>(plan.buffer_len);
-    const int64_t fresh_start = ragged_id - 127 + buffer_len;
-    const int64_t page = static_cast<int64_t>(plan.read_page_1);
-    const buffer_t* kv_page = kv_buffer_ + page * page_elem_size_;
-
+    const int64_t fresh_start = static_cast<int64_t>(plan.ragged_id) - 127 + buffer_len;
+    const buffer_t* kv_page = kv_buffer_ + static_cast<int64_t>(plan.read_page_1) * page_elem_size_;
     const int64_t t_start = tg * kTokensPerGroup;
 
     // Load all kTokensPerGroup tokens into registers.
     float kv_reg[kTokensPerGroup];
     float score_reg[kTokensPerGroup];
-
     for (int64_t i = 0; i < kTokensPerGroup; ++i) {
       const int64_t t = t_start + i;
       if (t < buffer_len) {
@@ -168,7 +193,6 @@ struct FlashCompress128PrefillCompressKernel {
     //   section 2: scaled weighted_sum [2*kSmemSection + ...]
     const size_t kSmemSection = static_cast<size_t>(kTokenGroups * kTileDim);
     const size_t smem_idx = static_cast<size_t>(tg * kTileDim + h_lane);
-
     shared_[smem_idx] = local_max;
     item.barrier(sycl::access::fence_space::local_space);
 
@@ -228,16 +252,8 @@ struct FlashCompress128PrefillWriteKernel {
     }
 
     const int64_t h = split_offset + static_cast<int64_t>(lid);
-    if (h >= head_dim_) {
-      return;
-    }
-
-    const int64_t write_loc = static_cast<int64_t>(plan.write_loc);
-    const int64_t ragged_id = static_cast<int64_t>(plan.ragged_id);
-
-    buffer_t* kv_dst = kv_buffer_ + write_loc * elem_size_;
-    const input_t* kv_src = kv_input_ + ragged_id * elem_size_;
-
+    buffer_t* kv_dst = kv_buffer_ + static_cast<int64_t>(plan.write_loc) * elem_size_;
+    const input_t* kv_src = kv_input_ + static_cast<int64_t>(plan.ragged_id) * elem_size_;
     kv_dst[h] = static_cast<buffer_t>(kv_src[h]);
     kv_dst[head_dim_ + h] = static_cast<buffer_t>(kv_src[head_dim_ + h]);
   }
@@ -274,6 +290,7 @@ void flash_compress128_decode(
   const int64_t batch_size = kv_input.size(0);
   const int64_t elem_size = kv_input.size(1);
   const int64_t head_dim = kv_output.size(1);
+  TORCH_CHECK(head_dim % kTileDim == 0, "flash_compress128_decode requires head_dim divisible by ", kTileDim);
   TORCH_CHECK(elem_size == 2 * head_dim, "kv_input last dim must be 2 * head_dim");
   TORCH_CHECK(
       kv_buffer.size(1) == 128 && kv_buffer.size(2) == elem_size,
@@ -289,7 +306,7 @@ void flash_compress128_decode(
   }
 
   const int64_t page_elem_size = 128 * elem_size;
-  const uint32_t num_split = static_cast<uint32_t>((head_dim + kTileDim - 1) / kTileDim);
+  const uint32_t num_split = static_cast<uint32_t>(head_dim / kTileDim);
   auto queue = c10::xpu::getCurrentXPUStream().queue();
 
   SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_input.scalar_type(), "FlashCompress128Decode", [&]() {
@@ -297,6 +314,9 @@ void flash_compress128_decode(
     using output_t = scalar_t;
     SYCL_DISPATCH_WEIGHT_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress128Decode", [&]() {
       queue.submit([&](sycl::handler& cgh) {
+        // Shared memory: 3 sections × [kTokenGroups × kTileDim] floats.
+        const size_t kSmemElems = static_cast<size_t>(3 * kTokenGroups * kTileDim);
+        sycl::local_accessor<float, 1> shared(sycl::range<1>(kSmemElems), cgh);
         FlashCompress128Impl::FlashCompress128DecodeKernel<weight_t, input_t, output_t> kernel{
             kv_buffer.data_ptr<weight_t>(),
             kv_input.data_ptr<input_t>(),
@@ -307,8 +327,9 @@ void flash_compress128_decode(
             head_dim,
             elem_size,
             page_elem_size,
-            num_split};
-        constexpr uint32_t kLocalSize = 64;
+            num_split,
+            shared};
+        constexpr uint32_t kLocalSize = static_cast<uint32_t>(kTileDim * kTokenGroups);  // 512
         const uint32_t global_size = static_cast<uint32_t>(batch_size) * num_split * kLocalSize;
         cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
       });
@@ -346,7 +367,7 @@ void flash_compress128_prefill(
   const int64_t head_dim = kv_output.size(1);
   const int64_t num_compress = kv_output.size(0);
   const int64_t num_write = plan_w.size(0);
-
+  TORCH_CHECK(head_dim % kTileDim == 0, "flash_compress128_prefill requires head_dim divisible by ", kTileDim);
   TORCH_CHECK(elem_size == 2 * head_dim, "kv_input last dim must be 2 * head_dim");
   TORCH_CHECK(
       kv_buffer.size(1) == 128 && kv_buffer.size(2) == elem_size,
@@ -362,7 +383,7 @@ void flash_compress128_prefill(
   }
 
   const int64_t page_elem_size = 128 * elem_size;
-  const uint32_t num_split = static_cast<uint32_t>((head_dim + kTileDim - 1) / kTileDim);
+  const uint32_t num_split = static_cast<uint32_t>(head_dim / kTileDim);
   auto queue = c10::xpu::getCurrentXPUStream().queue();
 
   SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_input.scalar_type(), "FlashCompress128Prefill", [&]() {

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -430,10 +430,10 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "-> ()");
   m.impl("flash_compress128_decode", torch::kXPU, &at::native::xpu::flash_compress128_decode);
 
-    m.def(
-            "flash_compress128_prefill(Tensor! kv_buffer, Tensor kv_input, Tensor! kv_output, Tensor ape, Tensor plan_c, "
-            "Tensor plan_w) -> ()");
-    m.impl("flash_compress128_prefill", torch::kXPU, &at::native::xpu::flash_compress128_prefill);
+  m.def(
+      "flash_compress128_prefill(Tensor! kv_buffer, Tensor kv_input, Tensor! kv_output, Tensor ape, Tensor plan_c, "
+      "Tensor plan_w) -> ()");
+  m.impl("flash_compress128_prefill", torch::kXPU, &at::native::xpu::flash_compress128_prefill);
 }
 
 REGISTER_EXTENSION(common_ops)

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -429,6 +429,11 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "flash_compress128_decode(Tensor! kv_buffer, Tensor kv_input, Tensor! kv_output, Tensor ape, Tensor plan_d) "
       "-> ()");
   m.impl("flash_compress128_decode", torch::kXPU, &at::native::xpu::flash_compress128_decode);
+
+    m.def(
+            "flash_compress128_prefill(Tensor! kv_buffer, Tensor kv_input, Tensor! kv_output, Tensor ape, Tensor plan_c, "
+            "Tensor plan_w) -> ()");
+    m.impl("flash_compress128_prefill", torch::kXPU, &at::native::xpu::flash_compress128_prefill);
 }
 
 REGISTER_EXTENSION(common_ops)


### PR DESCRIPTION
### Motivation
This PR adds an XPU/SYCL implementation for `flash_compress128_prefill `and wires it through the C++ extension and Python wrapper, while also restructuring the existing `flash_compress128_decode `kernel to use a token-grouped reduction with local memory.

### Modifications
Register a new `torch.ops.sgl_kernel.flash_compress128_prefill` XPU operator.
Implement SYCL kernels for prefill compress + write, and refactor the decode kernel to use an 8-way token-group reduction over the 128-token window.
Switch the Python `flash_compress128_prefill `wrapper from a Torch reference loop to the new C++/SYCL op.

### Performance
The SYCL implementation significantly improves the performance of `flash_compress128_decode `and `flash_compress128_prefill  `on XPU.
The performance of `flash_compress128_decode `:
case | bs | seq_lens | head_dim | dtype | sycl implementation time(us) | pure-PyTorch implementation time(us) | speedup (PyTorch/SYCL)
-- | -- | -- | -- | -- | -- | -- | --
c128_seq128_hd512_f32_paged | 1 | 128 | 512 | f32 | 7.739 | 26.172 | 3.38x
c128_seq256_hd512_f32_paged | 1 | 256 | 512 | f32 | 7.663 | 26.146 | 3.41x
c128_seq512_hd512_f32_paged | 1 | 512 | 512 | f32 | 7.575 | 26.122 | 3.45x
c128_seq128_hd512_bf16_paged | 1 | 128 | 512 | bf16 | 7.956 | 31.874 | 4.01x
c128_seq256_hd512_bf16_paged | 1 | 256 | 512 | bf16 | 7.985 | 32.143 | 4.03x
c128_seq512_hd512_bf16_paged | 1 | 512 | 512 | bf16 | 8.275 | 31.966 | 3.86x
c128_decode_prefix0_step1_hd512_f32_paged | 1 | 1 | 512 | f32 | 4.974 | 4.996 | 1.00x
c128_decode_prefix0_step64_hd512_f32_paged | 1 | 64 | 512 | f32 | 5.047 | 5.159 | 1.02x
c128_decode_prefix0_step128_hd512_f32_paged | 1 | 128 | 512 | f32 | 7.900 | 26.418 | 3.34x
c128_decode_prefix128_step1_hd512_f32_paged | 1 | 129 | 512 | f32 | 5.005 | 5.073 | 1.01x
c128_decode_prefix128_step64_hd512_f32_paged | 1 | 192 | 512 | f32 | 4.986 | 5.111 | 1.03x
c128_decode_prefix128_step128_hd512_f32_paged | 1 | 256 | 512 | f32 | 7.903 | 26.160 | 3.31x
c128_decode_prefix256_step1_hd512_f32_paged | 1 | 257 | 512 | f32 | 4.827 | 5.078 | 1.05x
c128_decode_prefix256_step64_hd512_f32_paged | 1 | 320 | 512 | f32 | 4.870 | 4.993 | 1.03x
c128_decode_prefix256_step128_hd512_f32_paged | 1 | 384 | 512 | f32 | 7.706 | 26.176 | 3.40x
c128_decode_prefix0_step1_hd512_bf16_paged | 1 | 1 | 512 | bf16 | 4.609 | 4.669 | 1.01x
c128_decode_prefix0_step64_hd512_bf16_paged | 1 | 64 | 512 | bf16 | 4.615 | 4.682 | 1.01x
c128_decode_prefix0_step128_hd512_bf16_paged | 1 | 128 | 512 | bf16 | 8.125 | 31.860 | 3.92x
c128_decode_prefix128_step1_hd512_bf16_paged | 1 | 129 | 512 | bf16 | 4.689 | 4.656 | 0.99x
c128_decode_prefix128_step64_hd512_bf16_paged | 1 | 192 | 512 | bf16 | 4.601 | 4.719 | 1.03x
c128_decode_prefix128_step128_hd512_bf16_paged | 1 | 256 | 512 | bf16 | 8.081 | 31.835 | 3.94x
c128_decode_prefix256_step1_hd512_bf16_paged | 1 | 257 | 512 | bf16 | 4.513 | 4.685 | 1.04x
c128_decode_prefix256_step64_hd512_bf16_paged | 1 | 320 | 512 | bf16 | 4.646 | 4.731 | 1.02x
c128_decode_prefix256_step128_hd512_bf16_paged | 1 | 384 | 512 | bf16 | 8.033 | 32.185 | 4.01x

The performance of `flash_compress128_prefill `:
case | bs | seq_lens | extend_lens | num_q | head_dim | dtype | sycl implementation time(us) | pure-PyTorch implementation time(us) | speedup (PyTorch/SYCL)
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
c128_prefill_no_ctx_seq128_hd512_f32_paged | 1 | 128 | 128 | 128 | 512 | f32 | 17.002 | 3346.620 | 196.84x
c128_prefill_no_ctx_seq256_hd512_f32_paged | 1 | 256 | 256 | 256 | 512 | f32 | 29.366 | 6235.558 | 212.34x
c128_prefill_no_ctx_seq512_hd512_f32_paged | 1 | 512 | 512 | 512 | 512 | f32 | 55.780 | 12118.308 | 217.25x
c128_prefill_prefix128_hd512_f32_paged | 1 | 128 | 128 | 128 | 512 | f32 | 16.943 | 3311.384 | 195.44x
c128_prefill_prefix256_hd512_f32_paged | 1 | 256 | 256 | 256 | 512 | f32 | 29.532 | 6250.351 | 211.65x
c128_prefill_extend_prefix128_ext128_hd512_f32_paged | 1 | 256 | 128 | 128 | 512 | f32 | 16.956 | 3312.554 | 195.36x
c128_prefill_extend_prefix120_ext128_hd512_f32_paged | 1 | 248 | 128 | 128 | 512 | f32 | 19.680 | 7379.403 | 374.97x
c128_prefill_extend_prefix256_ext128_hd512_f32_paged | 1 | 384 | 128 | 128 | 512 | f32 | 16.964 | 3503.387 | 206.52x
c128_prefill_extend_prefix128_ext256_hd512_f32_paged | 1 | 384 | 256 | 256 | 512 | f32 | 29.373 | 6503.305 | 221.34x
c128_prefill_extend_prefix120_ext256_hd512_f32_paged | 1 | 376 | 256 | 256 | 512 | f32 | 32.151 | 10125.166 | 314.93x
c128_prefill_extend_prefix256_ext256_hd512_f32_paged | 1 | 512 | 256 | 256 | 512 | f32 | 29.363 | 6262.394 | 213.28x
c128_prefill_multibatch_hd512_f32_paged | 3 | 128\|256\|384 | 128\|256\|384 | 768 | 512 | f32 | 81.681 | 17832.573 | 218.32x
c128_prefill_no_ctx_seq128_hd512_bf16_paged | 1 | 128 | 128 | 128 | 512 | bf16 | 16.862 | 3387.135 | 200.88x
c128_prefill_no_ctx_seq256_hd512_bf16_paged | 1 | 256 | 256 | 256 | 512 | bf16 | 29.664 | 6225.915 | 209.88x
c128_prefill_no_ctx_seq512_hd512_bf16_paged | 1 | 512 | 512 | 512 | 512 | bf16 | 55.599 | 12042.222 | 216.59x
c128_prefill_prefix128_hd512_bf16_paged | 1 | 128 | 128 | 128 | 512 | bf16 | 17.055 | 3290.919 | 193.01x
c128_prefill_prefix256_hd512_bf16_paged | 1 | 256 | 256 | 256 | 512 | bf16 | 29.843 | 6356.595 | 212.99x
c128_prefill_extend_prefix128_ext128_hd512_bf16_paged | 1 | 256 | 128 | 128 | 512 | bf16 | 17.047 | 3434.727 | 201.49x
c128_prefill_extend_prefix120_ext128_hd512_bf16_paged | 1 | 248 | 128 | 128 | 512 | bf16 | 20.005 | 7411.839 | 370.50x
c128_prefill_extend_prefix256_ext128_hd512_bf16_paged | 1 | 384 | 128 | 128 | 512 | bf16 | 17.029 | 3315.846 | 194.72x
c128_prefill_extend_prefix128_ext256_hd512_bf16_paged | 1 | 384 | 256 | 256 | 512 | bf16 | 30.203 | 6228.957 | 206.23x
c128_prefill_extend_prefix120_ext256_hd512_bf16_paged | 1 | 376 | 256 | 256 | 512 | bf16 | 32.128 | 10108.806 | 314.64x
c128_prefill_extend_prefix256_ext256_hd512_bf16_paged | 1 | 512 | 256 | 256 | 512 | bf16 | 29.680 | 6275.575 | 211.44x
