### PR TITLE
[MoE] widen store_2d to fully utilize cache line

### DIFF
--- a/src/sycl/kernels/moe/xe20/bf16/moe_kernel.hpp
+++ b/src/sycl/kernels/moe/xe20/bf16/moe_kernel.hpp
@@ -31,6 +31,7 @@
  **************************************************************************************************/
 #pragma once
 
+#include "../common/block_2d_copy_d.hpp"
 #include "cute/tensor.hpp"
 #include "cutlass/cutlass.h"
 #include "cutlass/gemm/gemm.h"
@@ -61,12 +62,16 @@ template <
     typename ElementA,
     typename ElementB = ElementA,
     typename ElementS = ElementA,
-    typename ElementD = ElementA>
+    typename ElementD = ElementA,
+    // D-store atom. void => widest legal atom for the subgroup output tile
+    // (see moe_xe20::select_block_2d_store_D); or name an XE_STORE_2D<...>
+    // explicitly to pin the store geometry for a specific shape.
+    typename GmemTiledCopyD = void>
 class MoEGEMM {
  public:
   using TiledCopyA = decltype(make_block_2d_copy_A(TiledMMA{}, TensorA{}));
   using TiledCopyB = decltype(make_block_2d_copy_B(TiledMMA{}, TensorB{}));
-  using TiledCopyD = decltype(make_block_2d_copy_D(TiledMMA{}, TensorD{}));
+  using TiledCopyD = decltype(moe_xe20::make_moe_block_2d_copy_D<GmemTiledCopyD>(TiledMMA{}, TensorD{}));
   using SGPerWG = decltype(product(take<1, 4>(shape(typename TiledMMA::ThrLayoutVMNK{}))));
 
   constexpr static int Stages = 3;

--- a/src/sycl/kernels/moe/xe20/bf16/moe_mainloop.hpp
+++ b/src/sycl/kernels/moe/xe20/bf16/moe_mainloop.hpp
@@ -178,12 +178,13 @@ struct MoEMainloop<
     /* Partition C */
     SubgroupTensor tCrC = thr_mma.partition_sg_fragment_C(gD);
 
-    /* Partition D */
-    using TD = typename DTensor::element_type;
-    TD tCrD_final_frag[tCrC.size()];
-    Tensor tCrD_final_tensor = make_tensor(make_rmem_ptr(tCrD_final_frag), tCrC.layout());
-    SubgroupTensor tCrD_final_sg_tensor = make_subgroup_tensor(tCrD_final_tensor, tCrC.tv_layout());
-    Tensor tCgD = thr_mma.partition_C(gD);
+    /* Partition D.
+       The D fragment and its global target come from the *copy*, not the MMA:
+       the store atom may be wider than one MMA-C atom (CUTLASS9-656), in which
+       case the MMA-C register order no longer matches the store's. reorder()
+       below bridges the two. */
+    SubgroupTensor tCrD_final_sg_tensor = thr_copy_d.partition_sg_fragment_S(gD);
+    Tensor tCgD = thr_copy_d.partition_D(gD);
 
     /* Create TiledCopy objects for prefetches */
     auto prefetch_a = make_block_2d_prefetch(tiled_copy_a);
@@ -315,16 +316,13 @@ struct MoEMainloop<
     SubgroupTensor tCrC0 = thr_mma.partition_sg_fragment_C(gC0);
     SubgroupTensor tCrC1 = thr_mma.partition_sg_fragment_C(gC1);
 
-    /* Partition D */
-    using TD = typename DTensor::element_type;
-    TD tCrD_final_frag0[tCrC0.size()];
-    Tensor tCrD_final_tensor0 = make_tensor(make_rmem_ptr(tCrD_final_frag0), tCrC0.layout());
-    SubgroupTensor tCrD_final_sg_tensor0 = make_subgroup_tensor(tCrD_final_tensor0, tCrC0.tv_layout());
-    TD tCrD_final_frag1[tCrC1.size()];
-    Tensor tCrD_final_tensor1 = make_tensor(make_rmem_ptr(tCrD_final_frag1), tCrC1.layout());
-    SubgroupTensor tCrD_final_sg_tensor1 = make_subgroup_tensor(tCrD_final_tensor1, tCrC1.tv_layout());
-
-    Tensor tCgD = thr_mma.partition_C(gC0);
+    /* Partition D.  Fragment and global target come from the *copy*, not the
+       MMA: the store atom may be wider than one MMA-C atom (CUTLASS9-656), so
+       the MMA-C register order no longer matches the store's; reorder() below
+       bridges the two.  Only tCrC0 is stored -- the gated activation folds
+       tCrC1 into it -- so a single D fragment suffices. */
+    SubgroupTensor tCrD_final_sg_tensor0 = thr_copy_d.partition_sg_fragment_S(gC0);
+    Tensor tCgD = thr_copy_d.partition_D(gC0);
 
     /* Create TiledCopy objects for prefetches */
     auto prefetch_a = make_block_2d_prefetch(tiled_copy_a);

--- a/src/sycl/kernels/moe/xe20/common/block_2d_copy_d.hpp
+++ b/src/sycl/kernels/moe/xe20/common/block_2d_copy_d.hpp
@@ -1,0 +1,106 @@
+/***************************************************************************************************
+ * Copyright (C) 2025 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#pragma once
+
+// Explicit D-store atom selection for the Xe2 MoE GEMMs.
+//
+// Background (CUTLASS9-656).  cute's `make_block_2d_copy_D` sizes the D store
+// from a *single MMA-C atom*.  The Xe DPAS N is hardware-fixed at 16, so for a
+// 16-bit output that atom is 16 x 2B = 32B -- half of a 64B cache line -- even
+// when the subgroup owns a contiguous 32- or 64-element run of N.  Each store
+// then moves half a line, doubling the store message count for the same bytes.
+//
+// This header provides the explicit-op form: the store atom is chosen *here*,
+// from the per-subgroup output tile, and handed to `make_block_2d_copy_CD`
+// rather than left to the generic per-atom selector.  It keeps the widening
+// local to these kernels, so it does not depend on the pinned sycl-tla revision
+// having the upstream fix, and it leaves an override hook for tuning.
+//
+// Correctness prerequisite: a store wider than one MMA-C atom no longer matches
+// the DPAS accumulator's register order, so the caller must bridge through the
+// *copy's* fragment (`partition_sg_fragment_S` + `reorder`) and store to
+// `partition_D`, not to `thr_mma.partition_C`.
+
+#include "cute/tensor.hpp"
+
+namespace moe_xe20 {
+using namespace cute;
+
+// Per-subgroup output tile (SG_M, SG_N) of a TiledMMA: the work-group tile
+// divided by the (M,N) extent of the subgroup layout.
+template <class TiledMMA>
+CUTE_HOST_DEVICE constexpr auto sg_output_tile(TiledMMA const& mma) {
+  auto thr_vmnk = mma.get_thr_layout_vmnk();  // (ThrV,ThrM,ThrN,ThrK)
+  return shape_div(select<0, 1>(mma.tile_mnk()), make_shape(size<1>(shape(thr_vmnk)), size<2>(shape(thr_vmnk))));
+}
+
+// Widest block-2D store atom that a subgroup can legally use for a row-major D.
+//
+//   width  = gcd(64B / sizeof(ElementD), SG_N)   -- cap at one cache line
+//   height = gcd(SG_M, 8)                        -- 8 is the store height limit
+//
+// The gcd keeps this self-limiting: when the subgroup owns only one atom's worth
+// of N (e.g. WGTile N=64 over a 4-wide subgroup layout => SG_N=16) the result is
+// identical to what the generic selector already picks, so narrow tiles are
+// untouched.
+template <class ElementD, class TiledMMA>
+CUTE_HOST_DEVICE constexpr auto select_block_2d_store_D(TiledMMA const& mma) {
+  constexpr int Bits = sizeof_bits_v<ElementD>;
+  constexpr int MaxWidth = 64 * 8 / Bits;  // elements in a 64B cache line
+  constexpr int MaxHeight = 8;             // hardware store height limit
+
+  auto sg_tile = sg_output_tile(mma);
+  constexpr int SgM = size<0>(decltype(sg_tile){});
+  constexpr int SgN = size<1>(decltype(sg_tile){});
+
+  return XE_STORE_2D<Bits, cute::gcd(SgM, MaxHeight), cute::gcd(SgN, MaxWidth)>{};
+}
+
+// D-store TiledCopy for the MoE GEMMs.
+//
+//   CopyOp = void  -> pick the widest legal atom for this subgroup tile
+//                     (see select_block_2d_store_D)
+//   CopyOp = XE_STORE_2D<...> -> use exactly that atom
+//
+// Both paths go through `make_block_2d_copy_CD`, i.e. the op is always explicit
+// at this level; `void` only means "let this header choose" rather than "let the
+// generic per-atom selector choose".
+template <class CopyOp, class TiledMMA, class DTensor>
+CUTE_HOST_DEVICE auto make_moe_block_2d_copy_D(TiledMMA const& mma, DTensor const& d) {
+  if constexpr (!cute::is_void_v<CopyOp>) {
+    return make_block_2d_copy_CD(CopyOp{}, mma, d);
+  } else {
+    using ElementD = typename DTensor::element_type;
+    return make_block_2d_copy_CD(select_block_2d_store_D<ElementD>(mma), mma, d);
+  }
+}
+
+}  // namespace moe_xe20

--- a/src/sycl/kernels/moe/xe20/w4a16/gemm_xe2.hpp
+++ b/src/sycl/kernels/moe/xe20/w4a16/gemm_xe2.hpp
@@ -37,6 +37,7 @@
 #include <sycl/ext/intel/experimental/grf_size_properties.hpp>
 #include <sycl/sycl.hpp>
 
+#include "../common/block_2d_copy_d.hpp"
 #include "cutlass/kernel_hardware_info.h"
 #include "cutlass/platform/platform.h"
 #include "cutlass/tensor_ref.h"
@@ -112,7 +113,7 @@ CUTE_DEVICE void xe_gemm(
 
   auto copy_a = get_block_2d_copy_A<GmemTiledCopyA>(mma, A);
   auto copy_b = get_block_2d_copy_B<GmemTiledCopyB>(mma, B);
-  auto copy_c = get_block_2d_copy_D<GmemTiledCopyC>(mma, C);
+  auto copy_c = moe_xe20::make_moe_block_2d_copy_D<GmemTiledCopyC>(mma, C);
 
   auto thr_mma = mma.get_slice(local_id);
   auto thr_copy_a = copy_a.get_slice(local_id);
@@ -265,7 +266,7 @@ CUTE_DEVICE void xe_gemm_4bits(
 
   auto copy_a = get_block_2d_copy_A<GmemTiledCopyA>(mma, A);
   auto copy_b = get_block_2d_copy_B<GmemTiledCopyB>(mma, B);
-  auto copy_c = get_block_2d_copy_D<GmemTiledCopyC>(mma, C);
+  auto copy_c = moe_xe20::make_moe_block_2d_copy_D<GmemTiledCopyC>(mma, C);
 
   auto thr_mma = mma.get_slice(local_id);
   auto thr_copy_a = copy_a.get_slice(local_id);


### PR DESCRIPTION
In some cases, the store_d generated by SYCL-TLA can't fully utilize the cache line, which will slower the GEMM when K is smaller.
SYCL-TLA refused the changes in their side https://github.com/intel/sycl-tla/pull/837, so I need to apply here.

  Arc Pro B60 (bmg-g21), bf16, `hidden=3584`, `experts=64`, `topk=8`, silu, no bias.
  Down-GEMM K = `shard_intermediate_size / 2`.  measured by `benchmark/bench_fused_moe.py`.

  | down-K | inter | 1024 tok | 2048 tok | 4096 tok | 8192 tok | geomean |
  |-------:|------:|---------:|---------:|---------:|---------:|--------:|
  | 64 | 128 | 1.162× | 1.226× | 1.274× | 1.305× | **1.240×** |
  | 96 | 192 | 1.127× | 1.192× | 1.237× | 1.269× | **1.205×** |
  | 128 | 256 | 1.116× | 1.167× | 1.223× | 1.257× | **1.190×** |
  | 192 | 384 | 1.090× | 1.133× | 1.162× | 1.186× | **1.142×** |
  | 256 | 512 | 1.082× | 1.110× | 1.120× | 1.131× | **1.111×** |
  | 320 | 640 | 1.073× | 1.071× | 1.097× | 1.116× | **1.089×** |
  | 512 | 1024 | 1.056× | 1.047× | 1.053× | 1.063× | **1.055×** |
  | 640 | 1280 | 1.048× | 1.037× | 1.042× | 1.037× | **1.041×** |
  | **geomean** | | **1.094×** | **1.121×** | **1.148×** | **1.167×** | **1.132×** |