### PR TITLE
Add SYCL support for flash_compress4_decode

### DIFF
--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -788,6 +788,9 @@ void flash_compress128_prefill(
     torch::Tensor plan_c,
     torch::Tensor plan_w);
 
+void flash_compress4_decode(
+    torch::Tensor kv_buffer, torch::Tensor kv_input, torch::Tensor kv_output, torch::Tensor ape, torch::Tensor plan_d);
+
 }  // namespace at::native::xpu
 
 namespace flash {

--- a/python/sgl_kernel/__init__.py
+++ b/python/sgl_kernel/__init__.py
@@ -47,10 +47,7 @@ from sgl_kernel.elementwise import (
     silu_and_mul_clamp,
     store_cache_xpu,
 )
-from sgl_kernel.flash_compress_4_torch import (
-    flash_compress4_decode,
-    flash_compress4_prefill,
-)
+from sgl_kernel.flash_compress_4 import flash_compress4_decode, flash_compress4_prefill
 from sgl_kernel.flash_compress_128 import (
     flash_compress128_decode,
     flash_compress128_prefill,

--- a/python/sgl_kernel/flash_compress_4.py
+++ b/python/sgl_kernel/flash_compress_4.py
@@ -204,39 +204,6 @@ def flash_compress4_decode(
     ape: torch.Tensor,  # [8, head_dim]
     plan_d_u8: torch.Tensor,  # [B, 16]
 ) -> None:
-    head_dim = _infer_head_dim_c4(kv_input, ape, kv_output)
-
-    kv_flat = _flatten_slots(kv_buffer)
-    B = kv_input.shape[0]
-    assert kv_output.shape == (B, head_dim)
-
-    seq_len, write_loc, rp0, rp1 = decode_plan_d(plan_d_u8)
-
-    # Scatter every token's write in one shot (each token writes a distinct slot).
-    kv_flat.index_copy_(0, write_loc, kv_input.to(kv_flat.dtype))
-
-    # Compress fires for tokens whose seq_len just hit a multiple of the ratio.
-    # Each active token reads its own (distinct) pages, so reading after all writes
-    # matches the per-token write-then-read of the scalar path.
-    active = (seq_len % 4 == 0).nonzero(as_tuple=True)[0]
-    if active.numel() == 0:
-        return
-
-    # buffer_len is constant 8 in decode: overlap (rows 0..3) comes from page rp0,
-    # fresh (rows 4..7) from page rp1. Overlap is masked off when seq_len <= 4.
-    buf0 = kv_buffer[rp0[active]].float()  # [A, 4, head_dim*4]
-    buf1 = kv_buffer[rp1[active]].float()
-    kv_ov = buf0[:, :, :head_dim]
-    sc_ov = buf0[:, :, 2 * head_dim : 3 * head_dim]
-    kv_fr = buf1[:, :, head_dim : 2 * head_dim]
-    sc_fr = buf1[:, :, 3 * head_dim : 4 * head_dim]
-
-    need_overlap = (seq_len[active] > 4)[:, None, None]
-    neg_inf = -torch.finfo(torch.float32).max
-    kv_ov = torch.where(need_overlap, kv_ov, torch.zeros_like(kv_ov))
-    sc_ov = torch.where(need_overlap, sc_ov, torch.full_like(sc_ov, neg_inf))
-
-    kv = torch.cat([kv_ov, kv_fr], dim=1)  # [A, 8, head_dim]
-    sc = torch.cat([sc_ov, sc_fr], dim=1) + ape  # ape [8, head_dim] broadcasts
-    w = torch.softmax(sc, dim=1)
-    kv_output[active] = (kv * w).sum(dim=1).to(kv_output.dtype)
+    torch.ops.sgl_kernel.flash_compress4_decode(
+        kv_buffer, kv_input, kv_output, ape, plan_d_u8
+    )

--- a/src/sycl/FlashCompress128.cpp
+++ b/src/sycl/FlashCompress128.cpp
@@ -12,7 +12,9 @@ namespace at::native::xpu {
 
 constexpr int64_t kTileDim = 64;
 constexpr int64_t kTokenGroups = 8;
-constexpr int64_t kTokensPerGroup = 128 / kTokenGroups;  // 16
+constexpr int64_t kTokensPerGroup = 128 / kTokenGroups;                          // 16
+constexpr uint32_t kBlockSize = static_cast<uint32_t>(kTileDim * kTokenGroups);  // 512
+constexpr uint32_t kWriteBlockSize = 64;
 
 namespace FlashCompress128Impl {
 
@@ -307,9 +309,8 @@ void flash_compress128_decode(
             page_elem_size,
             num_split,
             shared};
-        constexpr uint32_t kLocalSize = static_cast<uint32_t>(kTileDim * kTokenGroups);  // 512
-        const uint32_t global_size = static_cast<uint32_t>(batch_size) * num_split * kLocalSize;
-        cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
+        const uint32_t global_size = static_cast<uint32_t>(batch_size) * num_split * kBlockSize;
+        cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kBlockSize)), kernel);
       });
     });
   });
@@ -385,9 +386,8 @@ void flash_compress128_prefill(
               page_elem_size,
               num_split,
               shared};
-          constexpr uint32_t kLocalSizeCompress = static_cast<uint32_t>(kTileDim * kTokenGroups);  // 512
-          const uint32_t global_size = static_cast<uint32_t>(num_compress) * num_split * kLocalSizeCompress;
-          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSizeCompress)), kernel);
+          const uint32_t global_size = static_cast<uint32_t>(num_compress) * num_split * kBlockSize;
+          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kBlockSize)), kernel);
         });
       }
 
@@ -401,9 +401,8 @@ void flash_compress128_prefill(
               head_dim,
               elem_size,
               num_split};
-          constexpr uint32_t kLocalSize = 64;
-          const uint32_t global_size = static_cast<uint32_t>(num_write) * num_split * kLocalSize;
-          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
+          const uint32_t global_size = static_cast<uint32_t>(num_write) * num_split * kWriteBlockSize;
+          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kWriteBlockSize)), kernel);
         });
       }
     });

--- a/src/sycl/FlashCompress4.cpp
+++ b/src/sycl/FlashCompress4.cpp
@@ -1,0 +1,192 @@
+#include <ATen/ATen.h>
+#include <c10/xpu/XPUStream.h>
+#include <torch/all.h>
+
+#include <limits>
+#include <sycl/sycl.hpp>
+
+#include "Compress.h"
+#include "Utils.h"
+
+namespace at::native::xpu {
+
+constexpr int64_t kTileDim = 64;  // kTileElements (4) * kWarpThreads (16)
+constexpr int64_t kTileElements = 4;
+
+namespace FlashCompress4Impl {
+
+template <typename buffer_t, typename input_t, typename out_t>
+struct FlashCompress4DecodeKernel {
+  [[sycl::reqd_sub_group_size(16)]]
+  void operator()(sycl::nd_item<1> item) const {
+    const uint32_t gid = static_cast<uint32_t>(item.get_group(0));
+    const uint32_t lid = static_cast<uint32_t>(item.get_local_id(0));
+
+    // Compute global warp id: group_id*4 + local_warp_id (since local_size=64 = 4 warps)
+    const uint32_t global_wid = gid * 4U + (lid / 16U);
+    const uint32_t bid = global_wid / num_split_;
+    const uint32_t split_id = global_wid % num_split_;
+    const int64_t split_offset = static_cast<int64_t>(split_id) * kTileDim;
+    const uint32_t tid_in_warp = lid % 16U;
+
+    if (bid >= batch_size_) {
+      return;
+    }
+
+    const DecodePlan plan = plan_d_[bid];
+    if (plan.seq_len == 0 || plan.write_loc < 0) {
+      return;
+    }
+
+    // Write current token to buffer
+    const int64_t write_loc = static_cast<int64_t>(plan.write_loc);
+    buffer_t* kv_dst = kv_buffer_ + write_loc * elem_size_;
+    const input_t* kv_src = kv_input_ + static_cast<int64_t>(bid) * elem_size_;
+
+    // Each thread processes 4 consecutive head_dim positions
+    for (int32_t i = 0; i < kTileElements; ++i) {
+      const int64_t h = split_offset + i * 16 + tid_in_warp;
+      if (h < head_dim_) {
+        // Write all 4 * head_dim elements (kv + score pairs for 4 positions)
+        for (int64_t j = 0; j < 4; ++j) {
+          kv_dst[j * head_dim_ + h] = static_cast<buffer_t>(kv_src[j * head_dim_ + h]);
+        }
+      }
+    }
+
+    item.barrier(sycl::access::fence_space::global_and_local);
+
+    // Compress only when a 4-token chunk is completed (every 4 tokens).
+    if (plan.seq_len % 4 != 0) {
+      return;
+    }
+
+    // Buffer row layout per token: | kv_overlap(head_dim) | kv(head_dim) | score_overlap(head_dim) | score(head_dim) |
+    // row stride = elem_size_ = 4 * head_dim_
+    // Overlap positions (t=0..3): from kv_buf_0, kv_overlap at [row+0], score_overlap at [row+2*head_dim]
+    // Fresh positions  (t=4..7): from kv_buf_1, kv at [row+head_dim], score at [row+3*head_dim]
+    const bool need_overlap = plan.seq_len > 4;
+    const buffer_t* kv_buf_0 = kv_buffer_ + static_cast<int64_t>(plan.read_page_0) * page_elem_size_;
+    const buffer_t* kv_buf_1 = kv_buffer_ + static_cast<int64_t>(plan.read_page_1) * page_elem_size_;
+    out_t* out_row = kv_output_ + static_cast<int64_t>(bid) * head_dim_;
+
+    for (int32_t i = 0; i < kTileElements; ++i) {
+      const int64_t h = split_offset + static_cast<int64_t>(i) * 16 + tid_in_warp;
+      if (h >= head_dim_) {
+        continue;
+      }
+
+      // First pass: max score
+      float max_score = -std::numeric_limits<float>::infinity();
+      for (int64_t t = 0; t < 8; ++t) {
+        const int64_t row_off = (t % 4) * elem_size_;
+        float score_val;
+        if (t < 4) {
+          score_val = need_overlap ? static_cast<float>(kv_buf_0[row_off + 2 * head_dim_ + h])
+                                   : -std::numeric_limits<float>::infinity();
+        } else {
+          score_val = static_cast<float>(kv_buf_1[row_off + 3 * head_dim_ + h]);
+        }
+        max_score = sycl::fmax(max_score, score_val + static_cast<float>(ape_[t * head_dim_ + h]));
+      }
+
+      // Second pass: weighted sum
+      float exp_sum = 0.0f;
+      float weighted_sum = 0.0f;
+      for (int64_t t = 0; t < 8; ++t) {
+        const int64_t row_off = (t % 4) * elem_size_;
+        float kv_val, score_val;
+        if (t < 4) {
+          kv_val = need_overlap ? static_cast<float>(kv_buf_0[row_off + h]) : 0.0f;
+          score_val = need_overlap ? static_cast<float>(kv_buf_0[row_off + 2 * head_dim_ + h])
+                                   : -std::numeric_limits<float>::infinity();
+        } else {
+          kv_val = static_cast<float>(kv_buf_1[row_off + head_dim_ + h]);
+          score_val = static_cast<float>(kv_buf_1[row_off + 3 * head_dim_ + h]);
+        }
+        const float w = sycl::exp(score_val + static_cast<float>(ape_[t * head_dim_ + h]) - max_score);
+        exp_sum += w;
+        weighted_sum += kv_val * w;
+      }
+
+      out_row[h] = static_cast<out_t>(weighted_sum / exp_sum);
+    }
+  }
+
+  buffer_t* kv_buffer_;
+  const input_t* kv_input_;
+  out_t* kv_output_;
+  const input_t* ape_;
+  const DecodePlan* plan_d_;
+  uint32_t batch_size_;
+  int64_t head_dim_;
+  int64_t elem_size_;       // 4 * head_dim
+  int64_t page_elem_size_;  // 4 * 4 * head_dim = 16 * head_dim
+  uint32_t num_split_;
+};
+
+}  // namespace FlashCompress4Impl
+
+void flash_compress4_decode(
+    torch::Tensor kv_buffer, torch::Tensor kv_input, torch::Tensor kv_output, torch::Tensor ape, torch::Tensor plan_d) {
+  TORCH_CHECK(
+      kv_buffer.is_xpu() && kv_buffer.dim() == 3 && kv_buffer.is_contiguous(),
+      "kv_buffer must be a contiguous 3D XPU tensor");
+  TORCH_CHECK(
+      kv_input.is_xpu() && kv_input.dim() == 2 && kv_input.is_contiguous(),
+      "kv_input must be a contiguous 2D XPU tensor");
+  TORCH_CHECK(
+      kv_output.is_xpu() && kv_output.dim() == 2 && kv_output.is_contiguous(),
+      "kv_output must be a contiguous 2D XPU tensor");
+  TORCH_CHECK(ape.is_xpu() && ape.dim() == 2 && ape.is_contiguous(), "ape must be a contiguous 2D XPU tensor");
+  TORCH_CHECK(
+      plan_d.is_xpu() && plan_d.dim() == 2 && plan_d.dtype() == torch::kUInt8 && plan_d.is_contiguous(),
+      "plan_d must be a contiguous 2D XPU uint8 tensor");
+  TORCH_CHECK(kv_input.dtype() == kv_output.dtype(), "kv_input and kv_output must have the same dtype");
+  TORCH_CHECK(kv_input.dtype() == ape.dtype(), "kv_input and ape must have same dtype");
+
+  const int64_t batch_size = kv_input.size(0);
+  const int64_t elem_size = kv_input.size(1);
+  const int64_t head_dim = kv_output.size(1);
+  TORCH_CHECK(elem_size == 4 * head_dim, "kv_input last dim must be 4 * head_dim");
+  TORCH_CHECK(
+      kv_buffer.size(1) == 4 && kv_buffer.size(2) == elem_size, "kv_buffer shape must be [num_pages, 4, 4*head_dim]");
+  TORCH_CHECK(kv_output.size(0) == batch_size, "kv_output batch must match kv_input batch");
+  TORCH_CHECK(ape.size(0) == 8 && ape.size(1) == head_dim, "ape shape must be [8, head_dim]");
+  TORCH_CHECK(
+      plan_d.size(0) == batch_size && plan_d.size(1) == static_cast<int64_t>(sizeof(DecodePlan)),
+      "plan_d shape must be [B, 16]");
+
+  if (batch_size == 0) {
+    return;
+  }
+
+  const int64_t page_elem_size = 4 * elem_size;  // 4 positions * 4 * head_dim
+  const uint32_t num_split = static_cast<uint32_t>((head_dim + kTileDim - 1) / kTileDim);
+  auto queue = c10::xpu::getCurrentXPUStream().queue();
+
+  SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_input.scalar_type(), "FlashCompress4Decode", [&]() {
+    using input_t = scalar_t;
+    using output_t = scalar_t;
+    SYCL_DISPATCH_WEIGHT_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress4Decode", [&]() {
+      queue.submit([&](sycl::handler& cgh) {
+        FlashCompress4Impl::FlashCompress4DecodeKernel<weight_t, input_t, output_t> kernel{
+            kv_buffer.data_ptr<weight_t>(),
+            kv_input.data_ptr<input_t>(),
+            kv_output.data_ptr<output_t>(),
+            ape.data_ptr<input_t>(),
+            reinterpret_cast<const DecodePlan*>(plan_d.data_ptr<uint8_t>()),
+            static_cast<uint32_t>(batch_size),
+            head_dim,
+            elem_size,
+            page_elem_size,
+            num_split};
+        constexpr uint32_t kLocalSize = 64;  // 4 sub_groups, each handling 1 warp's work
+        const uint32_t global_size = static_cast<uint32_t>(batch_size) * num_split * 16;
+        cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
+      });
+    });
+  });
+}
+
+}  // namespace at::native::xpu

--- a/src/sycl/FlashCompress4.cpp
+++ b/src/sycl/FlashCompress4.cpp
@@ -12,6 +12,7 @@ namespace at::native::xpu {
 
 constexpr int64_t kTileDim = 64;  // kTileElements (4) * kWarpThreads (16)
 constexpr int64_t kTileElements = 4;
+constexpr uint32_t kWarpThreads = 16;
 
 namespace FlashCompress4Impl {
 
@@ -19,97 +20,86 @@ template <typename buffer_t, typename input_t, typename out_t>
 struct FlashCompress4DecodeKernel {
   [[sycl::reqd_sub_group_size(16)]]
   void operator()(sycl::nd_item<1> item) const {
-    const uint32_t gid = static_cast<uint32_t>(item.get_group(0));
-    const uint32_t lid = static_cast<uint32_t>(item.get_local_id(0));
+    const uint32_t global_tid = static_cast<uint32_t>(item.get_global_id(0));
+    const uint32_t local_tid = static_cast<uint32_t>(item.get_local_id(0));
 
-    // Compute global warp id: group_id*4 + local_warp_id (since local_size=64 = 4 warps)
-    const uint32_t global_wid = gid * 4U + (lid / 16U);
-    const uint32_t bid = global_wid / num_split_;
-    const uint32_t split_id = global_wid % num_split_;
-    const int64_t split_offset = static_cast<int64_t>(split_id) * kTileDim;
-    const uint32_t tid_in_warp = lid % 16U;
+    const uint32_t global_wid = global_tid / kWarpThreads;  // warp id
+    const uint32_t global_bid = global_wid / num_split_;    // batch id
+    const uint32_t global_sid = global_wid % num_split_;    // split id
+    const int64_t split_offset = static_cast<int64_t>(global_sid) * kTileDim;
+    const uint32_t lane_id = local_tid % kWarpThreads;
 
-    if (bid >= batch_size_) {
+    if (global_bid >= batch_size_) {
       return;
     }
 
-    const DecodePlan plan = plan_d_[bid];
+    const DecodePlan plan = plan_d_[global_bid];
     if (plan.seq_len == 0 || plan.write_loc < 0) {
       return;
     }
 
-    // Write current token to buffer
+    // Decode path: write the current token to page buffer first.
     const int64_t write_loc = static_cast<int64_t>(plan.write_loc);
     buffer_t* kv_dst = kv_buffer_ + write_loc * elem_size_;
-    const input_t* kv_src = kv_input_ + static_cast<int64_t>(bid) * elem_size_;
+    const input_t* kv_src = kv_input_ + static_cast<int64_t>(global_bid) * elem_size_;
 
-    // Each thread processes 4 consecutive head_dim positions
+    // One warp handles one split; each lane processes strided head_dim elements.
     for (int32_t i = 0; i < kTileElements; ++i) {
-      const int64_t h = split_offset + i * 16 + tid_in_warp;
-      if (h < head_dim_) {
-        // Write all 4 * head_dim elements (kv + score pairs for 4 positions)
-        for (int64_t j = 0; j < 4; ++j) {
-          kv_dst[j * head_dim_ + h] = static_cast<buffer_t>(kv_src[j * head_dim_ + h]);
-        }
+      const int64_t h = split_offset + static_cast<int64_t>(i) * kWarpThreads + lane_id;
+      for (int64_t j = 0; j < 4; ++j) {
+        kv_dst[j * head_dim_ + h] = static_cast<buffer_t>(kv_src[j * head_dim_ + h]);
       }
     }
 
-    item.barrier(sycl::access::fence_space::global_and_local);
-
-    // Compress only when a 4-token chunk is completed (every 4 tokens).
+    // Compress only when we close a 4-token chunk.
     if (plan.seq_len % 4 != 0) {
       return;
     }
 
-    // Buffer row layout per token: | kv_overlap(head_dim) | kv(head_dim) | score_overlap(head_dim) | score(head_dim) |
-    // row stride = elem_size_ = 4 * head_dim_
-    // Overlap positions (t=0..3): from kv_buf_0, kv_overlap at [row+0], score_overlap at [row+2*head_dim]
-    // Fresh positions  (t=4..7): from kv_buf_1, kv at [row+head_dim], score at [row+3*head_dim]
+    // Buffer row layout:
+    // [kv_overlap | kv | score_overlap | score], row stride = elem_size_.
+    // t in [0, 3] reads overlap terms from kv_buf_0; t in [4, 7] reads fresh terms from kv_buf_1.
     const bool need_overlap = plan.seq_len > 4;
     const buffer_t* kv_buf_0 = kv_buffer_ + static_cast<int64_t>(plan.read_page_0) * page_elem_size_;
     const buffer_t* kv_buf_1 = kv_buffer_ + static_cast<int64_t>(plan.read_page_1) * page_elem_size_;
-    out_t* out_row = kv_output_ + static_cast<int64_t>(bid) * head_dim_;
+    out_t* kv_out = kv_output_ + static_cast<int64_t>(global_bid) * head_dim_;
 
     for (int32_t i = 0; i < kTileElements; ++i) {
-      const int64_t h = split_offset + static_cast<int64_t>(i) * 16 + tid_in_warp;
-      if (h >= head_dim_) {
-        continue;
+      const int64_t h = split_offset + static_cast<int64_t>(i) * kWarpThreads + lane_id;
+
+      // Load all 8 tokens into registers (overlap [0,3] from kv_buf_0, fresh [4,7] from kv_buf_1).
+      float kv_reg[8];
+      float score_reg[8];
+      for (int32_t t = 0; t < 4; ++t) {
+        const int64_t row_off = static_cast<int64_t>(t) * elem_size_;
+        kv_reg[t] = need_overlap ? static_cast<float>(kv_buf_0[row_off + h]) : 0.0f;
+        score_reg[t] = (need_overlap ? static_cast<float>(kv_buf_0[row_off + 2 * head_dim_ + h])
+                                     : -std::numeric_limits<float>::infinity()) +
+                       static_cast<float>(ape_[static_cast<int64_t>(t) * head_dim_ + h]);
+      }
+      for (int32_t t = 0; t < 4; ++t) {
+        const int64_t row_off = static_cast<int64_t>(t) * elem_size_;
+        kv_reg[t + 4] = static_cast<float>(kv_buf_1[row_off + head_dim_ + h]);
+        score_reg[t + 4] = static_cast<float>(kv_buf_1[row_off + 3 * head_dim_ + h]) +
+                           static_cast<float>(ape_[static_cast<int64_t>(t + 4) * head_dim_ + h]);
       }
 
-      // First pass: max score
-      float max_score = -std::numeric_limits<float>::infinity();
-      for (int64_t t = 0; t < 8; ++t) {
-        const int64_t row_off = (t % 4) * elem_size_;
-        float score_val;
-        if (t < 4) {
-          score_val = need_overlap ? static_cast<float>(kv_buf_0[row_off + 2 * head_dim_ + h])
-                                   : -std::numeric_limits<float>::infinity();
-        } else {
-          score_val = static_cast<float>(kv_buf_1[row_off + 3 * head_dim_ + h]);
-        }
-        max_score = sycl::fmax(max_score, score_val + static_cast<float>(ape_[t * head_dim_ + h]));
+      // Pass 1: max score.
+      float max_score = score_reg[0];
+      for (int32_t t = 1; t < 8; ++t) {
+        max_score = sycl::fmax(max_score, score_reg[t]);
       }
 
-      // Second pass: weighted sum
+      // Pass 2: weighted kv reduction.
       float exp_sum = 0.0f;
       float weighted_sum = 0.0f;
-      for (int64_t t = 0; t < 8; ++t) {
-        const int64_t row_off = (t % 4) * elem_size_;
-        float kv_val, score_val;
-        if (t < 4) {
-          kv_val = need_overlap ? static_cast<float>(kv_buf_0[row_off + h]) : 0.0f;
-          score_val = need_overlap ? static_cast<float>(kv_buf_0[row_off + 2 * head_dim_ + h])
-                                   : -std::numeric_limits<float>::infinity();
-        } else {
-          kv_val = static_cast<float>(kv_buf_1[row_off + head_dim_ + h]);
-          score_val = static_cast<float>(kv_buf_1[row_off + 3 * head_dim_ + h]);
-        }
-        const float w = sycl::exp(score_val + static_cast<float>(ape_[t * head_dim_ + h]) - max_score);
+      for (int32_t t = 0; t < 8; ++t) {
+        const float w = sycl::exp(score_reg[t] - max_score);
         exp_sum += w;
-        weighted_sum += kv_val * w;
+        weighted_sum += kv_reg[t] * w;
       }
 
-      out_row[h] = static_cast<out_t>(weighted_sum / exp_sum);
+      kv_out[h] = static_cast<out_t>(weighted_sum / exp_sum);
     }
   }
 
@@ -148,6 +138,7 @@ void flash_compress4_decode(
   const int64_t batch_size = kv_input.size(0);
   const int64_t elem_size = kv_input.size(1);
   const int64_t head_dim = kv_output.size(1);
+  TORCH_CHECK(head_dim % kTileDim == 0, "flash_compress4_decode requires head_dim divisible by ", kTileDim);
   TORCH_CHECK(elem_size == 4 * head_dim, "kv_input last dim must be 4 * head_dim");
   TORCH_CHECK(
       kv_buffer.size(1) == 4 && kv_buffer.size(2) == elem_size, "kv_buffer shape must be [num_pages, 4, 4*head_dim]");
@@ -161,8 +152,8 @@ void flash_compress4_decode(
     return;
   }
 
-  const int64_t page_elem_size = 4 * elem_size;  // 4 positions * 4 * head_dim
-  const uint32_t num_split = static_cast<uint32_t>((head_dim + kTileDim - 1) / kTileDim);
+  const int64_t page_elem_size = 4 * elem_size;
+  const uint32_t num_split = static_cast<uint32_t>(head_dim / kTileDim);
   auto queue = c10::xpu::getCurrentXPUStream().queue();
 
   SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_input.scalar_type(), "FlashCompress4Decode", [&]() {
@@ -181,8 +172,11 @@ void flash_compress4_decode(
             elem_size,
             page_elem_size,
             num_split};
-        constexpr uint32_t kLocalSize = 64;  // 4 sub_groups, each handling 1 warp's work
-        const uint32_t global_size = static_cast<uint32_t>(batch_size) * num_split * 16;
+        constexpr uint32_t kWarpsPerGroup = 4;
+        constexpr uint32_t kLocalSize = kWarpsPerGroup * kWarpThreads;
+        const uint32_t num_warps = static_cast<uint32_t>(batch_size) * num_split;
+        const uint32_t num_groups = (num_warps + kWarpsPerGroup - 1) / kWarpsPerGroup;
+        const uint32_t global_size = num_groups * kLocalSize;
         cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
       });
     });

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -444,6 +444,11 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "flash_compress128_prefill(Tensor! kv_buffer, Tensor kv_input, Tensor! kv_output, Tensor ape, Tensor plan_c, "
       "Tensor plan_w) -> ()");
   m.impl("flash_compress128_prefill", torch::kXPU, &at::native::xpu::flash_compress128_prefill);
+
+  m.def(
+      "flash_compress4_decode(Tensor! kv_buffer, Tensor kv_input, Tensor! kv_output, Tensor ape, Tensor plan_d) "
+      "-> ()");
+  m.impl("flash_compress4_decode", torch::kXPU, &at::native::xpu::flash_compress4_decode);
 }
 
 REGISTER_EXTENSION(common_ops)

--- a/tests/test_c4_v2.py
+++ b/tests/test_c4_v2.py
@@ -23,8 +23,10 @@ Context = Union[LegacyContext, PagedContext]
 HEAD_DIM = 512
 RATIO = 4
 WINDOW = 8  # = 2 * RATIO (overlap + current)
-ATOL = 5e-3
-RTOL = 5e-3
+precision = {
+    torch.bfloat16: 2e-2,
+    torch.float32: 5e-3,
+}
 
 
 # -----------------------------------------------------------------------------
@@ -119,7 +121,8 @@ def _make_inputs(
 
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("seq_len", [4, 8, 32, 256, 1024])
-def test_prefill_no_context(mode: str, seq_len: int) -> None:
+@pytest.mark.parametrize("input_dtype", [torch.float32, torch.bfloat16])
+def test_prefill_no_context(mode: str, seq_len: int, input_dtype: torch.dtype) -> None:
     """Prefill once, no prefix. Every compress event must match fp64 GT."""
     if mode == "legacy":
         ctx: Context = make_legacy_context(
@@ -135,8 +138,8 @@ def test_prefill_no_context(mode: str, seq_len: int) -> None:
     out = _run_prefill(
         ctx,
         pool,
-        kv_in_cpu.to(get_device()),
-        ape_cpu.to(get_device()),
+        kv_in_cpu.to(get_device(), dtype=input_dtype),
+        ape_cpu.to(get_device(), dtype=input_dtype),
         seq_lens_cpu,
         extend_lens_cpu,
     )
@@ -148,15 +151,18 @@ def test_prefill_no_context(mode: str, seq_len: int) -> None:
         triton.testing.assert_close(
             out[plan_id].cpu(),
             gt,
-            atol=ATOL,
-            rtol=RTOL,
+            atol=precision[input_dtype],
+            rtol=precision[input_dtype],
             err_msg=f"{plan_id=}, {P=} failed",
         )
 
 
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("prefix_len", [4, 256])
-def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
+@pytest.mark.parametrize("input_dtype", [torch.float32, torch.bfloat16])
+def test_prefill_then_decode(
+    mode: str, prefix_len: int, input_dtype: torch.dtype
+) -> None:
     """Prefill once, then decode 4 more tokens through one compress boundary."""
     extend_decode = 4
     seq_len = prefix_len + extend_decode
@@ -178,8 +184,8 @@ def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
     _run_prefill(
         ctx,
         pool,
-        kv_full_cpu[:prefix_len].to(get_device()),
-        ape_cpu.to(get_device()),
+        kv_full_cpu[:prefix_len].to(get_device(), dtype=input_dtype),
+        ape_cpu.to(get_device(), dtype=input_dtype),
         seq_lens_cpu,
         extend_lens_cpu,
     )
@@ -191,8 +197,16 @@ def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
         seq_lens_gpu = torch.tensor(
             [cur_seq_len], dtype=torch.int64, device=get_device()
         )
-        kv_step = kv_full_cpu[prefix_len + k : prefix_len + k + 1].to(get_device())
-        out = _run_decode(ctx, pool, kv_step, ape_cpu.to(get_device()), seq_lens_gpu)
+        kv_step = kv_full_cpu[prefix_len + k : prefix_len + k + 1].to(
+            get_device(), dtype=input_dtype
+        )
+        out = _run_decode(
+            ctx,
+            pool,
+            kv_step,
+            ape_cpu.to(get_device(), dtype=input_dtype),
+            seq_lens_gpu,
+        )
         if cur_seq_len % RATIO == 0:
             final_out = out
 
@@ -200,13 +214,18 @@ def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
     P = seq_len - 1
     gt = _gt_compress(kv_full_cpu, ape_cpu, P=P, head_dim=ctx.head_dim)
     assert final_out is not None
-    triton.testing.assert_close(final_out[0].cpu(), gt, atol=ATOL, rtol=RTOL)
+    triton.testing.assert_close(
+        final_out[0].cpu(), gt, atol=precision[input_dtype], rtol=precision[input_dtype]
+    )
 
 
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("prefix_len", [256, 512, 768])
 @pytest.mark.parametrize("extend_len", [4, 32])
-def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> None:
+@pytest.mark.parametrize("input_dtype", [torch.float32, torch.bfloat16])
+def test_prefill_then_extend(
+    mode: str, prefix_len: int, extend_len: int, input_dtype: torch.dtype
+) -> None:
     """Prefill once, then prefill an extend that crosses one or more compress events.
 
     The first prefill ends at a swa_page boundary (only relevant for paged),
@@ -231,8 +250,8 @@ def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> Non
     _run_prefill(
         ctx,
         pool,
-        kv_full_cpu[:prefix_len].to(get_device()),
-        ape_cpu.to(get_device()),
+        kv_full_cpu[:prefix_len].to(get_device(), dtype=input_dtype),
+        ape_cpu.to(get_device(), dtype=input_dtype),
         seq_lens_cpu,
         extend_lens_cpu,
     )
@@ -242,8 +261,8 @@ def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> Non
     out = _run_prefill(
         ctx,
         pool,
-        kv_full_cpu[prefix_len:].to(get_device()),
-        ape_cpu.to(get_device()),
+        kv_full_cpu[prefix_len:].to(get_device(), dtype=input_dtype),
+        ape_cpu.to(get_device(), dtype=input_dtype),
         seq_lens_cpu,
         extend_lens_cpu,
     )
@@ -253,7 +272,11 @@ def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> Non
     for plan_id, P in enumerate(range(first_event, seq_len, RATIO)):
         gt = _gt_compress(kv_full_cpu, ape_cpu, P=P, head_dim=ctx.head_dim)
         triton.testing.assert_close(
-            out[plan_id].cpu(), gt, atol=ATOL, rtol=RTOL, err_msg=f"{plan_id=}, {P=}"
+            out[plan_id].cpu(),
+            gt,
+            atol=precision[input_dtype],
+            rtol=precision[input_dtype],
+            err_msg=f"{plan_id=}, {P=}",
         )
 
 
@@ -303,8 +326,8 @@ def test_paged_buffer_intermediate() -> None:
             triton.testing.assert_close(
                 actual,
                 expected,
-                atol=ATOL,
-                rtol=RTOL,
+                atol=precision[torch.float32],
+                rtol=precision[torch.float32],
             )
 
 
@@ -350,8 +373,8 @@ def test_prefill_multibatch(mode: str) -> None:
             triton.testing.assert_close(
                 out[plan_id].cpu(),
                 gt,
-                atol=ATOL,
-                rtol=RTOL,
+                atol=precision[torch.float32],
+                rtol=precision[torch.float32],
             )
             plan_id += 1
         base += ext


### PR DESCRIPTION
### Motivation
Adds an SYCL implementation of `flash_compress4_decode `and wires it through the C++/Torch extension so the Python API uses the native op instead of a Torch fallback implementation.

### Modifications
Register `flash_compress4_decode `as an XPU op in the SYCL torch extension.
Add a new SYCL kernel implementation for `flash_compress4_decode`.
Update the Python wrapper to call `torch.ops.sgl_kernel.flash_compress4_decode`.

### Performance
The SYCL implementation significantly improves the performance of `flash_compress4_decode `on XPU.
case | bs | seq_lens | head_dim | dtype | sycl implementation time(us) | pure-PyTorch implementation time(us) | speedup (PyTorch/SYCL)
-- | -- | -- | -- | -- | -- | -- | --
c4_seq4_hd512_f32_paged | 1 | 4 | 512 | f32 | 9.126 | 1163.300 | 127.47x
c4_seq8_hd512_f32_paged | 1 | 8 | 512 | f32 | 9.160 | 1129.916 | 123.35x
c4_seq32_hd512_f32_paged | 1 | 32 | 512 | f32 | 9.204 | 1190.264 | 129.32x
c4_seq256_hd512_f32_paged | 1 | 256 | 512 | f32 | 9.194 | 1468.133 | 159.68x
c4_seq1024_hd512_f32_paged | 1 | 1024 | 512 | f32 | 8.926 | 1370.259 | 153.52x
c4_seq4_hd512_bf16_paged | 1 | 4 | 512 | bf16 | 8.337 | 1502.010 | 180.16x
c4_seq8_hd512_bf16_paged | 1 | 8 | 512 | bf16 | 8.493 | 1257.852 | 148.11x
c4_seq32_hd512_bf16_paged | 1 | 32 | 512 | bf16 | 8.438 | 1162.285 | 137.74x
c4_seq256_hd512_bf16_paged | 1 | 256 | 512 | bf16 | 8.432 | 1380.678 | 163.75x
c4_seq1024_hd512_bf16_paged | 1 | 1024 | 512 | bf16 | 8.470 | 1285.776 | 151.80x
c4_decode_prefix4_step4_hd512_f32_paged | 1 | 8 | 512 | f32 | 9.139 | 1362.542 | 149.09x
c4_decode_prefix256_step4_hd512_f32_paged | 1 | 260 | 512 | f32 | 9.030 | 1239.655 | 137.28x
c4_decode_prefix4_step4_hd512_bf16_paged | 1 | 8 | 512 | bf16 | 8.300 | 1194.341 | 143.90x
c4_decode_prefix256_step4_hd512_bf16_paged | 1 | 260 | 512 | bf16 | 8.321 | 1253.894 | 150.69x
c4_multibatch_hd512_f32_paged | 4 | 8\|256\|260\|1023 | 512 | f32 | 8.716 | 1062.242 | 121.87x