### PR TITLE
Expand gemma_rmsnorm input dimension

### DIFF
--- a/src/sycl/Norm.h
+++ b/src/sycl/Norm.h
@@ -21,7 +21,7 @@ inline std::tuple<int64_t, int64_t> _check_layer_norm_inputs(
     std::optional<torch::Tensor>& weight /* optional */,
     std::optional<torch::Tensor>& bias /* optional */) {
   CHECK_LAST_DIM_CONTIGUOUS(input);
-  TORCH_CHECK(input.dim() == 2 || input.dim() == 3, "input must be a 2D or 3D tensor");
+  TORCH_CHECK(input.dim() == 2 || input.dim() == 3 || input.dim() == 4, "input must be a 2D, 3D, or 4D tensor");
 #define TENSOR_CHECK(T)                          \
   if (T.has_value()) {                           \
     CHECK_LAST_DIM_CONTIGUOUS(T.value());        \

--- a/src/sycl/Norm.h
+++ b/src/sycl/Norm.h
@@ -113,20 +113,28 @@ class NormConfig {
       int element_size_bytes,
       int input_batch_stride,
       int output_batch_stride,
-      int input_inner_size = 1,
-      int input_inner_stride = 0,
-      int output_inner_size = 1,
-      int output_inner_stride = 0)
+      int input_inner0_size = 1,
+      int input_inner0_stride = 0,
+      int output_inner0_size = 1,
+      int output_inner0_stride = 0,
+      int input_inner1_size = 1,
+      int input_inner1_stride = 0,
+      int output_inner1_size = 1,
+      int output_inner1_stride = 0)
       : Batch(Batch),
         Plane(Plane),
         problem_dim(problem_dim),
         element_size_bytes(element_size_bytes),
         input_batch_stride(input_batch_stride),
         output_batch_stride(output_batch_stride),
-        input_inner_size(input_inner_size),
-        input_inner_stride(input_inner_stride),
-        output_inner_size(output_inner_size),
-        output_inner_stride(output_inner_stride) {
+        input_inner0_size(input_inner0_size),
+        input_inner0_stride(input_inner0_stride),
+        output_inner0_size(output_inner0_size),
+        output_inner0_stride(output_inner0_stride),
+        input_inner1_size(input_inner1_size),
+        input_inner1_stride(input_inner1_stride),
+        output_inner1_size(output_inner1_size),
+        output_inner1_stride(output_inner1_stride) {
     semaphores_ptr = nullptr;
     scratchpad_ptr = nullptr;
     sub_group_num_global = 1;
@@ -152,10 +160,14 @@ class NormConfig {
       int input_batch_stride,
       int output_batch_stride,
       GetUpdateVecSizeFn get_update_vec_size,
-      int input_inner_size = 1,
-      int input_inner_stride = 0,
-      int output_inner_size = 1,
-      int output_inner_stride = 0)
+      int input_inner0_size = 1,
+      int input_inner0_stride = 0,
+      int output_inner0_size = 1,
+      int output_inner0_stride = 0,
+      int input_inner1_size = 1,
+      int input_inner1_stride = 0,
+      int output_inner1_size = 1,
+      int output_inner1_stride = 0)
       : NormConfig(
             Batch,
             Plane,
@@ -163,10 +175,14 @@ class NormConfig {
             element_size_bytes,
             input_batch_stride,
             output_batch_stride,
-            input_inner_size,
-            input_inner_stride,
-            output_inner_size,
-            output_inner_stride) {
+            input_inner0_size,
+            input_inner0_stride,
+            output_inner0_size,
+            output_inner0_stride,
+            input_inner1_size,
+            input_inner1_stride,
+            output_inner1_size,
+            output_inner1_stride) {
     workgroup_num = Batch;
     workgroup_num_foreach = 1;
     WGPlane = Plane;
@@ -189,15 +205,23 @@ class NormConfig {
 
   int input_batch_stride;
   int output_batch_stride;
-  // Inner-stride support for non-flattenable 3D tensors.  For a tensor viewed
-  // as (outer, inner, plane), the flattened row index r is split as
-  // (r / inner_size) for the outer index and (r % inner_size) for the inner
-  // index.  For 2D or flattenable 3D tensors, inner_size is 1 so the inner
-  // term collapses to zero.
-  int input_inner_size;
-  int input_inner_stride;
-  int output_inner_size;
-  int output_inner_stride;
+  // Inner-stride support for non-flattenable 3D/4D tensors.  A tensor viewed
+  // as (outer, inner0, inner1, plane) has its flattened row index r split as
+  //   outer  = r / (inner0_size * inner1_size)
+  //   inner0 = (r % (inner0_size * inner1_size)) / inner1_size
+  //   inner1 = r % inner1_size
+  // For 2D, flattenable 3D, or 4D tensors whose leading dim folds away,
+  // inner1_size is 1 so the inner1 term collapses to zero (and inner0_size is
+  // 1 too when fully flattenable).  inner1 is only non-trivial for 4D tensors
+  // whose leading dim is independent of the rest (e.g. a batched QKV slice).
+  int input_inner0_size;
+  int input_inner0_stride;
+  int output_inner0_size;
+  int output_inner0_stride;
+  int input_inner1_size;
+  int input_inner1_stride;
+  int output_inner1_size;
+  int output_inner1_stride;
   int* semaphores_ptr;
   void* scratchpad_ptr;
   int sub_group_num_global;
@@ -229,7 +253,8 @@ class NormConfig {
 
   int get_stride_aligned_vec_size(int vec_size) const {
     while (vec_size > 1 && (input_batch_stride % vec_size != 0 || output_batch_stride % vec_size != 0 ||
-                            input_inner_stride % vec_size != 0 || output_inner_stride % vec_size != 0)) {
+                            input_inner0_stride % vec_size != 0 || output_inner0_stride % vec_size != 0 ||
+                            input_inner1_stride % vec_size != 0 || output_inner1_stride % vec_size != 0)) {
       vec_size = vec_size >> 1;
     }
     return vec_size;

--- a/src/sycl/RMSNorm.cpp
+++ b/src/sycl/RMSNorm.cpp
@@ -66,7 +66,7 @@ static inline RowStrides get_row_strides(const Tensor& t) {
   int64_t outer_stride = t.stride(-3);
   int64_t inner_size = t.size(-2);
   int64_t inner_stride = t.stride(-2);
-  if (((t.dim() == 3) && (t.size(0) == 1)) || t.size(-2) == 1 || outer_stride == inner_size * inner_stride) {
+  if (t.size(-3) == 1 || outer_stride == inner_size * inner_stride) {
     // Flattenable: a single stride describes all rows.
     return {inner_stride, 1, 0};
   }

--- a/src/sycl/RMSNorm.cpp
+++ b/src/sycl/RMSNorm.cpp
@@ -48,15 +48,25 @@ struct RowStrides {
 };
 
 static inline RowStrides get_row_strides(const Tensor& t) {
-  TORCH_CHECK(t.dim() == 2 || t.dim() == 3, "get_row_strides: expected a 2D or 3D tensor, got ", t.dim(), "D");
+  TORCH_CHECK(
+      t.dim() == 2 || t.dim() == 3 || t.dim() == 4, "get_row_strides: expected a 2D/3D/4D tensor, got ", t.dim(), "D");
   if (t.dim() == 2) {
     return {t.stride(0), 1, 0};
   }
-  // 3D
-  int64_t outer_stride = t.stride(0);
-  int64_t inner_size = t.size(1);
-  int64_t inner_stride = t.stride(1);
-  if (t.size(0) == 1 || outer_stride == inner_size * inner_stride) {
+  if (t.dim() == 4) {
+    // 4D only: the leading batch-like dimension (dim 0) must be size 1,
+    // since our two-level (outer, inner) stride formula cannot represent
+    // a third level of striding.
+    TORCH_CHECK(
+        t.size(0) == 1, "get_row_strides: leading dimension 0 must have size 1 for a 4D tensor, got size ", t.size(0));
+  }
+
+  // For 3D/4D tensors, the outer is the second-to-last dimension and
+  // the inner is the last dimension.
+  int64_t outer_stride = t.stride(-3);
+  int64_t inner_size = t.size(-2);
+  int64_t inner_stride = t.stride(-2);
+  if (t.size(-2) == 1 || outer_stride == inner_size * inner_stride) {
     // Flattenable: a single stride describes all rows.
     return {inner_stride, 1, 0};
   }

--- a/src/sycl/RMSNorm.cpp
+++ b/src/sycl/RMSNorm.cpp
@@ -47,15 +47,25 @@ struct RowStrides {
 };
 
 static inline RowStrides get_row_strides(const Tensor& t) {
-  TORCH_CHECK(t.dim() == 2 || t.dim() == 3, "get_row_strides: expected a 2D or 3D tensor, got ", t.dim(), "D");
+  TORCH_CHECK(
+      t.dim() == 2 || t.dim() == 3 || t.dim() == 4, "get_row_strides: expected a 2D/3D/4D tensor, got ", t.dim(), "D");
   if (t.dim() == 2) {
     return {t.stride(0), 1, 0};
   }
-  // 3D
-  int64_t outer_stride = t.stride(0);
-  int64_t inner_size = t.size(1);
-  int64_t inner_stride = t.stride(1);
-  if (t.size(0) == 1 || outer_stride == inner_size * inner_stride) {
+  if (t.dim() == 4) {
+    // 4D only: the leading batch-like dimension (dim 0) must be size 1,
+    // since our two-level (outer, inner) stride formula cannot represent
+    // a third level of striding.
+    TORCH_CHECK(
+        t.size(0) == 1, "get_row_strides: leading dimension 0 must have size 1 for a 4D tensor, got size ", t.size(0));
+  }
+
+  // For 3D/4D tensors, the outer is the second-to-last dimension and
+  // the inner is the last dimension.
+  int64_t outer_stride = t.stride(-3);
+  int64_t inner_size = t.size(-2);
+  int64_t inner_stride = t.stride(-2);
+  if (t.size(-2) == 1 || outer_stride == inner_size * inner_stride) {
     // Flattenable: a single stride describes all rows.
     return {inner_stride, 1, 0};
   }

--- a/src/sycl/RMSNorm.cpp
+++ b/src/sycl/RMSNorm.cpp
@@ -66,7 +66,7 @@ static inline RowStrides get_row_strides(const Tensor& t) {
   int64_t outer_stride = t.stride(-3);
   int64_t inner_size = t.size(-2);
   int64_t inner_stride = t.stride(-2);
-  if (t.size(-2) == 1 || outer_stride == inner_size * inner_stride) {
+  if (((t.dim() == 3) && (t.size(0) == 1)) || t.size(-2) == 1 || outer_stride == inner_size * inner_stride) {
     // Flattenable: a single stride describes all rows.
     return {inner_stride, 1, 0};
   }

--- a/src/sycl/RMSNorm.cpp
+++ b/src/sycl/RMSNorm.cpp
@@ -31,46 +31,85 @@ static inline Tensor flatten_to_2d(const Tensor& t, int64_t M, int64_t N) {
 }
 
 // Describes how a flattened row index (0 .. M-1) maps to a byte offset on a
-// 2D or 3D tensor without requiring a contiguous copy.  For 2D and
-// flattenable 3D tensors, (inner_size == 1, inner_stride == 0) reduces the
-// kernel's per-row offset formula
+// 2D/3D/4D tensor without requiring a contiguous copy.  A row is decomposed
+// into up to 3 nested indices (outer, inner0, inner1), from outermost to
+// innermost:
 //
-//   offset(r) = (r / inner_size) * batch_stride + (r % inner_size) * inner_stride
+//   outer  = r / (inner0_size * inner1_size)
+//   inner0 = (r % (inner0_size * inner1_size)) / inner1_size
+//   inner1 = r % inner1_size
+//   offset(r) = outer * batch_stride + inner0 * inner0_stride + inner1 * inner1_stride
 //
-// to the existing behaviour `offset(r) = r * batch_stride`.  For
-// non-flattenable 3D tensors (e.g. a per-head slice of a packed QKV buffer
-// reshaped to (tokens, heads, head_dim)) we fall back to the general formula
-// by setting inner_size = size(1) and inner_stride = stride(1).
+// For 2D and flattenable 3D tensors, inner0_size == inner1_size == 1 so the
+// formula collapses to `offset(r) = r * batch_stride`.  For non-flattenable
+// 3D tensors (e.g. a per-head slice of a packed QKV buffer reshaped to
+// (tokens, heads, head_dim)) inner0_size/inner0_stride describe the second
+// dim, with inner1_size == 1.  4D tensors additionally use inner1 when the
+// leading dim (dim 0) is independent of dim 1 (e.g. a batched QKV slice),
+// otherwise dim 0 folds away and only the 2-level form is needed.
 struct RowStrides {
   int64_t batch_stride;
-  int64_t inner_size;
-  int64_t inner_stride;
+  int64_t inner0_size;
+  int64_t inner0_stride;
+  int64_t inner1_size;
+  int64_t inner1_stride;
 };
 
 static inline RowStrides get_row_strides(const Tensor& t) {
   TORCH_CHECK(
       t.dim() == 2 || t.dim() == 3 || t.dim() == 4, "get_row_strides: expected a 2D/3D/4D tensor, got ", t.dim(), "D");
   if (t.dim() == 2) {
-    return {t.stride(0), 1, 0};
-  }
-  if (t.dim() == 4) {
-    // 4D only: the leading batch-like dimension (dim 0) must be size 1,
-    // since our two-level (outer, inner) stride formula cannot represent
-    // a third level of striding.
-    TORCH_CHECK(
-        t.size(0) == 1, "get_row_strides: leading dimension 0 must have size 1 for a 4D tensor, got size ", t.size(0));
+    return {t.stride(0), 1, 0, 1, 0};
   }
 
-  // For 3D/4D tensors, the outer is the second-to-last dimension and
-  // the inner is the last dimension.
-  int64_t outer_stride = t.stride(-3);
-  int64_t inner_size = t.size(-2);
-  int64_t inner_stride = t.stride(-2);
-  if (t.size(-3) == 1 || outer_stride == inner_size * inner_stride) {
-    // Flattenable: a single stride describes all rows.
-    return {inner_stride, 1, 0};
+  // dim0/dim1 always participate in both the 3D and 4D shapes, so the fold
+  // check between them is shared; dim2 only exists for 4D.
+  int64_t d0_size = t.size(0);
+  int64_t d0_stride = t.stride(0);
+  int64_t d1_size = t.size(1);
+  int64_t d1_stride = t.stride(1);
+  bool d0_folds_into_d1 = (d0_size == 1) || (d0_stride == d1_size * d1_stride);
+
+  if (t.dim() == 3) {
+    if (d0_folds_into_d1) {
+      return {d1_stride, 1, 0, 1, 0};
+    }
+    return {d0_stride, d1_size, d1_stride, 1, 0};
   }
-  return {outer_stride, inner_size, inner_stride};
+
+  // t.dim() == 4: shape (d0, d1, d2, plane); row = d0*d1*d2.
+  int64_t d2_size = t.size(2);
+  int64_t d2_stride = t.stride(2);
+  bool d1_folds_into_d2 = (d1_size == 1) || (d1_stride == d2_size * d2_stride);
+
+  if (d0_folds_into_d1 && d1_folds_into_d2) {
+    // Everything collapses into a single stride.
+    return {d2_stride, 1, 0, 1, 0};
+  }
+  if (d0_folds_into_d1) {
+    // dim0 contributes nothing; (d1, d2) alone need the 2-level form.
+    return {d1_stride, d2_size, d2_stride, 1, 0};
+  }
+  // Fully independent: need the full 3-level (d0, d1, d2) decomposition.
+  return {d0_stride, d1_size, d1_stride, d2_size, d2_stride};
+}
+
+// Shared 3-level row-offset computation used by every kernel site below; see
+// the RowStrides comment for the (outer, inner0, inner1) decomposition.
+template <typename index_t>
+static inline index_t compute_row_offset(
+    index_t row,
+    index_t batch_stride,
+    index_t inner0_size,
+    index_t inner0_stride,
+    index_t inner1_size,
+    index_t inner1_stride) {
+  index_t combined_inner = inner0_size * inner1_size;
+  index_t outer_idx = row / combined_inner;
+  index_t rem = row % combined_inner;
+  index_t inner0_idx = rem / inner1_size;
+  index_t inner1_idx = rem % inner1_size;
+  return outer_idx * batch_stride + inner0_idx * inner0_stride + inner1_idx * inner1_stride;
 }
 
 template <typename scalar_t, typename weight_t, typename mean_t = float>
@@ -90,8 +129,13 @@ class RMSNormForward : public NormForward<scalar_t, weight_t, true> {
     auto group_id = item_id.get_group(0);
     auto group_id_foreach = item_id.get_group(1);
     auto local_id = item_id.get_local_id(2);
-    index_t group_offset = (group_id / cfg.input_inner_size) * cfg.input_batch_stride +
-                           (group_id % cfg.input_inner_size) * cfg.input_inner_stride;
+    index_t group_offset = compute_row_offset<index_t>(
+        group_id,
+        cfg.input_batch_stride,
+        cfg.input_inner0_size,
+        cfg.input_inner0_stride,
+        cfg.input_inner1_size,
+        cfg.input_inner1_stride);
 
     for (index_t j = local_id * vec_size; j < cfg.WGPlane; j += cfg.workgroup_size * vec_size) {
       index_t plane_offset = group_id_foreach * cfg.WGPlane + j;
@@ -118,10 +162,20 @@ class RMSNormForward : public NormForward<scalar_t, weight_t, true> {
     auto group_id_foreach = item_id.get_group(1);
     auto local_id = item_id.get_local_id(2);
 
-    index_t x_group_offset = (group_id / cfg.input_inner_size) * cfg.input_batch_stride +
-                             (group_id % cfg.input_inner_size) * cfg.input_inner_stride;
-    index_t y_group_offset = (group_id / cfg.output_inner_size) * cfg.output_batch_stride +
-                             (group_id % cfg.output_inner_size) * cfg.output_inner_stride;
+    index_t x_group_offset = compute_row_offset<index_t>(
+        group_id,
+        cfg.input_batch_stride,
+        cfg.input_inner0_size,
+        cfg.input_inner0_stride,
+        cfg.input_inner1_size,
+        cfg.input_inner1_stride);
+    index_t y_group_offset = compute_row_offset<index_t>(
+        group_id,
+        cfg.output_batch_stride,
+        cfg.output_inner0_size,
+        cfg.output_inner0_stride,
+        cfg.output_inner1_size,
+        cfg.output_inner1_stride);
     if (cfg.workgroup_num_foreach == 1) {
       if (local_id == 0) {
         reduce_project(item_id, sum_value, sum_tmp, cfg);
@@ -171,8 +225,13 @@ class AddRMSNormForward : public RMSNormForward<scalar_t, weight_t> {
     auto group_id = item_id.get_group(0);
     auto group_id_foreach = item_id.get_group(1);
     auto local_id = item_id.get_local_id(2);
-    index_t group_offset = (group_id / cfg.input_inner_size) * cfg.input_batch_stride +
-                           (group_id % cfg.input_inner_size) * cfg.input_inner_stride;
+    index_t group_offset = compute_row_offset<index_t>(
+        group_id,
+        cfg.input_batch_stride,
+        cfg.input_inner0_size,
+        cfg.input_inner0_stride,
+        cfg.input_inner1_size,
+        cfg.input_inner1_stride);
 
     for (index_t j = local_id * vec_size; j < cfg.WGPlane; j += cfg.workgroup_size * vec_size) {
       index_t plane_offset = group_id_foreach * cfg.WGPlane + j;
@@ -586,10 +645,20 @@ struct RMSNormNoRstdKernelFunctor {
 
   [[sycl::reqd_sub_group_size(NUM_REDUCE_STAGES)]] void operator()(sycl::nd_item<1> item_id) const {
     const index_t row = item_id.get_group(0);
-    const index_t x_group_offset =
-        (row / cfg.input_inner_size) * cfg.input_batch_stride + (row % cfg.input_inner_size) * cfg.input_inner_stride;
-    const index_t y_group_offset = (row / cfg.output_inner_size) * cfg.output_batch_stride +
-                                   (row % cfg.output_inner_size) * cfg.output_inner_stride;
+    const index_t x_group_offset = compute_row_offset<index_t>(
+        row,
+        cfg.input_batch_stride,
+        cfg.input_inner0_size,
+        cfg.input_inner0_stride,
+        cfg.input_inner1_size,
+        cfg.input_inner1_stride);
+    const index_t y_group_offset = compute_row_offset<index_t>(
+        row,
+        cfg.output_batch_stride,
+        cfg.output_inner0_size,
+        cfg.output_inner0_stride,
+        cfg.output_inner1_size,
+        cfg.output_inner1_stride);
 
     accscalar_t sum_value = 0;
     vec_t reg[cache_inputs ? ITERS : 1];
@@ -687,10 +756,14 @@ void RMSNormKernelImplInternal(
     Tensor& rstd,
     int64_t input_batch_stride,
     int64_t output_batch_stride,
-    int64_t input_inner_size,
-    int64_t input_inner_stride,
-    int64_t output_inner_size,
-    int64_t output_inner_stride) {
+    int64_t input_inner0_size,
+    int64_t input_inner0_stride,
+    int64_t output_inner0_size,
+    int64_t output_inner0_stride,
+    int64_t input_inner1_size,
+    int64_t input_inner1_stride,
+    int64_t output_inner1_size,
+    int64_t output_inner1_stride) {
   scalar_t* X_data = X.data_ptr<scalar_t>();
   scalar_t* Y_data = Y.data_ptr<scalar_t>();
   mean_t* var_data = rstd.data_ptr<mean_t>();
@@ -703,10 +776,14 @@ void RMSNormKernelImplInternal(
       sizeof(scalar_t),
       input_batch_stride,
       output_batch_stride,
-      input_inner_size,
-      input_inner_stride,
-      output_inner_size,
-      output_inner_stride);
+      input_inner0_size,
+      input_inner0_stride,
+      output_inner0_size,
+      output_inner0_stride,
+      input_inner1_size,
+      input_inner1_stride,
+      output_inner1_size,
+      output_inner1_stride);
   RMSNormForward<scalar_t, weight_t> rms_norm_forward(X_data, Y_data, var_data, gemma_data, eps, M, N);
   config.workgroup_num_foreach = 1;
   config.WGPlane = config.Plane;
@@ -747,10 +824,14 @@ void GemmaRMSNormKernelImplInternal(
     Tensor& Y,
     int64_t input_batch_stride,
     int64_t output_batch_stride,
-    int64_t input_inner_size,
-    int64_t input_inner_stride,
-    int64_t output_inner_size,
-    int64_t output_inner_stride) {
+    int64_t input_inner0_size,
+    int64_t input_inner0_stride,
+    int64_t output_inner0_size,
+    int64_t output_inner0_stride,
+    int64_t input_inner1_size,
+    int64_t input_inner1_stride,
+    int64_t output_inner1_size,
+    int64_t output_inner1_stride) {
   scalar_t* X_data = X.data_ptr<scalar_t>();
   scalar_t* Y_data = Y.data_ptr<scalar_t>();
   weight_t* gemma_data = gemma.data_ptr<weight_t>();
@@ -766,10 +847,14 @@ void GemmaRMSNormKernelImplInternal(
       [&](int plane, int max_vec_size) {
         return gemma_rms_norm_no_rstd_forward.get_update_vec_size(plane, max_vec_size);
       },
-      input_inner_size,
-      input_inner_stride,
-      output_inner_size,
-      output_inner_stride);
+      input_inner0_size,
+      input_inner0_stride,
+      output_inner0_size,
+      output_inner0_stride,
+      input_inner1_size,
+      input_inner1_stride,
+      output_inner1_size,
+      output_inner1_stride);
   launch_vectorized_rmsnorm_no_rstd_kernel<scalar_t, weight_t>(gemma_rms_norm_no_rstd_forward, config);
 }
 
@@ -826,10 +911,14 @@ SGL_KERNEL_EXPORT void rmsnorm(torch::Tensor& output, torch::Tensor& input, torc
                   rstd,
                   in_strides.batch_stride,
                   out_strides.batch_stride,
-                  in_strides.inner_size,
-                  in_strides.inner_stride,
-                  out_strides.inner_size,
-                  out_strides.inner_stride);
+                  in_strides.inner0_size,
+                  in_strides.inner0_stride,
+                  out_strides.inner0_size,
+                  out_strides.inner0_stride,
+                  in_strides.inner1_size,
+                  in_strides.inner1_stride,
+                  out_strides.inner1_size,
+                  out_strides.inner1_stride);
             });
       });
 }
@@ -879,10 +968,14 @@ SGL_KERNEL_EXPORT void gemma_rmsnorm(torch::Tensor& output, torch::Tensor& input
                   output,
                   in_strides.batch_stride,
                   out_strides.batch_stride,
-                  in_strides.inner_size,
-                  in_strides.inner_stride,
-                  out_strides.inner_size,
-                  out_strides.inner_stride);
+                  in_strides.inner0_size,
+                  in_strides.inner0_stride,
+                  out_strides.inner0_size,
+                  out_strides.inner0_stride,
+                  in_strides.inner1_size,
+                  in_strides.inner1_stride,
+                  out_strides.inner1_size,
+                  out_strides.inner1_stride);
             });
       });
 }

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -443,14 +443,16 @@ def test_gemma_norm_3d_non_flattenable(
 ###############################################################################
 # 4D tensor tests for gemma_rmsnorm
 ###############################################################################
-'''
+
 
 def _make_non_flattenable_4d(num_tokens, num_heads, head_dim, dtype, extra_heads=4):
     """Create a 4D tensor [1, tokens, heads, head_dim] whose row strides are
     not flattenable by a single outer stride.
     """
     total_heads = num_heads + extra_heads
-    full = torch.randn(1, num_tokens, total_heads * head_dim, device=device, dtype=dtype)
+    full = torch.randn(
+        1, num_tokens, total_heads * head_dim, device=device, dtype=dtype
+    )
     q_flat = full[:, :, : num_heads * head_dim]
     q_4d = q_flat.unflatten(-1, (num_heads, head_dim))
     assert q_4d.size(0) == 1
@@ -505,7 +507,7 @@ def test_gemma_norm_4d_invalid_leading_dim_size_raises():
 
     with pytest.raises(RuntimeError, match="leading dimension 0 must have size 1"):
         sgl_kernel.gemma_rmsnorm(x, w)
-'''
+
 
 ###############################################################################
 # Mixed input/weight dtype tests

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -448,22 +448,51 @@ def test_gemma_norm_3d_non_flattenable(
 ###############################################################################
 
 
-def _make_non_flattenable_4d(num_tokens, num_heads, head_dim, dtype, extra_heads=4):
-    """Create a 4D tensor [1, tokens, heads, head_dim] whose row strides are
-    not flattenable by a single outer stride.
+def _make_non_flattenable_4d(
+    batch_size,
+    num_tokens,
+    num_heads,
+    head_dim,
+    dtype,
+    break_d0_d1,
+    extra_tokens=3,
+    extra_heads=4,
+):
+    """Build a 4D tensor [batch, tokens, heads, head_dim] that is not flattenable:
+
+      break_d0_d1=False  -> dim0 can be flattened
+      break_d0_d1=True  -> fully independent; needs the full 3-level form
+
+    break_d0_d1 allocates extra token rows and slices down to num_tokens, so
+    stride(0) != size(1)*stride(1) (requires batch_size > 1, since dim0 of
+    size 1 always folds regardless of stride).
     """
-    total_heads = num_heads + extra_heads
+    if break_d0_d1:
+        assert batch_size > 1, "batch_size must be > 1 to exercise an independent dim0"
+        tokens_alloc = num_tokens + extra_tokens
+    else:
+        tokens_alloc = num_tokens
+
     full = torch.randn(
-        1, num_tokens, total_heads * head_dim, device=device, dtype=dtype
+        batch_size,
+        tokens_alloc,
+        (num_heads + extra_heads) * head_dim,
+        device=device,
+        dtype=dtype,
     )
-    q_flat = full[:, :, : num_heads * head_dim]
-    q_4d = q_flat.unflatten(-1, (num_heads, head_dim))
-    assert q_4d.size(0) == 1
-    assert q_4d.stride(-3) == total_heads * head_dim
-    assert q_4d.stride(-3) != q_4d.size(-2) * q_4d.stride(-2)
-    return q_4d
+    x = full[:, :num_tokens, : num_heads * head_dim].unflatten(
+        -1, (num_heads, head_dim)
+    )
+
+    if break_d0_d1:
+        assert x.stride(0) != x.size(1) * x.stride(1)
+    else:
+        assert x.stride(0) == x.size(1) * x.stride(1)
+
+    return x
 
 
+@pytest.mark.parametrize("batch_size", [1, 3])
 @pytest.mark.parametrize("num_tokens", [1, 7])
 # num_heads=1 and head_dim=1 exercise the "other dim == 1" shapes (excluding
 # the leading batch/token dims) that bypass the flattenable fast-path check
@@ -472,8 +501,10 @@ def _make_non_flattenable_4d(num_tokens, num_heads, head_dim, dtype, extra_heads
 @pytest.mark.parametrize("head_dim", [1, 64, 128])
 @pytest.mark.parametrize("dtype", [torch.float16])
 @pytest.mark.parametrize("specify_out", [True, False])
-def test_gemma_norm_4d(num_tokens, num_heads, head_dim, dtype, specify_out):
-    x = torch.randn(1, num_tokens, num_heads, head_dim, device=device, dtype=dtype)
+def test_gemma_norm_4d(batch_size, num_tokens, num_heads, head_dim, dtype, specify_out):
+    x = torch.randn(
+        batch_size, num_tokens, num_heads, head_dim, device=device, dtype=dtype
+    )
     w = torch.randn(head_dim, device=device, dtype=dtype)
 
     y_ref = gemma_rms_norm(x, w)
@@ -491,11 +522,13 @@ def test_gemma_norm_4d(num_tokens, num_heads, head_dim, dtype, specify_out):
 ###############################################################################
 
 
-def _make_non_contiguous_4d(num_tokens, num_heads, head_dim, dtype, extra=64):
-    """Create a last-dim-non-contiguous 4D tensor [1, tokens, heads, head_dim]
+def _make_non_contiguous_4d(
+    batch_size, num_tokens, num_heads, head_dim, dtype, extra=64
+):
+    """Create a last-dim-non-contiguous 4D tensor [batch_size, tokens, heads, head_dim]
     by slicing a larger tensor along the last dimension."""
     full = torch.randn(
-        1, num_tokens, num_heads, head_dim + extra, device=device, dtype=dtype
+        batch_size, num_tokens, num_heads, head_dim + extra, device=device, dtype=dtype
     )
     view = full[..., :head_dim]
     assert view.stride(-1) == 1
@@ -503,33 +536,21 @@ def _make_non_contiguous_4d(num_tokens, num_heads, head_dim, dtype, extra=64):
     return view
 
 
+@pytest.mark.parametrize("batch_size", [1, 3])
 @pytest.mark.parametrize("num_tokens", [1, 7])
 @pytest.mark.parametrize("num_heads", [4, 8])
 @pytest.mark.parametrize("head_dim", [64, 128])
 @pytest.mark.parametrize("dtype", [torch.float16])
-def test_gemma_norm_4d_non_contiguous(num_tokens, num_heads, head_dim, dtype):
-    x_nc = _make_non_contiguous_4d(num_tokens, num_heads, head_dim, dtype)
+def test_gemma_norm_4d_non_contiguous(
+    batch_size, num_tokens, num_heads, head_dim, dtype
+):
+    x_nc = _make_non_contiguous_4d(batch_size, num_tokens, num_heads, head_dim, dtype)
     w = torch.randn(head_dim, device=device, dtype=dtype)
 
     y_ref = gemma_rms_norm(x_nc.clone(), w)
     y = sgl_kernel.gemma_rmsnorm(x_nc, w)
 
     torch.testing.assert_close(y_ref, y, **norm_tolerances(dtype))
-
-
-def test_gemma_norm_4d_non_flattenable_row_strides():
-    x = _make_non_flattenable_4d(7, 4, 128, torch.float16)
-    w = torch.randn(x.size(-1), device=device, dtype=x.dtype)
-
-    assert x.size(-2) > 1
-    assert x.stride(-2) != 0
-    assert x.stride(-3) != x.size(-2) * x.stride(-2)
-
-    y = torch.empty_strided(x.shape, x.stride(), device=device, dtype=x.dtype)
-    y_ref = gemma_rms_norm(x.clone(), w)
-    sgl_kernel.gemma_rmsnorm(x, w, out=y)
-
-    torch.testing.assert_close(y_ref, y, **norm_tolerances(x.dtype))
 
 
 def test_gemma_norm_4d_non_flattenable_unaligned_row_strides():
@@ -548,15 +569,33 @@ def test_gemma_norm_4d_non_flattenable_unaligned_row_strides():
     torch.testing.assert_close(y_ref, y, **norm_tolerances(x.dtype))
 
 
+@pytest.mark.parametrize("break_d0_d1", [False, True])
+@pytest.mark.parametrize("batch_size", [1, 3])
 @pytest.mark.parametrize("num_tokens", [7, 32])
 @pytest.mark.parametrize("num_heads", [4, 8])
 @pytest.mark.parametrize("head_dim", [64, 128])
 @pytest.mark.parametrize("dtype", [torch.float16])
 @pytest.mark.parametrize("specify_out", [True, False])
 def test_gemma_norm_4d_non_flattenable(
-    num_tokens, num_heads, head_dim, dtype, specify_out
+    break_d0_d1,
+    batch_size,
+    num_tokens,
+    num_heads,
+    head_dim,
+    dtype,
+    specify_out,
 ):
-    x = _make_non_flattenable_4d(num_tokens, num_heads, head_dim, dtype)
+    if break_d0_d1 and batch_size == 1:
+        pytest.skip("break_d0_d1 requires batch_size > 1")
+
+    x = _make_non_flattenable_4d(
+        batch_size,
+        num_tokens,
+        num_heads,
+        head_dim,
+        dtype,
+        break_d0_d1=break_d0_d1,
+    )
     w = torch.randn(head_dim, device=device, dtype=dtype)
 
     y_ref = gemma_rms_norm(x.clone(), w)
@@ -567,14 +606,6 @@ def test_gemma_norm_4d_non_flattenable(
         y = sgl_kernel.gemma_rmsnorm(x, w)
 
     torch.testing.assert_close(y_ref, y, **norm_tolerances(dtype))
-
-
-def test_gemma_norm_4d_invalid_leading_dim_size_raises():
-    x = torch.randn(2, 7, 4, 128, device=device, dtype=torch.float16)
-    w = torch.randn(128, device=device, dtype=torch.float16)
-
-    with pytest.raises(RuntimeError, match="leading dimension 0 must have size 1"):
-        sgl_kernel.gemma_rmsnorm(x, w)
 
 
 ###############################################################################

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -441,6 +441,73 @@ def test_gemma_norm_3d_non_flattenable(
 
 
 ###############################################################################
+# 4D tensor tests for gemma_rmsnorm
+###############################################################################
+'''
+
+def _make_non_flattenable_4d(num_tokens, num_heads, head_dim, dtype, extra_heads=4):
+    """Create a 4D tensor [1, tokens, heads, head_dim] whose row strides are
+    not flattenable by a single outer stride.
+    """
+    total_heads = num_heads + extra_heads
+    full = torch.randn(1, num_tokens, total_heads * head_dim, device=device, dtype=dtype)
+    q_flat = full[:, :, : num_heads * head_dim]
+    q_4d = q_flat.unflatten(-1, (num_heads, head_dim))
+    assert q_4d.size(0) == 1
+    assert q_4d.stride(-3) == total_heads * head_dim
+    assert q_4d.stride(-3) != q_4d.size(-2) * q_4d.stride(-2)
+    return q_4d
+
+
+@pytest.mark.parametrize("num_tokens", [1, 7])
+@pytest.mark.parametrize("num_heads", [4, 8])
+@pytest.mark.parametrize("head_dim", [64, 128])
+@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize("specify_out", [True, False])
+def test_gemma_norm_4d(num_tokens, num_heads, head_dim, dtype, specify_out):
+    x = torch.randn(1, num_tokens, num_heads, head_dim, device=device, dtype=dtype)
+    w = torch.randn(head_dim, device=device, dtype=dtype)
+
+    y_ref = gemma_rms_norm(x, w)
+    if specify_out:
+        y = torch.empty_like(x)
+        sgl_kernel.gemma_rmsnorm(x, w, out=y)
+    else:
+        y = sgl_kernel.gemma_rmsnorm(x, w)
+
+    torch.testing.assert_close(y_ref, y, **norm_tolerances(dtype))
+
+
+@pytest.mark.parametrize("num_tokens", [7, 32])
+@pytest.mark.parametrize("num_heads", [4, 8])
+@pytest.mark.parametrize("head_dim", [64, 128])
+@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize("specify_out", [True, False])
+def test_gemma_norm_4d_non_flattenable(
+    num_tokens, num_heads, head_dim, dtype, specify_out
+):
+    x = _make_non_flattenable_4d(num_tokens, num_heads, head_dim, dtype)
+    w = torch.randn(head_dim, device=device, dtype=dtype)
+
+    y_ref = gemma_rms_norm(x.clone(), w)
+    if specify_out:
+        y = torch.empty_strided(x.shape, x.stride(), device=device, dtype=x.dtype)
+        sgl_kernel.gemma_rmsnorm(x, w, out=y)
+    else:
+        y = sgl_kernel.gemma_rmsnorm(x, w)
+
+    torch.testing.assert_close(y_ref, y, **norm_tolerances(dtype))
+
+
+def test_gemma_norm_4d_invalid_leading_dim_size_raises():
+    x = torch.randn(2, 7, 4, 128, device=device, dtype=torch.float16)
+    w = torch.randn(128, device=device, dtype=torch.float16)
+
+    with pytest.raises(RuntimeError, match="leading dimension 0 must have size 1"):
+        sgl_kernel.gemma_rmsnorm(x, w)
+'''
+
+###############################################################################
 # Mixed input/weight dtype tests
 ###############################################################################
 

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -254,7 +254,10 @@ def test_fused_add_rmsnorm_3d(batch_size, seq_len, hidden_size, dtype):
 
 @pytest.mark.parametrize("batch_size", [1, 4, 19])
 @pytest.mark.parametrize("seq_len", [1, 7, 32])
-@pytest.mark.parametrize("hidden_size", [111, 1024, 4096])
+# hidden_size=1 exercises the "other dim == 1" shape (excluding the leading
+# batch dim) that bypasses the flattenable fast-path check but still yields
+# a correct result.
+@pytest.mark.parametrize("hidden_size", [1, 111, 1024, 4096])
 @pytest.mark.parametrize("dtype", [torch.float16])
 @pytest.mark.parametrize("specify_out", [True, False])
 def test_gemma_norm_3d(batch_size, seq_len, hidden_size, dtype, specify_out):
@@ -462,8 +465,11 @@ def _make_non_flattenable_4d(num_tokens, num_heads, head_dim, dtype, extra_heads
 
 
 @pytest.mark.parametrize("num_tokens", [1, 7])
-@pytest.mark.parametrize("num_heads", [4, 8])
-@pytest.mark.parametrize("head_dim", [64, 128])
+# num_heads=1 and head_dim=1 exercise the "other dim == 1" shapes (excluding
+# the leading batch/token dims) that bypass the flattenable fast-path check
+# but still yield a correct result.
+@pytest.mark.parametrize("num_heads", [1, 4, 8])
+@pytest.mark.parametrize("head_dim", [1, 64, 128])
 @pytest.mark.parametrize("dtype", [torch.float16])
 @pytest.mark.parametrize("specify_out", [True, False])
 def test_gemma_norm_4d(num_tokens, num_heads, head_dim, dtype, specify_out):
@@ -478,6 +484,68 @@ def test_gemma_norm_4d(num_tokens, num_heads, head_dim, dtype, specify_out):
         y = sgl_kernel.gemma_rmsnorm(x, w)
 
     torch.testing.assert_close(y_ref, y, **norm_tolerances(dtype))
+
+
+###############################################################################
+# Non-contiguous 4D tensor tests (sliced last-dim, flattenable leading dims)
+###############################################################################
+
+
+def _make_non_contiguous_4d(num_tokens, num_heads, head_dim, dtype, extra=64):
+    """Create a last-dim-non-contiguous 4D tensor [1, tokens, heads, head_dim]
+    by slicing a larger tensor along the last dimension."""
+    full = torch.randn(
+        1, num_tokens, num_heads, head_dim + extra, device=device, dtype=dtype
+    )
+    view = full[..., :head_dim]
+    assert view.stride(-1) == 1
+    assert view.stride(-2) == head_dim + extra
+    return view
+
+
+@pytest.mark.parametrize("num_tokens", [1, 7])
+@pytest.mark.parametrize("num_heads", [4, 8])
+@pytest.mark.parametrize("head_dim", [64, 128])
+@pytest.mark.parametrize("dtype", [torch.float16])
+def test_gemma_norm_4d_non_contiguous(num_tokens, num_heads, head_dim, dtype):
+    x_nc = _make_non_contiguous_4d(num_tokens, num_heads, head_dim, dtype)
+    w = torch.randn(head_dim, device=device, dtype=dtype)
+
+    y_ref = gemma_rms_norm(x_nc.clone(), w)
+    y = sgl_kernel.gemma_rmsnorm(x_nc, w)
+
+    torch.testing.assert_close(y_ref, y, **norm_tolerances(dtype))
+
+
+def test_gemma_norm_4d_non_flattenable_row_strides():
+    x = _make_non_flattenable_4d(7, 4, 128, torch.float16)
+    w = torch.randn(x.size(-1), device=device, dtype=x.dtype)
+
+    assert x.size(-2) > 1
+    assert x.stride(-2) != 0
+    assert x.stride(-3) != x.size(-2) * x.stride(-2)
+
+    y = torch.empty_strided(x.shape, x.stride(), device=device, dtype=x.dtype)
+    y_ref = gemma_rms_norm(x.clone(), w)
+    sgl_kernel.gemma_rmsnorm(x, w, out=y)
+
+    torch.testing.assert_close(y_ref, y, **norm_tolerances(x.dtype))
+
+
+def test_gemma_norm_4d_non_flattenable_unaligned_row_strides():
+    full = torch.randn(1, 7, 8, 130, device=device, dtype=torch.float16)
+    x = full[:, :, :4, :128]
+    w = torch.randn(x.size(-1), device=device, dtype=x.dtype)
+
+    assert x.stride(-3) != x.size(-2) * x.stride(-2)
+    assert x.size(-1) % 8 == 0
+    assert x.stride(-2) % 8 != 0
+
+    y = torch.empty_strided(x.shape, x.stride(), device=device, dtype=x.dtype)
+    y_ref = gemma_rms_norm(x.clone(), w)
+    sgl_kernel.gemma_rmsnorm(x, w, out=y)
+
+    torch.testing.assert_close(y_ref, y, **norm_tolerances(x.dtype))
 
 
 @pytest.mark.parametrize("num_tokens", [7, 32])


### PR DESCRIPTION
According to [gemma3 model in sglang](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/models/gemma3_causal.py), `gemma_rmsnorm` may receive a 4d input. This PR expand the input dimension to flattenable/unflattenable 4d shape and add corresponding test.