### PR TITLE
Add SYCL support for flash_compress4_prefill

### DIFF
--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -974,6 +974,14 @@ void flash_compress128_prefill(
 void flash_compress4_decode(
     torch::Tensor kv_buffer, torch::Tensor kv_input, torch::Tensor kv_output, torch::Tensor ape, torch::Tensor plan_d);
 
+void flash_compress4_prefill(
+    torch::Tensor kv_buffer,
+    torch::Tensor kv_input,
+    torch::Tensor kv_output,
+    torch::Tensor ape,
+    torch::Tensor plan_c,
+    torch::Tensor plan_w);
+
 }  // namespace at::native::xpu
 
 namespace flash {

--- a/python/sgl_kernel/flash_compress_4.py
+++ b/python/sgl_kernel/flash_compress_4.py
@@ -155,46 +155,9 @@ def flash_compress4_prefill(
     plan_c_u8: torch.Tensor,  # [C, 16]
     plan_w_u8: torch.Tensor,  # [W, 8]
 ) -> None:
-    head_dim = _infer_head_dim_c4(kv_input, ape, kv_output)
-
-    kv_flat = _flatten_slots(kv_buffer)
-    C = plan_c_u8.shape[0]
-    assert kv_output.shape == (C, head_dim)
-
-    seq_len, ragged_id, buffer_len, rp0, rp1 = decode_plan_c(plan_c_u8)
-
-    # compress
-    for pid in range(C):
-        if seq_len[pid].item() < 0:
-            continue
-
-        P = int(ragged_id[pid].item())
-        bl = int(buffer_len[pid].item())
-        need_overlap = int(seq_len[pid].item()) > 4
-
-        kv_buf_0 = _page_slice(kv_flat, int(rp0[pid].item()))
-        kv_buf_1 = _page_slice(kv_flat, int(rp1[pid].item()))
-
-        kv_output[pid].copy_(
-            c4_forward_torch(
-                kv_buf_0=kv_buf_0,
-                kv_buf_1=kv_buf_1,
-                kv_input=kv_input,
-                ragged_id=P,
-                ape=ape,
-                should_overlap=need_overlap,
-                buffer_len=bl,
-            )
-        )
-
-    # write after compress
-    rag_w, loc_w = decode_plan_w(plan_w_u8)
-    for i in range(plan_w_u8.shape[0]):
-        if rag_w[i].item() < 0:
-            continue
-        rid = int(rag_w[i].item())
-        loc = int(loc_w[i].item())
-        kv_flat[loc].copy_(kv_input[rid])
+    torch.ops.sgl_kernel.flash_compress4_prefill(
+        kv_buffer, kv_input, kv_output, ape, plan_c_u8, plan_w_u8
+    )
 
 
 def flash_compress4_decode(

--- a/src/sycl/CompressPlan.cpp
+++ b/src/sycl/CompressPlan.cpp
@@ -121,8 +121,8 @@ struct CompressPrefillStage0Kernel {
     }
 
     if (tx < kStage0NumSubGroups) {
-      warp_max_[tx] = 0;
-      warp_min_[tx] = 0xFFFFFFFFu;
+      sg_max_[tx] = 0;
+      sg_min_[tx] = 0xFFFFFFFFu;
     }
 
     uint32_t local_max_extend = 0;
@@ -142,15 +142,15 @@ struct CompressPrefillStage0Kernel {
     uint32_t sg_max = sycl::reduce_over_group(sg, local_max_extend, sycl::maximum<uint32_t>());
     uint32_t sg_min = sycl::reduce_over_group(sg, local_min_extend, sycl::minimum<uint32_t>());
     if (lane_id == 0) {
-      warp_max_[sg_id] = sg_max;
-      warp_min_[sg_id] = sg_min;
+      sg_max_[sg_id] = sg_max;
+      sg_min_[sg_id] = sg_min;
     }
     item.barrier(sycl::access::fence_space::local_space);
 
     // Level 2: subgroup 0 reduces subgroup outputs to block-wide min/max.
     if (sg_id == 0) {
-      uint32_t v_max = (lane_id < kStage0NumSubGroups) ? warp_max_[lane_id] : 0u;
-      uint32_t v_min = (lane_id < kStage0NumSubGroups) ? warp_min_[lane_id] : 0xFFFFFFFFu;
+      uint32_t v_max = (lane_id < kStage0NumSubGroups) ? sg_max_[lane_id] : 0u;
+      uint32_t v_min = (lane_id < kStage0NumSubGroups) ? sg_min_[lane_id] : 0xFFFFFFFFu;
       uint32_t block_max = sycl::reduce_over_group(sg, v_max, sycl::maximum<uint32_t>());
       uint32_t block_min = sycl::reduce_over_group(sg, v_min, sycl::minimum<uint32_t>());
       if (lane_id == 0) {
@@ -305,8 +305,8 @@ struct CompressPrefillStage0Kernel {
   sycl::local_accessor<uint32_t, 1> counter_w_local_;
   sycl::local_accessor<int32_t, 1> s_seq_len_;
   sycl::local_accessor<int32_t, 1> s_prefix_len_;
-  sycl::local_accessor<uint32_t, 1> warp_max_;
-  sycl::local_accessor<uint32_t, 1> warp_min_;
+  sycl::local_accessor<uint32_t, 1> sg_max_;
+  sycl::local_accessor<uint32_t, 1> sg_min_;
   sycl::local_accessor<uint32_t, 1> s_max_extend_;
   sycl::local_accessor<uint32_t, 1> s_min_extend_;
 };
@@ -539,8 +539,8 @@ SGL_KERNEL_EXPORT std::tuple<torch::Tensor, torch::Tensor> plan_compress_prefill
     sycl::local_accessor<uint32_t, 1> counter_w_local(sycl::range<1>(1), cgh);
     sycl::local_accessor<int32_t, 1> s_seq_len(sycl::range<1>(kMaxPrefillBatchSize), cgh);
     sycl::local_accessor<int32_t, 1> s_prefix_len(sycl::range<1>(kMaxPrefillBatchSize), cgh);
-    sycl::local_accessor<uint32_t, 1> warp_max(sycl::range<1>(kStage0NumSubGroups), cgh);
-    sycl::local_accessor<uint32_t, 1> warp_min(sycl::range<1>(kStage0NumSubGroups), cgh);
+    sycl::local_accessor<uint32_t, 1> sg_max(sycl::range<1>(kStage0NumSubGroups), cgh);
+    sycl::local_accessor<uint32_t, 1> sg_min(sycl::range<1>(kStage0NumSubGroups), cgh);
     sycl::local_accessor<uint32_t, 1> s_max_extend(sycl::range<1>(1), cgh);
     sycl::local_accessor<uint32_t, 1> s_min_extend(sycl::range<1>(1), cgh);
 
@@ -558,8 +558,8 @@ SGL_KERNEL_EXPORT std::tuple<torch::Tensor, torch::Tensor> plan_compress_prefill
         counter_w_local,
         s_seq_len,
         s_prefix_len,
-        warp_max,
-        warp_min,
+        sg_max,
+        sg_min,
         s_max_extend,
         s_min_extend};
     cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(kStage0BlockSize), sycl::range<1>(kStage0BlockSize)), kernel);

--- a/src/sycl/CompressPlan.cpp
+++ b/src/sycl/CompressPlan.cpp
@@ -404,22 +404,19 @@ SGL_KERNEL_EXPORT torch::Tensor plan_compress_decode(
     int64_t compress_ratio,
     int64_t swa_page_size,
     int64_t ring_size) {
-  TORCH_CHECK(
-      req_pool_indices.is_xpu() && req_pool_indices.dtype() == torch::kInt64 && req_pool_indices.dim() == 1 &&
-          req_pool_indices.is_contiguous(),
-      "req_pool_indices must be a contiguous 1D int64 XPU tensor");
-  TORCH_CHECK(
-      req_to_token.is_xpu() && req_to_token.dtype() == torch::kInt32 && req_to_token.dim() == 2 &&
-          req_to_token.is_contiguous(),
-      "req_to_token must be a contiguous 2D int32 XPU tensor");
-  TORCH_CHECK(
-      full_to_state.is_xpu() && full_to_state.dtype() == torch::kInt64 && full_to_state.dim() == 1 &&
-          full_to_state.is_contiguous(),
-      "full_to_state must be a contiguous 1D int64 XPU tensor");
-  TORCH_CHECK(
-      seq_lens.is_xpu() && seq_lens.dtype() == torch::kInt64 && seq_lens.dim() == 1 && seq_lens.is_contiguous(),
-      "seq_lens must be a contiguous 1D int64 XPU tensor");
-  TORCH_CHECK(req_pool_indices.numel() == seq_lens.numel(), "req_pool_indices and seq_lens must have the same length");
+  CHECK_INPUT(req_pool_indices);
+  CHECK_DIM(1, req_pool_indices);
+  CHECK_EQ(req_pool_indices.dtype(), torch::kInt64);
+  CHECK_INPUT(req_to_token);
+  CHECK_DIM(2, req_to_token);
+  CHECK_EQ(req_to_token.dtype(), torch::kInt32);
+  CHECK_INPUT(full_to_state);
+  CHECK_DIM(1, full_to_state);
+  CHECK_EQ(full_to_state.dtype(), torch::kInt64);
+  CHECK_INPUT(seq_lens);
+  CHECK_DIM(1, seq_lens);
+  CHECK_EQ(seq_lens.dtype(), torch::kInt64);
+  CHECK_EQ(req_pool_indices.numel(), seq_lens.numel());
   TORCH_CHECK(compress_ratio > 0, "compress_ratio must be > 0");
 
   uint32_t batch_size = static_cast<uint32_t>(seq_lens.numel());
@@ -467,18 +464,15 @@ SGL_KERNEL_EXPORT std::tuple<torch::Tensor, torch::Tensor> plan_compress_prefill
   (void)pin_buffer;
   (void)use_cuda_graph;
 
-  TORCH_CHECK(
-      req_pool_indices.is_xpu() && req_pool_indices.dtype() == torch::kInt64 && req_pool_indices.dim() == 1 &&
-          req_pool_indices.is_contiguous(),
-      "req_pool_indices must be a contiguous 1D int64 XPU tensor");
-  TORCH_CHECK(
-      req_to_token.is_xpu() && req_to_token.dtype() == torch::kInt32 && req_to_token.dim() == 2 &&
-          req_to_token.is_contiguous(),
-      "req_to_token must be a contiguous 2D int32 XPU tensor");
-  TORCH_CHECK(
-      full_to_state.is_xpu() && full_to_state.dtype() == torch::kInt64 && full_to_state.dim() == 1 &&
-          full_to_state.is_contiguous(),
-      "full_to_state must be a contiguous 1D int64 XPU tensor");
+  CHECK_INPUT(req_pool_indices);
+  CHECK_DIM(1, req_pool_indices);
+  CHECK_EQ(req_pool_indices.dtype(), torch::kInt64);
+  CHECK_INPUT(req_to_token);
+  CHECK_DIM(2, req_to_token);
+  CHECK_EQ(req_to_token.dtype(), torch::kInt32);
+  CHECK_INPUT(full_to_state);
+  CHECK_DIM(1, full_to_state);
+  CHECK_EQ(full_to_state.dtype(), torch::kInt64);
   TORCH_CHECK(
       (seq_lens.is_xpu() || seq_lens.device().is_cpu()) && seq_lens.dtype() == torch::kInt64 && seq_lens.dim() == 1 &&
           seq_lens.is_contiguous(),
@@ -491,8 +485,8 @@ SGL_KERNEL_EXPORT std::tuple<torch::Tensor, torch::Tensor> plan_compress_prefill
       pin_buffer.device().is_cpu() && pin_buffer.dtype() == torch::kUInt8 && pin_buffer.dim() == 1 &&
           pin_buffer.is_contiguous(),
       "pin_buffer must be a contiguous 1D uint8 CPU tensor");
-  TORCH_CHECK(seq_lens.numel() == extend_lens.numel(), "seq_lens and extend_lens must have the same length");
-  TORCH_CHECK(req_pool_indices.numel() == seq_lens.numel(), "req_pool_indices and seq_lens must have the same length");
+  CHECK_EQ(seq_lens.numel(), extend_lens.numel());
+  CHECK_EQ(req_pool_indices.numel(), seq_lens.numel());
 
   // Accept CPU metadata tensors and move them to the current XPU stream device.
   auto seq_lens_xpu = seq_lens;

--- a/src/sycl/FlashCompress128.cpp
+++ b/src/sycl/FlashCompress128.cpp
@@ -13,13 +13,13 @@
 namespace at::native::xpu {
 
 constexpr int64_t kTileElements = 4;
-constexpr uint32_t kWarpThreads = 16;
-constexpr int64_t kTileDim = kTileElements * static_cast<int64_t>(kWarpThreads);  // 64
+constexpr uint32_t kSubGroupSize = 16;
+constexpr int64_t kTileDim = kTileElements * static_cast<int64_t>(kSubGroupSize);  // 64
 constexpr int64_t kTokenGroups = 8;
 constexpr int64_t kTokensPerGroup = 128 / kTokenGroups;                          // 16
 constexpr uint32_t kBlockSize = static_cast<uint32_t>(kTileDim * kTokenGroups);  // 512
 constexpr uint32_t kWriteBlockSize = 128;
-constexpr uint32_t kWarpsPerWriteBlock = kWriteBlockSize / kWarpThreads;  // 8
+constexpr uint32_t kSubGroupsPerWriteBlock = kWriteBlockSize / kSubGroupSize;  // 8
 
 namespace FlashCompress128Impl {
 
@@ -52,11 +52,11 @@ inline void c128_write_token_strided(
 }
 
 // Load + online softmax + weighted reduction shared by decode and prefill compress.
-// For decode, pass buffer_len=128 so all tokens load from kv_page.
+// For decode, pass buffer_len=128 so all tokens load from kv_buf.
 template <typename buffer_t, typename input_t, typename out_t>
 inline void c128_forward(
-    const buffer_t* kv_page,
-    const input_t* kv_input,
+    const buffer_t* kv_buf,
+    const input_t* kv_src,
     const input_t* ape,
     int64_t fresh_start,
     int64_t buffer_len,
@@ -66,7 +66,7 @@ inline void c128_forward(
     int64_t h,
     int64_t tg,
     int64_t h_lane,
-    out_t* kv_out_row,
+    out_t* kv_out,
     sycl::nd_item<1> item,
     sycl::local_accessor<float, 1> shared) {
   float kv_reg[kTokensPerGroup];
@@ -74,11 +74,11 @@ inline void c128_forward(
   for (int64_t i = 0; i < kTokensPerGroup; ++i) {
     const int64_t t = t_start + i;
     if (t < buffer_len) {
-      const buffer_t* row_ptr = kv_page + t * elem_size;
+      const buffer_t* row_ptr = kv_buf + t * elem_size;
       kv_reg[i] = static_cast<float>(row_ptr[h]);
       score_reg[i] = static_cast<float>(row_ptr[head_dim + h]) + static_cast<float>(ape[t * head_dim + h]);
     } else {
-      const input_t* row_ptr = kv_input + (fresh_start + (t - buffer_len)) * elem_size;
+      const input_t* row_ptr = kv_src + (fresh_start + (t - buffer_len)) * elem_size;
       kv_reg[i] = static_cast<float>(row_ptr[h]);
       score_reg[i] = static_cast<float>(row_ptr[head_dim + h]) + static_cast<float>(ape[t * head_dim + h]);
     }
@@ -118,13 +118,13 @@ inline void c128_forward(
       exp_sum += shared[kSmemSection + static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)];
       weighted_sum += shared[2 * kSmemSection + static_cast<size_t>(g * kTileDim) + static_cast<size_t>(h_lane)];
     }
-    kv_out_row[h] = static_cast<out_t>(weighted_sum / exp_sum);
+    kv_out[h] = static_cast<out_t>(weighted_sum / exp_sum);
   }
 }
 
 template <typename buffer_t, typename input_t, typename out_t>
 struct FlashCompress128DecodeKernel {
-  [[sycl::reqd_sub_group_size(16)]]
+  [[sycl::reqd_sub_group_size(kSubGroupSize)]]
   void operator()(sycl::nd_item<1> item) const {
     const uint32_t gid = static_cast<uint32_t>(item.get_group(0));
     const uint32_t lid = static_cast<uint32_t>(item.get_local_id(0));
@@ -144,25 +144,24 @@ struct FlashCompress128DecodeKernel {
     const int64_t h_lane = static_cast<int64_t>(lid % static_cast<uint32_t>(kTileDim));
     const int64_t tg = static_cast<int64_t>(lid / static_cast<uint32_t>(kTileDim));
     const int64_t h = split_offset + h_lane;
-    const uint32_t sg_id = lid / kWarpThreads;
-    const uint32_t lane_id = lid % kWarpThreads;
+    const uint32_t sg_id = lid / kSubGroupSize;
+    const uint32_t lane_id = lid % kSubGroupSize;
 
     // only the first subgroup performs decode writeback.
-    constexpr uint32_t kWriteSubGroupId = 0;
-    if (sg_id == kWriteSubGroupId) {
+    if (sg_id == 0) {
       buffer_t* kv_dst = kv_buffer_ + static_cast<int64_t>(plan.write_loc) * elem_size_;
       const input_t* kv_src = kv_input_ + static_cast<int64_t>(bid) * elem_size_;
       c128_write_token_strided<buffer_t, input_t>(kv_dst, kv_src, split_offset, lane_id, head_dim_);
     }
 
-    // Compress only when write location reaches page tail.
-    if (plan.write_loc % 128 != 127) {
+    // Compress only when a 128-token chunk is completed.
+    if (plan.seq_len % 128 != 0) {
       return;
     }
 
     item.barrier(sycl::access::fence_space::global_and_local);
 
-    // buffer_len=128: all tokens come from kv_page, kv_input/fresh_start unused.
+    // buffer_len=128: all tokens come from kv_buf, kv_src/fresh_start unused.
     c128_forward(
         kv_buffer_ + static_cast<int64_t>(plan.read_page_1) * page_elem_size_,
         kv_input_,
@@ -195,7 +194,7 @@ struct FlashCompress128DecodeKernel {
 
 template <typename buffer_t, typename input_t, typename out_t>
 struct FlashCompress128PrefillCompressKernel {
-  [[sycl::reqd_sub_group_size(16)]]
+  [[sycl::reqd_sub_group_size(kSubGroupSize)]]
   void operator()(sycl::nd_item<1> item) const {
     const uint32_t gid = static_cast<uint32_t>(item.get_group(0));
     const uint32_t lid = static_cast<uint32_t>(item.get_local_id(0));
@@ -250,15 +249,15 @@ struct FlashCompress128PrefillCompressKernel {
 
 template <typename buffer_t, typename input_t>
 struct FlashCompress128PrefillWriteKernel {
-  [[sycl::reqd_sub_group_size(16)]]
+  [[sycl::reqd_sub_group_size(kSubGroupSize)]]
   void operator()(sycl::nd_item<1> item) const {
     const uint32_t gid = static_cast<uint32_t>(item.get_group(0));
     const uint32_t lid = static_cast<uint32_t>(item.get_local_id(0));
     const uint32_t global_tid = gid * kWriteBlockSize + lid;
-    const uint32_t global_wid = global_tid / kWarpThreads;
-    const uint32_t pid = global_wid / num_split_;
+    const uint32_t global_sg_id = global_tid / kSubGroupSize;
+    const uint32_t pid = global_sg_id / num_split_;
     // Contiguous flatten split: split [head_dim * 2] into num_split tiles of size (kTileDim * 2).
-    const int64_t split_offset = static_cast<int64_t>(global_wid % num_split_) * (kTileDim * 2);
+    const int64_t split_offset = static_cast<int64_t>(global_sg_id % num_split_) * (kTileDim * 2);
 
     if (pid >= num_write_) {
       return;
@@ -271,7 +270,7 @@ struct FlashCompress128PrefillWriteKernel {
 
     buffer_t* kv_dst = kv_buffer_ + static_cast<int64_t>(plan.write_loc) * elem_size_;
     const input_t* kv_src = kv_input_ + static_cast<int64_t>(plan.ragged_id) * elem_size_;
-    const uint32_t lane_id = lid % kWarpThreads;
+    const uint32_t lane_id = lid % kSubGroupSize;
     c128_write_token_strided<buffer_t, input_t>(kv_dst, kv_src, split_offset, lane_id, kTileDim);
   }
 
@@ -438,8 +437,8 @@ SGL_KERNEL_EXPORT void flash_compress128_prefill(
               static_cast<uint32_t>(num_write),
               elem_size,
               num_split};
-          const uint32_t total_warps = static_cast<uint32_t>(num_write) * num_split;
-          const uint32_t num_w_blocks = (total_warps + kWarpsPerWriteBlock - 1) / kWarpsPerWriteBlock;
+          const uint32_t total_sgs = static_cast<uint32_t>(num_write) * num_split;
+          const uint32_t num_w_blocks = (total_sgs + kSubGroupsPerWriteBlock - 1) / kSubGroupsPerWriteBlock;
           const uint32_t global_size = num_w_blocks * kWriteBlockSize;
           cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kWriteBlockSize)), kernel);
         });

--- a/src/sycl/FlashCompress128.cpp
+++ b/src/sycl/FlashCompress128.cpp
@@ -4,6 +4,7 @@
 
 #include <limits>
 #include <sycl/sycl.hpp>
+#include <type_traits>
 
 #include "Compress.h"
 #include "Utils.h"
@@ -11,13 +12,44 @@
 
 namespace at::native::xpu {
 
-constexpr int64_t kTileDim = 64;
+constexpr int64_t kTileElements = 4;
+constexpr uint32_t kWarpThreads = 16;
+constexpr int64_t kTileDim = kTileElements * static_cast<int64_t>(kWarpThreads);  // 64
 constexpr int64_t kTokenGroups = 8;
 constexpr int64_t kTokensPerGroup = 128 / kTokenGroups;                          // 16
 constexpr uint32_t kBlockSize = static_cast<uint32_t>(kTileDim * kTokenGroups);  // 512
-constexpr uint32_t kWriteBlockSize = 64;
+constexpr uint32_t kWriteBlockSize = 128;
+constexpr uint32_t kWarpsPerWriteBlock = kWriteBlockSize / kWarpThreads;  // 8
 
 namespace FlashCompress128Impl {
+
+template <typename buffer_t, typename input_t>
+inline void c128_write_token_strided(
+    buffer_t* kv_dst,
+    const input_t* kv_src,
+    const int64_t split_offset,
+    const uint32_t lane_id,
+    const int64_t row_stride) {
+  const int64_t lane_base = split_offset + static_cast<int64_t>(lane_id) * kTileElements;
+
+  if constexpr (std::is_same_v<buffer_t, input_t> && sizeof(input_t) == 2) {
+    // Fast path: copy 4 contiguous elements (8 bytes) per row via two 32-bit moves.
+    const uint32_t* src32_row0 = reinterpret_cast<const uint32_t*>(kv_src + lane_base);
+    const uint32_t* src32_row1 = reinterpret_cast<const uint32_t*>(kv_src + row_stride + lane_base);
+    uint32_t* dst32_row0 = reinterpret_cast<uint32_t*>(kv_dst + lane_base);
+    uint32_t* dst32_row1 = reinterpret_cast<uint32_t*>(kv_dst + row_stride + lane_base);
+    dst32_row0[0] = src32_row0[0];
+    dst32_row0[1] = src32_row0[1];
+    dst32_row1[0] = src32_row1[0];
+    dst32_row1[1] = src32_row1[1];
+  } else {
+    // Mixed dtype fallback: preserve conversion semantics.
+    for (int64_t x = 0; x < kTileElements; ++x) {
+      kv_dst[lane_base + x] = static_cast<buffer_t>(kv_src[lane_base + x]);
+      kv_dst[row_stride + lane_base + x] = static_cast<buffer_t>(kv_src[row_stride + lane_base + x]);
+    }
+  }
+}
 
 // Load + online softmax + weighted reduction shared by decode and prefill compress.
 // For decode, pass buffer_len=128 so all tokens load from kv_page.
@@ -112,17 +144,19 @@ struct FlashCompress128DecodeKernel {
     const int64_t h_lane = static_cast<int64_t>(lid % static_cast<uint32_t>(kTileDim));
     const int64_t tg = static_cast<int64_t>(lid / static_cast<uint32_t>(kTileDim));
     const int64_t h = split_offset + h_lane;
+    const uint32_t sg_id = lid / kWarpThreads;
+    const uint32_t lane_id = lid % kWarpThreads;
 
-    // Only tg=0 writes: all tg groups share the same h columns, avoid duplicate stores.
-    if (tg == 0 && h < head_dim_) {
+    // only the first subgroup performs decode writeback.
+    constexpr uint32_t kWriteSubGroupId = 0;
+    if (sg_id == kWriteSubGroupId) {
       buffer_t* kv_dst = kv_buffer_ + static_cast<int64_t>(plan.write_loc) * elem_size_;
       const input_t* kv_src = kv_input_ + static_cast<int64_t>(bid) * elem_size_;
-      kv_dst[h] = static_cast<buffer_t>(kv_src[h]);
-      kv_dst[head_dim_ + h] = static_cast<buffer_t>(kv_src[head_dim_ + h]);
+      c128_write_token_strided<buffer_t, input_t>(kv_dst, kv_src, split_offset, lane_id, head_dim_);
     }
 
-    // Compress only when a 128-token chunk is completed.
-    if (plan.seq_len % 128 != 0) {
+    // Compress only when write location reaches page tail.
+    if (plan.write_loc % 128 != 127) {
       return;
     }
 
@@ -220,8 +254,11 @@ struct FlashCompress128PrefillWriteKernel {
   void operator()(sycl::nd_item<1> item) const {
     const uint32_t gid = static_cast<uint32_t>(item.get_group(0));
     const uint32_t lid = static_cast<uint32_t>(item.get_local_id(0));
-    const uint32_t pid = gid / num_split_;
-    const int64_t split_offset = static_cast<int64_t>(gid % num_split_) * kTileDim;
+    const uint32_t global_tid = gid * kWriteBlockSize + lid;
+    const uint32_t global_wid = global_tid / kWarpThreads;
+    const uint32_t pid = global_wid / num_split_;
+    // Contiguous flatten split: split [head_dim * 2] into num_split tiles of size (kTileDim * 2).
+    const int64_t split_offset = static_cast<int64_t>(global_wid % num_split_) * (kTileDim * 2);
 
     if (pid >= num_write_) {
       return;
@@ -232,18 +269,16 @@ struct FlashCompress128PrefillWriteKernel {
       return;
     }
 
-    const int64_t h = split_offset + static_cast<int64_t>(lid);
     buffer_t* kv_dst = kv_buffer_ + static_cast<int64_t>(plan.write_loc) * elem_size_;
     const input_t* kv_src = kv_input_ + static_cast<int64_t>(plan.ragged_id) * elem_size_;
-    kv_dst[h] = static_cast<buffer_t>(kv_src[h]);
-    kv_dst[head_dim_ + h] = static_cast<buffer_t>(kv_src[head_dim_ + h]);
+    const uint32_t lane_id = lid % kWarpThreads;
+    c128_write_token_strided<buffer_t, input_t>(kv_dst, kv_src, split_offset, lane_id, kTileDim);
   }
 
   buffer_t* kv_buffer_;
   const input_t* kv_input_;
   const WritePlan* plan_w_;
   uint32_t num_write_;
-  int64_t head_dim_;
   int64_t elem_size_;
   uint32_t num_split_;
 };
@@ -343,6 +378,7 @@ SGL_KERNEL_EXPORT void flash_compress128_prefill(
   TORCH_CHECK(kv_input.dtype() == kv_output.dtype(), "kv_input and kv_output must have the same dtype");
   TORCH_CHECK(kv_input.dtype() == ape.dtype(), "kv_input and ape must have same dtype");
 
+  const int64_t num_q_tokens = kv_input.size(0);
   const int64_t elem_size = kv_input.size(1);
   const int64_t head_dim = kv_output.size(1);
   const int64_t num_compress = kv_output.size(0);
@@ -357,6 +393,7 @@ SGL_KERNEL_EXPORT void flash_compress128_prefill(
       plan_c.size(0) == num_compress && plan_c.size(1) == static_cast<int64_t>(sizeof(CompressPlan)),
       "plan_c shape must be [C, 16]");
   TORCH_CHECK(plan_w.size(1) == static_cast<int64_t>(sizeof(WritePlan)), "plan_w shape must be [W, 8]");
+  TORCH_CHECK(num_q_tokens >= num_write, "invalid prefill plan: num_q < num_w");
 
   if (num_compress == 0 && num_write == 0) {
     return;
@@ -399,10 +436,11 @@ SGL_KERNEL_EXPORT void flash_compress128_prefill(
               kv_input.data_ptr<input_t>(),
               reinterpret_cast<const WritePlan*>(plan_w.data_ptr<uint8_t>()),
               static_cast<uint32_t>(num_write),
-              head_dim,
               elem_size,
               num_split};
-          const uint32_t global_size = static_cast<uint32_t>(num_write) * num_split * kWriteBlockSize;
+          const uint32_t total_warps = static_cast<uint32_t>(num_write) * num_split;
+          const uint32_t num_w_blocks = (total_warps + kWarpsPerWriteBlock - 1) / kWarpsPerWriteBlock;
+          const uint32_t global_size = num_w_blocks * kWriteBlockSize;
           cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kWriteBlockSize)), kernel);
         });
       }

--- a/src/sycl/FlashCompress128.cpp
+++ b/src/sycl/FlashCompress128.cpp
@@ -286,21 +286,19 @@ struct FlashCompress128PrefillWriteKernel {
 
 SGL_KERNEL_EXPORT void flash_compress128_decode(
     torch::Tensor kv_buffer, torch::Tensor kv_input, torch::Tensor kv_output, torch::Tensor ape, torch::Tensor plan_d) {
-  TORCH_CHECK(
-      kv_buffer.is_xpu() && kv_buffer.dim() == 3 && kv_buffer.is_contiguous(),
-      "kv_buffer must be a contiguous 3D XPU tensor");
-  TORCH_CHECK(
-      kv_input.is_xpu() && kv_input.dim() == 2 && kv_input.is_contiguous(),
-      "kv_input must be a contiguous 2D XPU tensor");
-  TORCH_CHECK(
-      kv_output.is_xpu() && kv_output.dim() == 2 && kv_output.is_contiguous(),
-      "kv_output must be a contiguous 2D XPU tensor");
-  TORCH_CHECK(ape.is_xpu() && ape.dim() == 2 && ape.is_contiguous(), "ape must be a contiguous 2D XPU tensor");
-  TORCH_CHECK(
-      plan_d.is_xpu() && plan_d.dim() == 2 && plan_d.dtype() == torch::kUInt8 && plan_d.is_contiguous(),
-      "plan_d must be a contiguous 2D XPU uint8 tensor");
-  TORCH_CHECK(kv_input.dtype() == kv_output.dtype(), "kv_input and kv_output must have the same dtype");
-  TORCH_CHECK(kv_input.dtype() == ape.dtype(), "kv_input and ape must have same dtype");
+  CHECK_INPUT(kv_buffer);
+  CHECK_DIM(3, kv_buffer);
+  CHECK_INPUT(kv_input);
+  CHECK_DIM(2, kv_input);
+  CHECK_INPUT(kv_output);
+  CHECK_DIM(2, kv_output);
+  CHECK_INPUT(ape);
+  CHECK_DIM(2, ape);
+  CHECK_INPUT(plan_d);
+  CHECK_DIM(2, plan_d);
+  CHECK_EQ(plan_d.dtype(), torch::kUInt8);
+  CHECK_EQ(kv_input.dtype(), kv_output.dtype());
+  CHECK_EQ(kv_input.dtype(), ape.dtype());
 
   const int64_t batch_size = kv_input.size(0);
   const int64_t elem_size = kv_input.size(1);
@@ -358,24 +356,22 @@ SGL_KERNEL_EXPORT void flash_compress128_prefill(
     torch::Tensor ape,
     torch::Tensor plan_c,
     torch::Tensor plan_w) {
-  TORCH_CHECK(
-      kv_buffer.is_xpu() && kv_buffer.dim() == 3 && kv_buffer.is_contiguous(),
-      "kv_buffer must be a contiguous 3D XPU tensor");
-  TORCH_CHECK(
-      kv_input.is_xpu() && kv_input.dim() == 2 && kv_input.is_contiguous(),
-      "kv_input must be a contiguous 2D XPU tensor");
-  TORCH_CHECK(
-      kv_output.is_xpu() && kv_output.dim() == 2 && kv_output.is_contiguous(),
-      "kv_output must be a contiguous 2D XPU tensor");
-  TORCH_CHECK(ape.is_xpu() && ape.dim() == 2 && ape.is_contiguous(), "ape must be a contiguous 2D XPU tensor");
-  TORCH_CHECK(
-      plan_c.is_xpu() && plan_c.dim() == 2 && plan_c.dtype() == torch::kUInt8 && plan_c.is_contiguous(),
-      "plan_c must be a contiguous 2D XPU uint8 tensor");
-  TORCH_CHECK(
-      plan_w.is_xpu() && plan_w.dim() == 2 && plan_w.dtype() == torch::kUInt8 && plan_w.is_contiguous(),
-      "plan_w must be a contiguous 2D XPU uint8 tensor");
-  TORCH_CHECK(kv_input.dtype() == kv_output.dtype(), "kv_input and kv_output must have the same dtype");
-  TORCH_CHECK(kv_input.dtype() == ape.dtype(), "kv_input and ape must have same dtype");
+  CHECK_INPUT(kv_buffer);
+  CHECK_DIM(3, kv_buffer);
+  CHECK_INPUT(kv_input);
+  CHECK_DIM(2, kv_input);
+  CHECK_INPUT(kv_output);
+  CHECK_DIM(2, kv_output);
+  CHECK_INPUT(ape);
+  CHECK_DIM(2, ape);
+  CHECK_INPUT(plan_c);
+  CHECK_DIM(2, plan_c);
+  CHECK_EQ(plan_c.dtype(), torch::kUInt8);
+  CHECK_INPUT(plan_w);
+  CHECK_DIM(2, plan_w);
+  CHECK_EQ(plan_w.dtype(), torch::kUInt8);
+  CHECK_EQ(kv_input.dtype(), kv_output.dtype());
+  CHECK_EQ(kv_input.dtype(), ape.dtype());
 
   const int64_t num_q_tokens = kv_input.size(0);
   const int64_t elem_size = kv_input.size(1);

--- a/src/sycl/FlashCompress128.cpp
+++ b/src/sycl/FlashCompress128.cpp
@@ -297,6 +297,7 @@ SGL_KERNEL_EXPORT void flash_compress128_decode(
   CHECK_INPUT(plan_d);
   CHECK_DIM(2, plan_d);
   CHECK_EQ(plan_d.dtype(), torch::kUInt8);
+  CHECK_EQ(kv_input.dtype(), torch::kFloat);
   CHECK_EQ(kv_input.dtype(), kv_output.dtype());
   CHECK_EQ(kv_input.dtype(), ape.dtype());
 
@@ -322,29 +323,27 @@ SGL_KERNEL_EXPORT void flash_compress128_decode(
   const uint32_t num_split = static_cast<uint32_t>(head_dim / kTileDim);
   auto queue = c10::xpu::getCurrentXPUStream().queue();
 
-  SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_input.scalar_type(), "FlashCompress128Decode", [&]() {
-    using input_t = scalar_t;
-    using output_t = scalar_t;
-    SYCL_DISPATCH_WEIGHT_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress128Decode", [&]() {
-      queue.submit([&](sycl::handler& cgh) {
-        // Shared memory: 3 sections × [kTokenGroups × kTileDim] floats.
-        const size_t kSmemElems = static_cast<size_t>(3 * kTokenGroups * kTileDim);
-        sycl::local_accessor<float, 1> shared(sycl::range<1>(kSmemElems), cgh);
-        FlashCompress128Impl::FlashCompress128DecodeKernel<weight_t, input_t, output_t> kernel{
-            kv_buffer.data_ptr<weight_t>(),
-            kv_input.data_ptr<input_t>(),
-            kv_output.data_ptr<output_t>(),
-            ape.data_ptr<input_t>(),
-            reinterpret_cast<const DecodePlan*>(plan_d.data_ptr<uint8_t>()),
-            static_cast<uint32_t>(batch_size),
-            head_dim,
-            elem_size,
-            page_elem_size,
-            num_split,
-            shared};
-        const uint32_t global_size = static_cast<uint32_t>(batch_size) * num_split * kBlockSize;
-        cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kBlockSize)), kernel);
-      });
+  using input_t = float;
+  using output_t = float;
+  SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress128Decode", [&]() {
+    queue.submit([&](sycl::handler& cgh) {
+      // Shared memory: 3 sections × [kTokenGroups × kTileDim] floats.
+      const size_t kSmemElems = static_cast<size_t>(3 * kTokenGroups * kTileDim);
+      sycl::local_accessor<float, 1> shared(sycl::range<1>(kSmemElems), cgh);
+      FlashCompress128Impl::FlashCompress128DecodeKernel<scalar_t, input_t, output_t> kernel{
+          kv_buffer.data_ptr<scalar_t>(),
+          kv_input.data_ptr<input_t>(),
+          kv_output.data_ptr<output_t>(),
+          ape.data_ptr<input_t>(),
+          reinterpret_cast<const DecodePlan*>(plan_d.data_ptr<uint8_t>()),
+          static_cast<uint32_t>(batch_size),
+          head_dim,
+          elem_size,
+          page_elem_size,
+          num_split,
+          shared};
+      const uint32_t global_size = static_cast<uint32_t>(batch_size) * num_split * kBlockSize;
+      cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kBlockSize)), kernel);
     });
   });
 }
@@ -370,6 +369,7 @@ SGL_KERNEL_EXPORT void flash_compress128_prefill(
   CHECK_INPUT(plan_w);
   CHECK_DIM(2, plan_w);
   CHECK_EQ(plan_w.dtype(), torch::kUInt8);
+  CHECK_EQ(kv_input.dtype(), torch::kFloat);
   CHECK_EQ(kv_input.dtype(), kv_output.dtype());
   CHECK_EQ(kv_input.dtype(), ape.dtype());
 
@@ -398,48 +398,46 @@ SGL_KERNEL_EXPORT void flash_compress128_prefill(
   const uint32_t num_split = static_cast<uint32_t>(head_dim / kTileDim);
   auto queue = c10::xpu::getCurrentXPUStream().queue();
 
-  SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_input.scalar_type(), "FlashCompress128Prefill", [&]() {
-    using input_t = scalar_t;
-    using output_t = scalar_t;
-    SYCL_DISPATCH_WEIGHT_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress128Prefill", [&]() {
-      if (num_compress > 0) {
-        queue.submit([&](sycl::handler& cgh) {
-          // Shared memory: 3 sections × [kTokenGroups × kTileDim] floats.
-          const size_t kSmemElems = static_cast<size_t>(3 * kTokenGroups * kTileDim);
-          sycl::local_accessor<float, 1> shared(sycl::range<1>(kSmemElems), cgh);
-          FlashCompress128Impl::FlashCompress128PrefillCompressKernel<weight_t, input_t, output_t> kernel{
-              kv_buffer.data_ptr<weight_t>(),
-              kv_input.data_ptr<input_t>(),
-              kv_output.data_ptr<output_t>(),
-              ape.data_ptr<input_t>(),
-              reinterpret_cast<const CompressPlan*>(plan_c.data_ptr<uint8_t>()),
-              static_cast<uint32_t>(num_compress),
-              head_dim,
-              elem_size,
-              page_elem_size,
-              num_split,
-              shared};
-          const uint32_t global_size = static_cast<uint32_t>(num_compress) * num_split * kBlockSize;
-          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kBlockSize)), kernel);
-        });
-      }
+  using input_t = float;
+  using output_t = float;
+  SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress128Prefill", [&]() {
+    if (num_compress > 0) {
+      queue.submit([&](sycl::handler& cgh) {
+        // Shared memory: 3 sections × [kTokenGroups × kTileDim] floats.
+        const size_t kSmemElems = static_cast<size_t>(3 * kTokenGroups * kTileDim);
+        sycl::local_accessor<float, 1> shared(sycl::range<1>(kSmemElems), cgh);
+        FlashCompress128Impl::FlashCompress128PrefillCompressKernel<scalar_t, input_t, output_t> kernel{
+            kv_buffer.data_ptr<scalar_t>(),
+            kv_input.data_ptr<input_t>(),
+            kv_output.data_ptr<output_t>(),
+            ape.data_ptr<input_t>(),
+            reinterpret_cast<const CompressPlan*>(plan_c.data_ptr<uint8_t>()),
+            static_cast<uint32_t>(num_compress),
+            head_dim,
+            elem_size,
+            page_elem_size,
+            num_split,
+            shared};
+        const uint32_t global_size = static_cast<uint32_t>(num_compress) * num_split * kBlockSize;
+        cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kBlockSize)), kernel);
+      });
+    }
 
-      if (num_write > 0) {
-        queue.submit([&](sycl::handler& cgh) {
-          FlashCompress128Impl::FlashCompress128PrefillWriteKernel<weight_t, input_t> kernel{
-              kv_buffer.data_ptr<weight_t>(),
-              kv_input.data_ptr<input_t>(),
-              reinterpret_cast<const WritePlan*>(plan_w.data_ptr<uint8_t>()),
-              static_cast<uint32_t>(num_write),
-              elem_size,
-              num_split};
-          const uint32_t total_sgs = static_cast<uint32_t>(num_write) * num_split;
-          const uint32_t num_w_blocks = (total_sgs + kSubGroupsPerWriteBlock - 1) / kSubGroupsPerWriteBlock;
-          const uint32_t global_size = num_w_blocks * kWriteBlockSize;
-          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kWriteBlockSize)), kernel);
-        });
-      }
-    });
+    if (num_write > 0) {
+      queue.submit([&](sycl::handler& cgh) {
+        FlashCompress128Impl::FlashCompress128PrefillWriteKernel<scalar_t, input_t> kernel{
+            kv_buffer.data_ptr<scalar_t>(),
+            kv_input.data_ptr<input_t>(),
+            reinterpret_cast<const WritePlan*>(plan_w.data_ptr<uint8_t>()),
+            static_cast<uint32_t>(num_write),
+            elem_size,
+            num_split};
+        const uint32_t total_sgs = static_cast<uint32_t>(num_write) * num_split;
+        const uint32_t num_w_blocks = (total_sgs + kSubGroupsPerWriteBlock - 1) / kSubGroupsPerWriteBlock;
+        const uint32_t global_size = num_w_blocks * kWriteBlockSize;
+        cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kWriteBlockSize)), kernel);
+      });
+    }
   });
 }
 

--- a/src/sycl/FlashCompress4.cpp
+++ b/src/sycl/FlashCompress4.cpp
@@ -29,7 +29,7 @@ inline void c4_write_token_strided(
     const int64_t row_stride) {
   const int64_t lane_base = split_offset + static_cast<int64_t>(lane_id) * kTileElements;
 
-  if constexpr (std::is_same_v<buffer_t, input_t> && sizeof(input_t) == 2) {
+  if constexpr (std::is_same_v<buffer_t, input_t> && at::is_reduced_floating_point_v<input_t>) {
     // Fast path: copy 4 contiguous elements (8 bytes) per row via two 32-bit moves.
     for (int64_t i = 0; i < kTileElements; ++i) {
       const int64_t row_off = lane_base + i * row_stride;

--- a/src/sycl/FlashCompress4.cpp
+++ b/src/sycl/FlashCompress4.cpp
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <ATen/cpu/vec/vec_base.h>
 #include <c10/xpu/XPUStream.h>
 #include <torch/all.h>
 
@@ -288,21 +289,19 @@ struct FlashCompress4WriteKernel {
 
 SGL_KERNEL_EXPORT void flash_compress4_decode(
     torch::Tensor kv_buffer, torch::Tensor kv_input, torch::Tensor kv_output, torch::Tensor ape, torch::Tensor plan_d) {
-  TORCH_CHECK(
-      kv_buffer.is_xpu() && kv_buffer.dim() == 3 && kv_buffer.is_contiguous(),
-      "kv_buffer must be a contiguous 3D XPU tensor");
-  TORCH_CHECK(
-      kv_input.is_xpu() && kv_input.dim() == 2 && kv_input.is_contiguous(),
-      "kv_input must be a contiguous 2D XPU tensor");
-  TORCH_CHECK(
-      kv_output.is_xpu() && kv_output.dim() == 2 && kv_output.is_contiguous(),
-      "kv_output must be a contiguous 2D XPU tensor");
-  TORCH_CHECK(ape.is_xpu() && ape.dim() == 2 && ape.is_contiguous(), "ape must be a contiguous 2D XPU tensor");
-  TORCH_CHECK(
-      plan_d.is_xpu() && plan_d.dim() == 2 && plan_d.dtype() == torch::kUInt8 && plan_d.is_contiguous(),
-      "plan_d must be a contiguous 2D XPU uint8 tensor");
-  TORCH_CHECK(kv_input.dtype() == kv_output.dtype(), "kv_input and kv_output must have the same dtype");
-  TORCH_CHECK(kv_input.dtype() == ape.dtype(), "kv_input and ape must have same dtype");
+  CHECK_INPUT(kv_buffer);
+  CHECK_DIM(3, kv_buffer);
+  CHECK_INPUT(kv_input);
+  CHECK_DIM(2, kv_input);
+  CHECK_INPUT(kv_output);
+  CHECK_DIM(2, kv_output);
+  CHECK_INPUT(ape);
+  CHECK_DIM(2, ape);
+  CHECK_INPUT(plan_d);
+  CHECK_DIM(2, plan_d);
+  CHECK_EQ(plan_d.dtype(), torch::kUInt8);
+  CHECK_EQ(kv_input.dtype(), kv_output.dtype());
+  CHECK_EQ(kv_input.dtype(), ape.dtype());
 
   const int64_t batch_size = kv_input.size(0);
   const int64_t elem_size = kv_input.size(1);
@@ -357,24 +356,22 @@ SGL_KERNEL_EXPORT void flash_compress4_prefill(
     torch::Tensor ape,
     torch::Tensor plan_c,
     torch::Tensor plan_w) {
-  TORCH_CHECK(
-      kv_buffer.is_xpu() && kv_buffer.dim() == 3 && kv_buffer.is_contiguous(),
-      "kv_buffer must be a contiguous 3D XPU tensor");
-  TORCH_CHECK(
-      kv_input.is_xpu() && kv_input.dim() == 2 && kv_input.is_contiguous(),
-      "kv_input must be a contiguous 2D XPU tensor");
-  TORCH_CHECK(
-      kv_output.is_xpu() && kv_output.dim() == 2 && kv_output.is_contiguous(),
-      "kv_output must be a contiguous 2D XPU tensor");
-  TORCH_CHECK(ape.is_xpu() && ape.dim() == 2 && ape.is_contiguous(), "ape must be a contiguous 2D XPU tensor");
-  TORCH_CHECK(
-      plan_c.is_xpu() && plan_c.dim() == 2 && plan_c.dtype() == torch::kUInt8 && plan_c.is_contiguous(),
-      "plan_c must be a contiguous 2D XPU uint8 tensor");
-  TORCH_CHECK(
-      plan_w.is_xpu() && plan_w.dim() == 2 && plan_w.dtype() == torch::kUInt8 && plan_w.is_contiguous(),
-      "plan_w must be a contiguous 2D XPU uint8 tensor");
-  TORCH_CHECK(kv_input.dtype() == kv_output.dtype(), "kv_input and kv_output must have the same dtype");
-  TORCH_CHECK(kv_input.dtype() == ape.dtype(), "kv_input and ape must have same dtype");
+  CHECK_INPUT(kv_buffer);
+  CHECK_DIM(3, kv_buffer);
+  CHECK_INPUT(kv_input);
+  CHECK_DIM(2, kv_input);
+  CHECK_INPUT(kv_output);
+  CHECK_DIM(2, kv_output);
+  CHECK_INPUT(ape);
+  CHECK_DIM(2, ape);
+  CHECK_INPUT(plan_c);
+  CHECK_DIM(2, plan_c);
+  CHECK_EQ(plan_c.dtype(), torch::kUInt8);
+  CHECK_INPUT(plan_w);
+  CHECK_DIM(2, plan_w);
+  CHECK_EQ(plan_w.dtype(), torch::kUInt8);
+  CHECK_EQ(kv_input.dtype(), kv_output.dtype());
+  CHECK_EQ(kv_input.dtype(), ape.dtype());
 
   const int64_t num_compress = plan_c.size(0);
   const int64_t num_write = plan_w.size(0);

--- a/src/sycl/FlashCompress4.cpp
+++ b/src/sycl/FlashCompress4.cpp
@@ -116,6 +116,160 @@ struct FlashCompress4DecodeKernel {
   uint32_t num_split_;
 };
 
+template <typename buffer_t, typename input_t, typename out_t>
+struct FlashCompress4CompressKernel {
+  [[sycl::reqd_sub_group_size(16)]]
+  void operator()(sycl::nd_item<1> item) const {
+    const uint32_t gid = static_cast<uint32_t>(item.get_group(0));
+    const uint32_t lid = static_cast<uint32_t>(item.get_local_id(0));
+    const uint32_t global_wid = gid * 4U + (lid / 16U);
+    const uint32_t pid = global_wid / num_split_;
+    const uint32_t split_id = global_wid % num_split_;
+    const int64_t split_offset = static_cast<int64_t>(split_id) * kTileDim;
+    const uint32_t tid_in_warp = lid % 16U;
+
+    if (pid >= num_compress_) {
+      return;
+    }
+
+    const CompressPlan plan = plan_c_[pid];
+    if (plan.is_invalid()) {
+      return;
+    }
+
+    const bool need_overlap = plan.seq_len > 4;
+    const int32_t buffer_len = static_cast<int32_t>(plan.buffer_len);
+    const buffer_t* kv_buf_0 = kv_buffer_ + static_cast<int64_t>(plan.read_page_0) * page_elem_size_;
+    const buffer_t* kv_buf_1 = kv_buffer_ + static_cast<int64_t>(plan.read_page_1) * page_elem_size_;
+    // kv_src points to position ragged_id in the ragged input
+    const input_t* kv_src = kv_input_ + static_cast<int64_t>(plan.ragged_id) * elem_size_;
+    out_t* out_row = kv_output_ + static_cast<int64_t>(pid) * head_dim_;
+
+    for (int32_t i = 0; i < kTileElements; ++i) {
+      const int64_t h = split_offset + static_cast<int64_t>(i) * 16 + tid_in_warp;
+      if (h >= head_dim_) {
+        continue;
+      }
+
+      // First pass: max score
+      float max_score = -std::numeric_limits<float>::infinity();
+      for (int32_t t = 0; t < 8; ++t) {
+        const int64_t row_off = static_cast<int64_t>(t % 4) * elem_size_;
+        float score_val;
+        if (t < 4) {
+          if (need_overlap && t < buffer_len) {
+            score_val = static_cast<float>(kv_buf_0[row_off + 2 * head_dim_ + h]);
+          } else if (need_overlap) {
+            // fallback: ragged input at position ragged_id - (7 - t)
+            score_val = static_cast<float>(kv_src[(static_cast<int64_t>(t) - 7) * elem_size_ + 2 * head_dim_ + h]);
+          } else {
+            score_val = -std::numeric_limits<float>::infinity();
+          }
+        } else {
+          if (t < buffer_len) {
+            score_val = static_cast<float>(kv_buf_1[row_off + 3 * head_dim_ + h]);
+          } else {
+            // fallback: ragged input, j = t-4, position ragged_id - (3 - j)
+            const int32_t j = t - 4;
+            score_val = static_cast<float>(kv_src[(static_cast<int64_t>(j) - 3) * elem_size_ + 3 * head_dim_ + h]);
+          }
+        }
+        max_score =
+            sycl::fmax(max_score, score_val + static_cast<float>(ape_[static_cast<int64_t>(t) * head_dim_ + h]));
+      }
+
+      // Second pass: weighted sum
+      float exp_sum = 0.0f;
+      float weighted_sum = 0.0f;
+      for (int32_t t = 0; t < 8; ++t) {
+        const int64_t row_off = static_cast<int64_t>(t % 4) * elem_size_;
+        float kv_val, score_val;
+        if (t < 4) {
+          if (need_overlap && t < buffer_len) {
+            kv_val = static_cast<float>(kv_buf_0[row_off + h]);
+            score_val = static_cast<float>(kv_buf_0[row_off + 2 * head_dim_ + h]);
+          } else if (need_overlap) {
+            const int64_t offset = (static_cast<int64_t>(t) - 7) * elem_size_;
+            kv_val = static_cast<float>(kv_src[offset + h]);
+            score_val = static_cast<float>(kv_src[offset + 2 * head_dim_ + h]);
+          } else {
+            kv_val = 0.0f;
+            score_val = -std::numeric_limits<float>::infinity();
+          }
+        } else {
+          if (t < buffer_len) {
+            kv_val = static_cast<float>(kv_buf_1[row_off + head_dim_ + h]);
+            score_val = static_cast<float>(kv_buf_1[row_off + 3 * head_dim_ + h]);
+          } else {
+            const int32_t j = t - 4;
+            const int64_t offset = (static_cast<int64_t>(j) - 3) * elem_size_;
+            kv_val = static_cast<float>(kv_src[offset + head_dim_ + h]);
+            score_val = static_cast<float>(kv_src[offset + 3 * head_dim_ + h]);
+          }
+        }
+        const float w =
+            sycl::exp(score_val + static_cast<float>(ape_[static_cast<int64_t>(t) * head_dim_ + h]) - max_score);
+        exp_sum += w;
+        weighted_sum += kv_val * w;
+      }
+
+      out_row[h] = static_cast<out_t>(weighted_sum / exp_sum);
+    }
+  }
+
+  buffer_t* kv_buffer_;
+  const input_t* kv_input_;
+  out_t* kv_output_;
+  const input_t* ape_;
+  const CompressPlan* plan_c_;
+  uint32_t num_compress_;
+  int64_t head_dim_;
+  int64_t elem_size_;       // 4 * head_dim
+  int64_t page_elem_size_;  // 16 * head_dim
+  uint32_t num_split_;
+};
+
+template <typename buffer_t, typename input_t>
+struct FlashCompress4WriteKernel {
+  [[sycl::reqd_sub_group_size(16)]]
+  void operator()(sycl::nd_item<1> item) const {
+    const uint32_t gid = static_cast<uint32_t>(item.get_group(0));
+    const uint32_t lid = static_cast<uint32_t>(item.get_local_id(0));
+    const uint32_t global_wid = gid * 4U + (lid / 16U);
+    const uint32_t pid = global_wid / num_split_;
+    const uint32_t split_id = global_wid % num_split_;
+    // Split over full elem_size (4 * head_dim); each sub-group covers kTileDim consecutive elements
+    const int64_t split_offset = static_cast<int64_t>(split_id) * kTileDim;
+    const uint32_t tid_in_warp = lid % 16U;
+
+    if (pid >= num_write_) {
+      return;
+    }
+
+    const WritePlan plan = plan_w_[pid];
+    if (plan.is_invalid()) {
+      return;
+    }
+
+    const input_t* kv_src = kv_input_ + static_cast<int64_t>(plan.ragged_id) * elem_size_ + split_offset;
+    buffer_t* kv_dst = kv_buffer_ + static_cast<int64_t>(plan.write_loc) * elem_size_ + split_offset;
+
+    for (int32_t i = 0; i < kTileElements; ++i) {
+      const int64_t pos = static_cast<int64_t>(i) * 16 + tid_in_warp;
+      if (split_offset + pos < elem_size_) {
+        kv_dst[pos] = static_cast<buffer_t>(kv_src[pos]);
+      }
+    }
+  }
+
+  buffer_t* kv_buffer_;
+  const input_t* kv_input_;
+  const WritePlan* plan_w_;
+  uint32_t num_write_;
+  int64_t elem_size_;  // 4 * head_dim
+  uint32_t num_split_;
+};
+
 }  // namespace FlashCompress4Impl
 
 SGL_KERNEL_EXPORT void flash_compress4_decode(
@@ -180,6 +334,95 @@ SGL_KERNEL_EXPORT void flash_compress4_decode(
         const uint32_t global_size = num_groups * kLocalSize;
         cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
       });
+    });
+  });
+}
+
+void flash_compress4_prefill(
+    torch::Tensor kv_buffer,
+    torch::Tensor kv_input,
+    torch::Tensor kv_output,
+    torch::Tensor ape,
+    torch::Tensor plan_c,
+    torch::Tensor plan_w) {
+  TORCH_CHECK(
+      kv_buffer.is_xpu() && kv_buffer.dim() == 3 && kv_buffer.is_contiguous(),
+      "kv_buffer must be a contiguous 3D XPU tensor");
+  TORCH_CHECK(
+      kv_input.is_xpu() && kv_input.dim() == 2 && kv_input.is_contiguous(),
+      "kv_input must be a contiguous 2D XPU tensor");
+  TORCH_CHECK(
+      kv_output.is_xpu() && kv_output.dim() == 2 && kv_output.is_contiguous(),
+      "kv_output must be a contiguous 2D XPU tensor");
+  TORCH_CHECK(ape.is_xpu() && ape.dim() == 2 && ape.is_contiguous(), "ape must be a contiguous 2D XPU tensor");
+  TORCH_CHECK(
+      plan_c.is_xpu() && plan_c.dim() == 2 && plan_c.dtype() == torch::kUInt8 && plan_c.is_contiguous(),
+      "plan_c must be a contiguous 2D XPU uint8 tensor");
+  TORCH_CHECK(
+      plan_w.is_xpu() && plan_w.dim() == 2 && plan_w.dtype() == torch::kUInt8 && plan_w.is_contiguous(),
+      "plan_w must be a contiguous 2D XPU uint8 tensor");
+  TORCH_CHECK(kv_input.dtype() == kv_output.dtype(), "kv_input and kv_output must have the same dtype");
+  TORCH_CHECK(kv_input.dtype() == ape.dtype(), "kv_input and ape must have same dtype");
+
+  const int64_t num_compress = plan_c.size(0);
+  const int64_t num_write = plan_w.size(0);
+  const int64_t elem_size = kv_input.size(1);
+  const int64_t head_dim = kv_output.size(1);
+  TORCH_CHECK(elem_size == 4 * head_dim, "kv_input last dim must be 4 * head_dim");
+  TORCH_CHECK(
+      kv_buffer.size(1) == 4 && kv_buffer.size(2) == elem_size, "kv_buffer shape must be [num_pages, 4, 4*head_dim]");
+  TORCH_CHECK(ape.size(0) == 8 && ape.size(1) == head_dim, "ape shape must be [8, head_dim]");
+  TORCH_CHECK(
+      plan_c.size(1) == static_cast<int64_t>(sizeof(CompressPlan)), "plan_c row size must be sizeof(CompressPlan)");
+  TORCH_CHECK(plan_w.size(1) == static_cast<int64_t>(sizeof(WritePlan)), "plan_w row size must be sizeof(WritePlan)");
+  TORCH_CHECK(kv_output.size(0) == num_compress, "kv_output rows must match num compress plans");
+
+  if (num_compress == 0 && num_write == 0) {
+    return;
+  }
+
+  const int64_t page_elem_size = 4 * elem_size;
+  const uint32_t num_split = static_cast<uint32_t>((head_dim + kTileDim - 1) / kTileDim);
+  auto queue = c10::xpu::getCurrentXPUStream().queue();
+
+  SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_input.scalar_type(), "FlashCompress4Prefill", [&]() {
+    using input_t = scalar_t;
+    using output_t = scalar_t;
+    SYCL_DISPATCH_WEIGHT_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress4Prefill", [&]() {
+      if (num_compress > 0) {
+        queue.submit([&](sycl::handler& cgh) {
+          FlashCompress4Impl::FlashCompress4CompressKernel<weight_t, input_t, output_t> kernel{
+              kv_buffer.data_ptr<weight_t>(),
+              kv_input.data_ptr<input_t>(),
+              kv_output.data_ptr<output_t>(),
+              ape.data_ptr<input_t>(),
+              reinterpret_cast<const CompressPlan*>(plan_c.data_ptr<uint8_t>()),
+              static_cast<uint32_t>(num_compress),
+              head_dim,
+              elem_size,
+              page_elem_size,
+              num_split};
+          constexpr uint32_t kLocalSize = 64;
+          const uint32_t global_size = static_cast<uint32_t>(num_compress) * num_split * 16;
+          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
+        });
+      }
+      if (num_write > 0) {
+        // num_split_write covers elem_size = 4 * head_dim at kTileDim elements per split
+        const uint32_t num_split_write = num_split * 4;
+        queue.submit([&](sycl::handler& cgh) {
+          FlashCompress4Impl::FlashCompress4WriteKernel<weight_t, input_t> kernel{
+              kv_buffer.data_ptr<weight_t>(),
+              kv_input.data_ptr<input_t>(),
+              reinterpret_cast<const WritePlan*>(plan_w.data_ptr<uint8_t>()),
+              static_cast<uint32_t>(num_write),
+              elem_size,
+              num_split_write};
+          constexpr uint32_t kLocalSize = 64;
+          const uint32_t global_size = static_cast<uint32_t>(num_write) * num_split_write * 16;
+          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
+        });
+      }
     });
   });
 }

--- a/src/sycl/FlashCompress4.cpp
+++ b/src/sycl/FlashCompress4.cpp
@@ -13,10 +13,10 @@
 namespace at::native::xpu {
 
 constexpr int64_t kTileElements = 4;
-constexpr uint32_t kWarpThreads = 16;
-constexpr int64_t kTileDim = kTileElements * static_cast<int64_t>(kWarpThreads);  // 64
-constexpr uint32_t kWarpsPerGroup = 4;
-constexpr uint32_t kLocalSize = kWarpsPerGroup * kWarpThreads;  // 64
+constexpr uint32_t kSubGroupSize = 16;
+constexpr int64_t kTileDim = kTileElements * static_cast<int64_t>(kSubGroupSize);  // 64
+constexpr uint32_t kSubGroupsPerBlock = 4;
+constexpr uint32_t kBlockSize = kSubGroupsPerBlock * kSubGroupSize;  // 64
 
 namespace FlashCompress4Impl {
 
@@ -63,7 +63,7 @@ inline void c4_forward(
     const int64_t head_dim,
     const int64_t elem_size) {
   for (int32_t i = 0; i < kTileElements; ++i) {
-    const int64_t h = split_offset + static_cast<int64_t>(i) * kWarpThreads + lane_id;
+    const int64_t h = split_offset + static_cast<int64_t>(i) * kSubGroupSize + lane_id;
 
     float kv_reg[8];
     float score_reg[8];
@@ -120,16 +120,16 @@ inline void c4_forward(
 
 template <typename buffer_t, typename input_t, typename out_t>
 struct FlashCompress4DecodeKernel {
-  [[sycl::reqd_sub_group_size(16)]]
+  [[sycl::reqd_sub_group_size(kSubGroupSize)]]
   void operator()(sycl::nd_item<1> item) const {
-    const uint32_t global_tid = static_cast<uint32_t>(item.get_global_id(0));
-    const uint32_t local_tid = static_cast<uint32_t>(item.get_local_id(0));
+    const uint32_t gid = static_cast<uint32_t>(item.get_group(0));
+    const uint32_t lid = static_cast<uint32_t>(item.get_local_id(0));
 
-    const uint32_t global_wid = global_tid / kWarpThreads;  // warp id
-    const uint32_t global_bid = global_wid / num_split_;    // batch id
-    const uint32_t global_sid = global_wid % num_split_;    // split id
+    const uint32_t global_sg_id = gid * kSubGroupsPerBlock + (lid / kSubGroupSize);
+    const uint32_t global_bid = global_sg_id / num_split_;  // batch id
+    const uint32_t global_sid = global_sg_id % num_split_;  // split id
     const int64_t split_offset = static_cast<int64_t>(global_sid) * kTileDim;
-    const uint32_t lane_id = local_tid % kWarpThreads;
+    const uint32_t lane_id = lid % kSubGroupSize;
 
     if (global_bid >= batch_size_) {
       return;
@@ -145,7 +145,7 @@ struct FlashCompress4DecodeKernel {
     buffer_t* kv_dst = kv_buffer_ + write_loc * elem_size_;
     const input_t* kv_src = kv_input_ + static_cast<int64_t>(global_bid) * elem_size_;
 
-    // One warp handles one split; each lane copies a contiguous 4-element chunk per row.
+    // One sub-group handles one split; each lane copies a contiguous 4-element chunk per row.
     c4_write_token_strided<buffer_t, input_t>(kv_dst, kv_src, split_offset, lane_id, head_dim_);
 
     // Compress only when we close a 4-token chunk.
@@ -188,15 +188,15 @@ struct FlashCompress4DecodeKernel {
 
 template <typename buffer_t, typename input_t, typename out_t>
 struct FlashCompress4CompressKernel {
-  [[sycl::reqd_sub_group_size(16)]]
+  [[sycl::reqd_sub_group_size(kSubGroupSize)]]
   void operator()(sycl::nd_item<1> item) const {
     const uint32_t gid = static_cast<uint32_t>(item.get_group(0));
     const uint32_t lid = static_cast<uint32_t>(item.get_local_id(0));
-    const uint32_t global_wid = gid * 4U + (lid / 16U);
-    const uint32_t pid = global_wid / num_split_;
-    const uint32_t split_id = global_wid % num_split_;
+    const uint32_t global_sg_id = gid * kSubGroupsPerBlock + (lid / kSubGroupSize);
+    const uint32_t pid = global_sg_id / num_split_;
+    const uint32_t split_id = global_sg_id % num_split_;
     const int64_t split_offset = static_cast<int64_t>(split_id) * kTileDim;
-    const uint32_t tid_in_warp = lid % 16U;
+    const uint32_t lane_id = lid % kSubGroupSize;
 
     if (pid >= num_compress_) {
       return;
@@ -230,7 +230,7 @@ struct FlashCompress4CompressKernel {
         need_overlap,
         buffer_len,
         split_offset,
-        tid_in_warp,
+        lane_id,
         head_dim_,
         elem_size_);
   }
@@ -249,16 +249,17 @@ struct FlashCompress4CompressKernel {
 
 template <typename buffer_t, typename input_t>
 struct FlashCompress4WriteKernel {
-  [[sycl::reqd_sub_group_size(16)]]
+  [[sycl::reqd_sub_group_size(kSubGroupSize)]]
   void operator()(sycl::nd_item<1> item) const {
     const uint32_t gid = static_cast<uint32_t>(item.get_group(0));
     const uint32_t lid = static_cast<uint32_t>(item.get_local_id(0));
-    const uint32_t global_wid = gid * 4U + (lid / 16U);
-    const uint32_t pid = global_wid / num_split_;
-    const uint32_t split_id = global_wid % num_split_;
-    // Contiguous-tile mapping for prefill write: one warp copies one contiguous 4*kTileDim region.
-    const int64_t split_offset = static_cast<int64_t>(split_id) * (kTileDim * 4);
-    const uint32_t lane_id = lid % 16U;
+    const uint32_t global_sg_id = gid * kSubGroupsPerBlock + (lid / kSubGroupSize);
+    const uint32_t pid = global_sg_id / num_split_;
+    const uint32_t split_id = global_sg_id % num_split_;
+    // Split along head_dim columns (kTileDim=64) and copy all 4 rows with stride=head_dim.
+    const int64_t head_dim = elem_size_ / 4;
+    const int64_t split_offset = static_cast<int64_t>(split_id) * kTileDim;
+    const uint32_t lane_id = lid % kSubGroupSize;
 
     if (pid >= num_write_) {
       return;
@@ -272,7 +273,7 @@ struct FlashCompress4WriteKernel {
     const input_t* kv_src = kv_input_ + static_cast<int64_t>(plan.ragged_id) * elem_size_;
     buffer_t* kv_dst = kv_buffer_ + static_cast<int64_t>(plan.write_loc) * elem_size_;
 
-    c4_write_token_strided<buffer_t, input_t>(kv_dst, kv_src, split_offset, lane_id, kTileDim);
+    c4_write_token_strided<buffer_t, input_t>(kv_dst, kv_src, split_offset, lane_id, head_dim);
   }
 
   buffer_t* kv_buffer_;
@@ -340,10 +341,10 @@ SGL_KERNEL_EXPORT void flash_compress4_decode(
             elem_size,
             page_elem_size,
             num_split};
-        const uint32_t num_warps = static_cast<uint32_t>(batch_size) * num_split;
-        const uint32_t num_groups = (num_warps + kWarpsPerGroup - 1) / kWarpsPerGroup;
-        const uint32_t global_size = num_groups * kLocalSize;
-        cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
+        const uint32_t num_sgs = static_cast<uint32_t>(batch_size) * num_split;
+        const uint32_t num_blocks = (num_sgs + kSubGroupsPerBlock - 1) / kSubGroupsPerBlock;
+        const uint32_t global_size = num_blocks * kBlockSize;
+        cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kBlockSize)), kernel);
       });
     });
   });
@@ -416,10 +417,10 @@ SGL_KERNEL_EXPORT void flash_compress4_prefill(
               elem_size,
               page_elem_size,
               num_split};
-          const uint32_t num_warps = static_cast<uint32_t>(num_compress) * num_split;
-          const uint32_t num_groups = (num_warps + kWarpsPerGroup - 1) / kWarpsPerGroup;
-          const uint32_t global_size = num_groups * kLocalSize;
-          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
+          const uint32_t num_sgs = static_cast<uint32_t>(num_compress) * num_split;
+          const uint32_t num_blocks = (num_sgs + kSubGroupsPerBlock - 1) / kSubGroupsPerBlock;
+          const uint32_t global_size = num_blocks * kBlockSize;
+          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kBlockSize)), kernel);
         });
       }
       if (num_write > 0) {
@@ -433,10 +434,10 @@ SGL_KERNEL_EXPORT void flash_compress4_prefill(
               static_cast<uint32_t>(num_write),
               elem_size,
               num_split_write};
-          const uint32_t num_warps = static_cast<uint32_t>(num_write) * num_split_write;
-          const uint32_t num_groups = (num_warps + kWarpsPerGroup - 1) / kWarpsPerGroup;
-          const uint32_t global_size = num_groups * kLocalSize;
-          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
+          const uint32_t num_sgs = static_cast<uint32_t>(num_write) * num_split_write;
+          const uint32_t num_blocks = (num_sgs + kSubGroupsPerBlock - 1) / kSubGroupsPerBlock;
+          const uint32_t global_size = num_blocks * kBlockSize;
+          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kBlockSize)), kernel);
         });
       }
     });

--- a/src/sycl/FlashCompress4.cpp
+++ b/src/sycl/FlashCompress4.cpp
@@ -300,6 +300,7 @@ SGL_KERNEL_EXPORT void flash_compress4_decode(
   CHECK_INPUT(plan_d);
   CHECK_DIM(2, plan_d);
   CHECK_EQ(plan_d.dtype(), torch::kUInt8);
+  CHECK_EQ(kv_input.dtype(), torch::kFloat);
   CHECK_EQ(kv_input.dtype(), kv_output.dtype());
   CHECK_EQ(kv_input.dtype(), ape.dtype());
 
@@ -324,27 +325,25 @@ SGL_KERNEL_EXPORT void flash_compress4_decode(
   const uint32_t num_split = static_cast<uint32_t>(head_dim / kTileDim);
   auto queue = c10::xpu::getCurrentXPUStream().queue();
 
-  SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_input.scalar_type(), "FlashCompress4Decode", [&]() {
-    using input_t = scalar_t;
-    using output_t = scalar_t;
-    SYCL_DISPATCH_WEIGHT_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress4Decode", [&]() {
-      queue.submit([&](sycl::handler& cgh) {
-        FlashCompress4Impl::FlashCompress4DecodeKernel<weight_t, input_t, output_t> kernel{
-            kv_buffer.data_ptr<weight_t>(),
-            kv_input.data_ptr<input_t>(),
-            kv_output.data_ptr<output_t>(),
-            ape.data_ptr<input_t>(),
-            reinterpret_cast<const DecodePlan*>(plan_d.data_ptr<uint8_t>()),
-            static_cast<uint32_t>(batch_size),
-            head_dim,
-            elem_size,
-            page_elem_size,
-            num_split};
-        const uint32_t num_sgs = static_cast<uint32_t>(batch_size) * num_split;
-        const uint32_t num_blocks = (num_sgs + kSubGroupsPerBlock - 1) / kSubGroupsPerBlock;
-        const uint32_t global_size = num_blocks * kBlockSize;
-        cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kBlockSize)), kernel);
-      });
+  using input_t = float;
+  using output_t = float;
+  SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress4Decode", [&]() {
+    queue.submit([&](sycl::handler& cgh) {
+      FlashCompress4Impl::FlashCompress4DecodeKernel<scalar_t, input_t, output_t> kernel{
+          kv_buffer.data_ptr<scalar_t>(),
+          kv_input.data_ptr<input_t>(),
+          kv_output.data_ptr<output_t>(),
+          ape.data_ptr<input_t>(),
+          reinterpret_cast<const DecodePlan*>(plan_d.data_ptr<uint8_t>()),
+          static_cast<uint32_t>(batch_size),
+          head_dim,
+          elem_size,
+          page_elem_size,
+          num_split};
+      const uint32_t num_sgs = static_cast<uint32_t>(batch_size) * num_split;
+      const uint32_t num_blocks = (num_sgs + kSubGroupsPerBlock - 1) / kSubGroupsPerBlock;
+      const uint32_t global_size = num_blocks * kBlockSize;
+      cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kBlockSize)), kernel);
     });
   });
 }
@@ -370,6 +369,7 @@ SGL_KERNEL_EXPORT void flash_compress4_prefill(
   CHECK_INPUT(plan_w);
   CHECK_DIM(2, plan_w);
   CHECK_EQ(plan_w.dtype(), torch::kUInt8);
+  CHECK_EQ(kv_input.dtype(), torch::kFloat);
   CHECK_EQ(kv_input.dtype(), kv_output.dtype());
   CHECK_EQ(kv_input.dtype(), ape.dtype());
 
@@ -397,47 +397,45 @@ SGL_KERNEL_EXPORT void flash_compress4_prefill(
   const uint32_t num_split = static_cast<uint32_t>(head_dim / kTileDim);
   auto queue = c10::xpu::getCurrentXPUStream().queue();
 
-  SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_input.scalar_type(), "FlashCompress4Prefill", [&]() {
-    using input_t = scalar_t;
-    using output_t = scalar_t;
-    SYCL_DISPATCH_WEIGHT_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress4Prefill", [&]() {
-      if (num_compress > 0) {
-        queue.submit([&](sycl::handler& cgh) {
-          FlashCompress4Impl::FlashCompress4CompressKernel<weight_t, input_t, output_t> kernel{
-              kv_buffer.data_ptr<weight_t>(),
-              kv_input.data_ptr<input_t>(),
-              kv_output.data_ptr<output_t>(),
-              ape.data_ptr<input_t>(),
-              reinterpret_cast<const CompressPlan*>(plan_c.data_ptr<uint8_t>()),
-              static_cast<uint32_t>(num_compress),
-              head_dim,
-              elem_size,
-              page_elem_size,
-              num_split};
-          const uint32_t num_sgs = static_cast<uint32_t>(num_compress) * num_split;
-          const uint32_t num_blocks = (num_sgs + kSubGroupsPerBlock - 1) / kSubGroupsPerBlock;
-          const uint32_t global_size = num_blocks * kBlockSize;
-          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kBlockSize)), kernel);
-        });
-      }
-      if (num_write > 0) {
-        // Write path uses the same split count as head_dim partitioning.
-        const uint32_t num_split_write = num_split;
-        queue.submit([&](sycl::handler& cgh) {
-          FlashCompress4Impl::FlashCompress4WriteKernel<weight_t, input_t> kernel{
-              kv_buffer.data_ptr<weight_t>(),
-              kv_input.data_ptr<input_t>(),
-              reinterpret_cast<const WritePlan*>(plan_w.data_ptr<uint8_t>()),
-              static_cast<uint32_t>(num_write),
-              elem_size,
-              num_split_write};
-          const uint32_t num_sgs = static_cast<uint32_t>(num_write) * num_split_write;
-          const uint32_t num_blocks = (num_sgs + kSubGroupsPerBlock - 1) / kSubGroupsPerBlock;
-          const uint32_t global_size = num_blocks * kBlockSize;
-          cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kBlockSize)), kernel);
-        });
-      }
-    });
+  using input_t = float;
+  using output_t = float;
+  SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_buffer.scalar_type(), "FlashCompress4Prefill", [&]() {
+    if (num_compress > 0) {
+      queue.submit([&](sycl::handler& cgh) {
+        FlashCompress4Impl::FlashCompress4CompressKernel<scalar_t, input_t, output_t> kernel{
+            kv_buffer.data_ptr<scalar_t>(),
+            kv_input.data_ptr<input_t>(),
+            kv_output.data_ptr<output_t>(),
+            ape.data_ptr<input_t>(),
+            reinterpret_cast<const CompressPlan*>(plan_c.data_ptr<uint8_t>()),
+            static_cast<uint32_t>(num_compress),
+            head_dim,
+            elem_size,
+            page_elem_size,
+            num_split};
+        const uint32_t num_sgs = static_cast<uint32_t>(num_compress) * num_split;
+        const uint32_t num_blocks = (num_sgs + kSubGroupsPerBlock - 1) / kSubGroupsPerBlock;
+        const uint32_t global_size = num_blocks * kBlockSize;
+        cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kBlockSize)), kernel);
+      });
+    }
+    if (num_write > 0) {
+      // Write path uses the same split count as head_dim partitioning.
+      const uint32_t num_split_write = num_split;
+      queue.submit([&](sycl::handler& cgh) {
+        FlashCompress4Impl::FlashCompress4WriteKernel<scalar_t, input_t> kernel{
+            kv_buffer.data_ptr<scalar_t>(),
+            kv_input.data_ptr<input_t>(),
+            reinterpret_cast<const WritePlan*>(plan_w.data_ptr<uint8_t>()),
+            static_cast<uint32_t>(num_write),
+            elem_size,
+            num_split_write};
+        const uint32_t num_sgs = static_cast<uint32_t>(num_write) * num_split_write;
+        const uint32_t num_blocks = (num_sgs + kSubGroupsPerBlock - 1) / kSubGroupsPerBlock;
+        const uint32_t global_size = num_blocks * kBlockSize;
+        cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kBlockSize)), kernel);
+      });
+    }
   });
 }
 

--- a/src/sycl/FlashCompress4.cpp
+++ b/src/sycl/FlashCompress4.cpp
@@ -4,6 +4,7 @@
 
 #include <limits>
 #include <sycl/sycl.hpp>
+#include <type_traits>
 
 #include "Compress.h"
 #include "Utils.h"
@@ -11,11 +12,111 @@
 
 namespace at::native::xpu {
 
-constexpr int64_t kTileDim = 64;  // kTileElements (4) * kWarpThreads (16)
 constexpr int64_t kTileElements = 4;
 constexpr uint32_t kWarpThreads = 16;
+constexpr int64_t kTileDim = kTileElements * static_cast<int64_t>(kWarpThreads);  // 64
+constexpr uint32_t kWarpsPerGroup = 4;
+constexpr uint32_t kLocalSize = kWarpsPerGroup * kWarpThreads;  // 64
 
 namespace FlashCompress4Impl {
+
+template <typename buffer_t, typename input_t>
+inline void c4_write_token_strided(
+    buffer_t* kv_dst,
+    const input_t* kv_src,
+    const int64_t split_offset,
+    const uint32_t lane_id,
+    const int64_t row_stride) {
+  const int64_t lane_base = split_offset + static_cast<int64_t>(lane_id) * kTileElements;
+
+  if constexpr (std::is_same_v<buffer_t, input_t> && sizeof(input_t) == 2) {
+    // Fast path: copy 4 contiguous elements (8 bytes) per row via two 32-bit moves.
+    for (int64_t i = 0; i < kTileElements; ++i) {
+      const int64_t row_off = lane_base + i * row_stride;
+      const uint32_t* src32 = reinterpret_cast<const uint32_t*>(kv_src + row_off);
+      uint32_t* dst32 = reinterpret_cast<uint32_t*>(kv_dst + row_off);
+      dst32[0] = src32[0];
+      dst32[1] = src32[1];
+    }
+  } else {
+    // Mixed dtype fallback: preserve conversion semantics.
+    for (int64_t i = 0; i < kTileElements; ++i) {
+      const int64_t row_off = lane_base + i * row_stride;
+      for (int64_t x = 0; x < kTileElements; ++x) {
+        kv_dst[row_off + x] = static_cast<buffer_t>(kv_src[row_off + x]);
+      }
+    }
+  }
+}
+
+template <typename buffer_t, typename input_t, typename out_t>
+inline void c4_forward(
+    const buffer_t* kv_buf_0,
+    const buffer_t* kv_buf_1,
+    const input_t* kv_src,
+    out_t* kv_out,
+    const input_t* ape,
+    const bool need_overlap,
+    const int32_t buffer_len,
+    const int64_t split_offset,
+    const uint32_t lane_id,
+    const int64_t head_dim,
+    const int64_t elem_size) {
+  for (int32_t i = 0; i < kTileElements; ++i) {
+    const int64_t h = split_offset + static_cast<int64_t>(i) * kWarpThreads + lane_id;
+
+    float kv_reg[8];
+    float score_reg[8];
+
+    for (int32_t t = 0; t < 8; ++t) {
+      const int64_t row_off = static_cast<int64_t>(t % 4) * elem_size;
+      float kv_val;
+      float score_val;
+
+      if (t < 4) {
+        if (need_overlap && t < buffer_len) {
+          kv_val = static_cast<float>(kv_buf_0[row_off + h]);
+          score_val = static_cast<float>(kv_buf_0[row_off + 2 * head_dim + h]);
+        } else if (need_overlap) {
+          const int64_t offset = (static_cast<int64_t>(t) - 7) * elem_size;
+          kv_val = static_cast<float>(kv_src[offset + h]);
+          score_val = static_cast<float>(kv_src[offset + 2 * head_dim + h]);
+        } else {
+          kv_val = 0.0f;
+          score_val = -std::numeric_limits<float>::infinity();
+        }
+      } else {
+        if (t < buffer_len) {
+          kv_val = static_cast<float>(kv_buf_1[row_off + head_dim + h]);
+          score_val = static_cast<float>(kv_buf_1[row_off + 3 * head_dim + h]);
+        } else {
+          const int32_t j = t - 4;
+          const int64_t offset = (static_cast<int64_t>(j) - 3) * elem_size;
+          kv_val = static_cast<float>(kv_src[offset + head_dim + h]);
+          score_val = static_cast<float>(kv_src[offset + 3 * head_dim + h]);
+        }
+      }
+
+      kv_reg[t] = kv_val;
+      score_reg[t] = score_val + static_cast<float>(ape[static_cast<int64_t>(t) * head_dim + h]);
+    }
+
+    float max_score = score_reg[0];
+    for (int32_t t = 1; t < 8; ++t) {
+      max_score = sycl::fmax(max_score, score_reg[t]);
+    }
+
+    float exp_sum = 0.0f;
+    float weighted_sum = 0.0f;
+    for (int32_t t = 0; t < 8; ++t) {
+      const float w = sycl::exp(score_reg[t] - max_score);
+      exp_sum += w;
+      weighted_sum += kv_reg[t] * w;
+    }
+
+    kv_out[h] = static_cast<out_t>(weighted_sum / exp_sum);
+  }
+}
 
 template <typename buffer_t, typename input_t, typename out_t>
 struct FlashCompress4DecodeKernel {
@@ -44,13 +145,8 @@ struct FlashCompress4DecodeKernel {
     buffer_t* kv_dst = kv_buffer_ + write_loc * elem_size_;
     const input_t* kv_src = kv_input_ + static_cast<int64_t>(global_bid) * elem_size_;
 
-    // One warp handles one split; each lane processes strided head_dim elements.
-    for (int32_t i = 0; i < kTileElements; ++i) {
-      const int64_t h = split_offset + static_cast<int64_t>(i) * kWarpThreads + lane_id;
-      for (int64_t j = 0; j < 4; ++j) {
-        kv_dst[j * head_dim_ + h] = static_cast<buffer_t>(kv_src[j * head_dim_ + h]);
-      }
-    }
+    // One warp handles one split; each lane copies a contiguous 4-element chunk per row.
+    c4_write_token_strided<buffer_t, input_t>(kv_dst, kv_src, split_offset, lane_id, head_dim_);
 
     // Compress only when we close a 4-token chunk.
     if (plan.seq_len % 4 != 0) {
@@ -61,47 +157,21 @@ struct FlashCompress4DecodeKernel {
     // [kv_overlap | kv | score_overlap | score], row stride = elem_size_.
     // t in [0, 3] reads overlap terms from kv_buf_0; t in [4, 7] reads fresh terms from kv_buf_1.
     const bool need_overlap = plan.seq_len > 4;
-    const buffer_t* kv_buf_0 = kv_buffer_ + static_cast<int64_t>(plan.read_page_0) * page_elem_size_;
+    const buffer_t* kv_buf_0 = kv_buffer_;
+    if (need_overlap) {
+      if (plan.read_page_0 < 0) {
+        return;
+      }
+      kv_buf_0 = kv_buffer_ + static_cast<int64_t>(plan.read_page_0) * page_elem_size_;
+    }
+    if (plan.read_page_1 < 0) {
+      return;
+    }
     const buffer_t* kv_buf_1 = kv_buffer_ + static_cast<int64_t>(plan.read_page_1) * page_elem_size_;
     out_t* kv_out = kv_output_ + static_cast<int64_t>(global_bid) * head_dim_;
 
-    for (int32_t i = 0; i < kTileElements; ++i) {
-      const int64_t h = split_offset + static_cast<int64_t>(i) * kWarpThreads + lane_id;
-
-      // Load all 8 tokens into registers (overlap [0,3] from kv_buf_0, fresh [4,7] from kv_buf_1).
-      float kv_reg[8];
-      float score_reg[8];
-      for (int32_t t = 0; t < 4; ++t) {
-        const int64_t row_off = static_cast<int64_t>(t) * elem_size_;
-        kv_reg[t] = need_overlap ? static_cast<float>(kv_buf_0[row_off + h]) : 0.0f;
-        score_reg[t] = (need_overlap ? static_cast<float>(kv_buf_0[row_off + 2 * head_dim_ + h])
-                                     : -std::numeric_limits<float>::infinity()) +
-                       static_cast<float>(ape_[static_cast<int64_t>(t) * head_dim_ + h]);
-      }
-      for (int32_t t = 0; t < 4; ++t) {
-        const int64_t row_off = static_cast<int64_t>(t) * elem_size_;
-        kv_reg[t + 4] = static_cast<float>(kv_buf_1[row_off + head_dim_ + h]);
-        score_reg[t + 4] = static_cast<float>(kv_buf_1[row_off + 3 * head_dim_ + h]) +
-                           static_cast<float>(ape_[static_cast<int64_t>(t + 4) * head_dim_ + h]);
-      }
-
-      // Pass 1: max score.
-      float max_score = score_reg[0];
-      for (int32_t t = 1; t < 8; ++t) {
-        max_score = sycl::fmax(max_score, score_reg[t]);
-      }
-
-      // Pass 2: weighted kv reduction.
-      float exp_sum = 0.0f;
-      float weighted_sum = 0.0f;
-      for (int32_t t = 0; t < 8; ++t) {
-        const float w = sycl::exp(score_reg[t] - max_score);
-        exp_sum += w;
-        weighted_sum += kv_reg[t] * w;
-      }
-
-      kv_out[h] = static_cast<out_t>(weighted_sum / exp_sum);
-    }
+    c4_forward<buffer_t, input_t, out_t>(
+        kv_buf_0, kv_buf_1, kv_src, kv_out, ape_, need_overlap, 8, split_offset, lane_id, head_dim_, elem_size_);
   }
 
   buffer_t* kv_buffer_;
@@ -139,82 +209,30 @@ struct FlashCompress4CompressKernel {
 
     const bool need_overlap = plan.seq_len > 4;
     const int32_t buffer_len = static_cast<int32_t>(plan.buffer_len);
-    const buffer_t* kv_buf_0 = kv_buffer_ + static_cast<int64_t>(plan.read_page_0) * page_elem_size_;
-    const buffer_t* kv_buf_1 = kv_buffer_ + static_cast<int64_t>(plan.read_page_1) * page_elem_size_;
+    const buffer_t* kv_buf_0 = kv_buffer_;
+    const buffer_t* kv_buf_1 = kv_buffer_;
+    if (need_overlap && buffer_len > 0) {
+      kv_buf_0 = kv_buffer_ + static_cast<int64_t>(plan.read_page_0) * page_elem_size_;
+    }
+    if (buffer_len > 4) {
+      kv_buf_1 = kv_buffer_ + static_cast<int64_t>(plan.read_page_1) * page_elem_size_;
+    }
     // kv_src points to position ragged_id in the ragged input
     const input_t* kv_src = kv_input_ + static_cast<int64_t>(plan.ragged_id) * elem_size_;
     out_t* out_row = kv_output_ + static_cast<int64_t>(pid) * head_dim_;
 
-    for (int32_t i = 0; i < kTileElements; ++i) {
-      const int64_t h = split_offset + static_cast<int64_t>(i) * 16 + tid_in_warp;
-      if (h >= head_dim_) {
-        continue;
-      }
-
-      // First pass: max score
-      float max_score = -std::numeric_limits<float>::infinity();
-      for (int32_t t = 0; t < 8; ++t) {
-        const int64_t row_off = static_cast<int64_t>(t % 4) * elem_size_;
-        float score_val;
-        if (t < 4) {
-          if (need_overlap && t < buffer_len) {
-            score_val = static_cast<float>(kv_buf_0[row_off + 2 * head_dim_ + h]);
-          } else if (need_overlap) {
-            // fallback: ragged input at position ragged_id - (7 - t)
-            score_val = static_cast<float>(kv_src[(static_cast<int64_t>(t) - 7) * elem_size_ + 2 * head_dim_ + h]);
-          } else {
-            score_val = -std::numeric_limits<float>::infinity();
-          }
-        } else {
-          if (t < buffer_len) {
-            score_val = static_cast<float>(kv_buf_1[row_off + 3 * head_dim_ + h]);
-          } else {
-            // fallback: ragged input, j = t-4, position ragged_id - (3 - j)
-            const int32_t j = t - 4;
-            score_val = static_cast<float>(kv_src[(static_cast<int64_t>(j) - 3) * elem_size_ + 3 * head_dim_ + h]);
-          }
-        }
-        max_score =
-            sycl::fmax(max_score, score_val + static_cast<float>(ape_[static_cast<int64_t>(t) * head_dim_ + h]));
-      }
-
-      // Second pass: weighted sum
-      float exp_sum = 0.0f;
-      float weighted_sum = 0.0f;
-      for (int32_t t = 0; t < 8; ++t) {
-        const int64_t row_off = static_cast<int64_t>(t % 4) * elem_size_;
-        float kv_val, score_val;
-        if (t < 4) {
-          if (need_overlap && t < buffer_len) {
-            kv_val = static_cast<float>(kv_buf_0[row_off + h]);
-            score_val = static_cast<float>(kv_buf_0[row_off + 2 * head_dim_ + h]);
-          } else if (need_overlap) {
-            const int64_t offset = (static_cast<int64_t>(t) - 7) * elem_size_;
-            kv_val = static_cast<float>(kv_src[offset + h]);
-            score_val = static_cast<float>(kv_src[offset + 2 * head_dim_ + h]);
-          } else {
-            kv_val = 0.0f;
-            score_val = -std::numeric_limits<float>::infinity();
-          }
-        } else {
-          if (t < buffer_len) {
-            kv_val = static_cast<float>(kv_buf_1[row_off + head_dim_ + h]);
-            score_val = static_cast<float>(kv_buf_1[row_off + 3 * head_dim_ + h]);
-          } else {
-            const int32_t j = t - 4;
-            const int64_t offset = (static_cast<int64_t>(j) - 3) * elem_size_;
-            kv_val = static_cast<float>(kv_src[offset + head_dim_ + h]);
-            score_val = static_cast<float>(kv_src[offset + 3 * head_dim_ + h]);
-          }
-        }
-        const float w =
-            sycl::exp(score_val + static_cast<float>(ape_[static_cast<int64_t>(t) * head_dim_ + h]) - max_score);
-        exp_sum += w;
-        weighted_sum += kv_val * w;
-      }
-
-      out_row[h] = static_cast<out_t>(weighted_sum / exp_sum);
-    }
+    c4_forward<buffer_t, input_t, out_t>(
+        kv_buf_0,
+        kv_buf_1,
+        kv_src,
+        out_row,
+        ape_,
+        need_overlap,
+        buffer_len,
+        split_offset,
+        tid_in_warp,
+        head_dim_,
+        elem_size_);
   }
 
   buffer_t* kv_buffer_;
@@ -238,9 +256,9 @@ struct FlashCompress4WriteKernel {
     const uint32_t global_wid = gid * 4U + (lid / 16U);
     const uint32_t pid = global_wid / num_split_;
     const uint32_t split_id = global_wid % num_split_;
-    // Split over full elem_size (4 * head_dim); each sub-group covers kTileDim consecutive elements
-    const int64_t split_offset = static_cast<int64_t>(split_id) * kTileDim;
-    const uint32_t tid_in_warp = lid % 16U;
+    // Contiguous-tile mapping for prefill write: one warp copies one contiguous 4*kTileDim region.
+    const int64_t split_offset = static_cast<int64_t>(split_id) * (kTileDim * 4);
+    const uint32_t lane_id = lid % 16U;
 
     if (pid >= num_write_) {
       return;
@@ -251,15 +269,10 @@ struct FlashCompress4WriteKernel {
       return;
     }
 
-    const input_t* kv_src = kv_input_ + static_cast<int64_t>(plan.ragged_id) * elem_size_ + split_offset;
-    buffer_t* kv_dst = kv_buffer_ + static_cast<int64_t>(plan.write_loc) * elem_size_ + split_offset;
+    const input_t* kv_src = kv_input_ + static_cast<int64_t>(plan.ragged_id) * elem_size_;
+    buffer_t* kv_dst = kv_buffer_ + static_cast<int64_t>(plan.write_loc) * elem_size_;
 
-    for (int32_t i = 0; i < kTileElements; ++i) {
-      const int64_t pos = static_cast<int64_t>(i) * 16 + tid_in_warp;
-      if (split_offset + pos < elem_size_) {
-        kv_dst[pos] = static_cast<buffer_t>(kv_src[pos]);
-      }
-    }
+    c4_write_token_strided<buffer_t, input_t>(kv_dst, kv_src, split_offset, lane_id, kTileDim);
   }
 
   buffer_t* kv_buffer_;
@@ -327,8 +340,6 @@ SGL_KERNEL_EXPORT void flash_compress4_decode(
             elem_size,
             page_elem_size,
             num_split};
-        constexpr uint32_t kWarpsPerGroup = 4;
-        constexpr uint32_t kLocalSize = kWarpsPerGroup * kWarpThreads;
         const uint32_t num_warps = static_cast<uint32_t>(batch_size) * num_split;
         const uint32_t num_groups = (num_warps + kWarpsPerGroup - 1) / kWarpsPerGroup;
         const uint32_t global_size = num_groups * kLocalSize;
@@ -338,7 +349,7 @@ SGL_KERNEL_EXPORT void flash_compress4_decode(
   });
 }
 
-void flash_compress4_prefill(
+SGL_KERNEL_EXPORT void flash_compress4_prefill(
     torch::Tensor kv_buffer,
     torch::Tensor kv_input,
     torch::Tensor kv_output,
@@ -366,8 +377,10 @@ void flash_compress4_prefill(
 
   const int64_t num_compress = plan_c.size(0);
   const int64_t num_write = plan_w.size(0);
+  const int64_t num_q_tokens = kv_input.size(0);
   const int64_t elem_size = kv_input.size(1);
   const int64_t head_dim = kv_output.size(1);
+  TORCH_CHECK(head_dim % kTileDim == 0, "flash_compress4_prefill requires head_dim divisible by ", kTileDim);
   TORCH_CHECK(elem_size == 4 * head_dim, "kv_input last dim must be 4 * head_dim");
   TORCH_CHECK(
       kv_buffer.size(1) == 4 && kv_buffer.size(2) == elem_size, "kv_buffer shape must be [num_pages, 4, 4*head_dim]");
@@ -376,13 +389,14 @@ void flash_compress4_prefill(
       plan_c.size(1) == static_cast<int64_t>(sizeof(CompressPlan)), "plan_c row size must be sizeof(CompressPlan)");
   TORCH_CHECK(plan_w.size(1) == static_cast<int64_t>(sizeof(WritePlan)), "plan_w row size must be sizeof(WritePlan)");
   TORCH_CHECK(kv_output.size(0) == num_compress, "kv_output rows must match num compress plans");
+  TORCH_CHECK(num_q_tokens >= num_write, "invalid prefill plan: num_q < num_w");
 
   if (num_compress == 0 && num_write == 0) {
     return;
   }
 
   const int64_t page_elem_size = 4 * elem_size;
-  const uint32_t num_split = static_cast<uint32_t>((head_dim + kTileDim - 1) / kTileDim);
+  const uint32_t num_split = static_cast<uint32_t>(head_dim / kTileDim);
   auto queue = c10::xpu::getCurrentXPUStream().queue();
 
   SYCL_DISPATCH_FLOATING_TYPES(at::kHalf, at::kBFloat16, kv_input.scalar_type(), "FlashCompress4Prefill", [&]() {
@@ -402,14 +416,15 @@ void flash_compress4_prefill(
               elem_size,
               page_elem_size,
               num_split};
-          constexpr uint32_t kLocalSize = 64;
-          const uint32_t global_size = static_cast<uint32_t>(num_compress) * num_split * 16;
+          const uint32_t num_warps = static_cast<uint32_t>(num_compress) * num_split;
+          const uint32_t num_groups = (num_warps + kWarpsPerGroup - 1) / kWarpsPerGroup;
+          const uint32_t global_size = num_groups * kLocalSize;
           cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
         });
       }
       if (num_write > 0) {
-        // num_split_write covers elem_size = 4 * head_dim at kTileDim elements per split
-        const uint32_t num_split_write = num_split * 4;
+        // Write path uses the same split count as head_dim partitioning.
+        const uint32_t num_split_write = num_split;
         queue.submit([&](sycl::handler& cgh) {
           FlashCompress4Impl::FlashCompress4WriteKernel<weight_t, input_t> kernel{
               kv_buffer.data_ptr<weight_t>(),
@@ -418,8 +433,9 @@ void flash_compress4_prefill(
               static_cast<uint32_t>(num_write),
               elem_size,
               num_split_write};
-          constexpr uint32_t kLocalSize = 64;
-          const uint32_t global_size = static_cast<uint32_t>(num_write) * num_split_write * 16;
+          const uint32_t num_warps = static_cast<uint32_t>(num_write) * num_split_write;
+          const uint32_t num_groups = (num_warps + kWarpsPerGroup - 1) / kWarpsPerGroup;
+          const uint32_t global_size = num_groups * kLocalSize;
           cgh.parallel_for(sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(kLocalSize)), kernel);
         });
       }

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -557,6 +557,11 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "flash_compress4_decode(Tensor! kv_buffer, Tensor kv_input, Tensor! kv_output, Tensor ape, Tensor plan_d) "
       "-> ()");
   m.impl("flash_compress4_decode", torch::kXPU, &at::native::xpu::flash_compress4_decode);
+
+  m.def(
+      "flash_compress4_prefill(Tensor! kv_buffer, Tensor kv_input, Tensor! kv_output, Tensor ape, Tensor plan_c, "
+      "Tensor plan_w) -> ()");
+  m.impl("flash_compress4_prefill", torch::kXPU, &at::native::xpu::flash_compress4_prefill);
 }
 
 REGISTER_EXTENSION(common_ops)

--- a/tests/test_c128_v2.py
+++ b/tests/test_c128_v2.py
@@ -22,11 +22,8 @@ Context = Union[LegacyContext, PagedContext]
 # c128 input row layout: | kv | score |  each [head_dim]
 HEAD_DIM = 512
 RATIO = 128
-
-precision = {
-    torch.bfloat16: 1e-2,
-    torch.float32: 5e-3,
-}
+ATOL = 5e-3
+RTOL = 5e-3
 
 
 def _gt_compress(
@@ -98,8 +95,7 @@ def _run_decode(
 
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("seq_len", [128, 256, 512])
-@pytest.mark.parametrize("input_dtype", [torch.float32, torch.bfloat16])
-def test_prefill_no_context(mode: str, seq_len: int, input_dtype: torch.dtype) -> None:
+def test_prefill_no_context(mode: str, seq_len: int) -> None:
     """Single-shot prefill, no prefix. Every compress event must match fp64 GT."""
     if mode == "legacy":
         ctx: Context = make_legacy_context(
@@ -115,8 +111,8 @@ def test_prefill_no_context(mode: str, seq_len: int, input_dtype: torch.dtype) -
     out = _run_prefill(
         ctx,
         pool,
-        kv_in_cpu.to(get_device(), dtype=input_dtype),
-        ape_cpu.to(get_device(), dtype=input_dtype),
+        kv_in_cpu.to(get_device()),
+        ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,
     )
@@ -124,20 +120,12 @@ def test_prefill_no_context(mode: str, seq_len: int, input_dtype: torch.dtype) -
     # Compact prefill output: row per compress plan, in CPU-planner order.
     for plan_id, P in enumerate(range(RATIO - 1, seq_len, RATIO)):
         gt = _gt_compress(kv_in_cpu, ape_cpu, P=P, head_dim=ctx.head_dim)
-        triton.testing.assert_close(
-            out[plan_id].cpu(),
-            gt,
-            atol=precision[input_dtype],
-            rtol=precision[input_dtype],
-        )
+        triton.testing.assert_close(out[plan_id].cpu(), gt, atol=ATOL, rtol=RTOL)
 
 
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("prefix_len", [0, 128, 256])
-@pytest.mark.parametrize("input_dtype", [torch.float32, torch.bfloat16])
-def test_prefill_then_decode(
-    mode: str, prefix_len: int, input_dtype: torch.dtype
-) -> None:
+def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
     """Prefill ``prefix_len`` tokens, then decode through to the next 128 boundary."""
     seq_len = prefix_len + RATIO  # one full compress chunk after prefix
 
@@ -158,8 +146,8 @@ def test_prefill_then_decode(
         _run_prefill(
             ctx,
             pool,
-            kv_full_cpu[:prefix_len].to(get_device(), dtype=input_dtype),
-            ape_cpu.to(get_device(), dtype=input_dtype),
+            kv_full_cpu[:prefix_len].to(get_device()),
+            ape_cpu.to(get_device()),
             seq_lens_cpu,
             extend_lens_cpu,
         )
@@ -170,37 +158,21 @@ def test_prefill_then_decode(
         seq_lens_gpu = torch.tensor(
             [cur_seq_len], dtype=torch.int64, device=get_device()
         )
-        kv_step = kv_full_cpu[prefix_len + k : prefix_len + k + 1].to(
-            get_device(), dtype=input_dtype
-        )
-        out = _run_decode(
-            ctx,
-            pool,
-            kv_step,
-            ape_cpu.to(get_device(), dtype=input_dtype),
-            seq_lens_gpu,
-        )
+        kv_step = kv_full_cpu[prefix_len + k : prefix_len + k + 1].to(get_device())
+        out = _run_decode(ctx, pool, kv_step, ape_cpu.to(get_device()), seq_lens_gpu)
         if cur_seq_len % RATIO == 0:
             final_out = out
 
     P = seq_len - 1
     gt = _gt_compress(kv_full_cpu, ape_cpu, P=P, head_dim=ctx.head_dim)
     assert final_out is not None
-    triton.testing.assert_close(
-        final_out[0].cpu(),
-        gt,
-        atol=precision[input_dtype],
-        rtol=precision[input_dtype],
-    )
+    triton.testing.assert_close(final_out[0].cpu(), gt, atol=ATOL, rtol=RTOL)
 
 
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("prefix_len", [128, 120, 256])
 @pytest.mark.parametrize("extend_len", [128, 256])
-@pytest.mark.parametrize("input_dtype", [torch.float32, torch.bfloat16])
-def test_prefill_then_extend(
-    mode: str, prefix_len: int, extend_len: int, input_dtype: torch.dtype
-) -> None:
+def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> None:
     """Prefill once, then a second prefill that extends across compress event(s).
 
     A prefix that is not a multiple of the ratio (e.g. 120) makes the first
@@ -224,8 +196,8 @@ def test_prefill_then_extend(
     _run_prefill(
         ctx,
         pool,
-        kv_full_cpu[:prefix_len].to(get_device(), dtype=input_dtype),
-        ape_cpu.to(get_device(), dtype=input_dtype),
+        kv_full_cpu[:prefix_len].to(get_device()),
+        ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,
     )
@@ -234,8 +206,8 @@ def test_prefill_then_extend(
     out = _run_prefill(
         ctx,
         pool,
-        kv_full_cpu[prefix_len:].to(get_device(), dtype=input_dtype),
-        ape_cpu.to(get_device(), dtype=input_dtype),
+        kv_full_cpu[prefix_len:].to(get_device()),
+        ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,
     )
@@ -245,11 +217,7 @@ def test_prefill_then_extend(
     for plan_id, P in enumerate(range(first_event, seq_len, RATIO)):
         gt = _gt_compress(kv_full_cpu, ape_cpu, P=P, head_dim=ctx.head_dim)
         triton.testing.assert_close(
-            out[plan_id].cpu(),
-            gt,
-            atol=precision[input_dtype],
-            rtol=precision[input_dtype],
-            err_msg=f"{plan_id=}, {P=}",
+            out[plan_id].cpu(), gt, atol=ATOL, rtol=RTOL, err_msg=f"{plan_id=}, {P=}"
         )
 
 
@@ -295,8 +263,8 @@ def test_prefill_multibatch(mode: str) -> None:
             triton.testing.assert_close(
                 out[plan_id].cpu(),
                 gt,
-                atol=precision[torch.float32],
-                rtol=precision[torch.float32],
+                atol=ATOL,
+                rtol=RTOL,
             )
             plan_id += 1
         base += ext

--- a/tests/test_c4_v2.py
+++ b/tests/test_c4_v2.py
@@ -23,10 +23,8 @@ Context = Union[LegacyContext, PagedContext]
 HEAD_DIM = 512
 RATIO = 4
 WINDOW = 8  # = 2 * RATIO (overlap + current)
-precision = {
-    torch.bfloat16: 2e-2,
-    torch.float32: 5e-3,
-}
+ATOL = 5e-3
+RTOL = 5e-3
 
 
 # -----------------------------------------------------------------------------
@@ -121,8 +119,7 @@ def _make_inputs(
 
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("seq_len", [4, 8, 32, 256, 1024])
-@pytest.mark.parametrize("input_dtype", [torch.float32, torch.bfloat16])
-def test_prefill_no_context(mode: str, seq_len: int, input_dtype: torch.dtype) -> None:
+def test_prefill_no_context(mode: str, seq_len: int) -> None:
     """Prefill once, no prefix. Every compress event must match fp64 GT."""
     if mode == "legacy":
         ctx: Context = make_legacy_context(
@@ -138,8 +135,8 @@ def test_prefill_no_context(mode: str, seq_len: int, input_dtype: torch.dtype) -
     out = _run_prefill(
         ctx,
         pool,
-        kv_in_cpu.to(get_device(), dtype=input_dtype),
-        ape_cpu.to(get_device(), dtype=input_dtype),
+        kv_in_cpu.to(get_device()),
+        ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,
     )
@@ -151,18 +148,15 @@ def test_prefill_no_context(mode: str, seq_len: int, input_dtype: torch.dtype) -
         triton.testing.assert_close(
             out[plan_id].cpu(),
             gt,
-            atol=precision[input_dtype],
-            rtol=precision[input_dtype],
+            atol=ATOL,
+            rtol=RTOL,
             err_msg=f"{plan_id=}, {P=} failed",
         )
 
 
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("prefix_len", [4, 256])
-@pytest.mark.parametrize("input_dtype", [torch.float32, torch.bfloat16])
-def test_prefill_then_decode(
-    mode: str, prefix_len: int, input_dtype: torch.dtype
-) -> None:
+def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
     """Prefill once, then decode 4 more tokens through one compress boundary."""
     extend_decode = 4
     seq_len = prefix_len + extend_decode
@@ -184,8 +178,8 @@ def test_prefill_then_decode(
     _run_prefill(
         ctx,
         pool,
-        kv_full_cpu[:prefix_len].to(get_device(), dtype=input_dtype),
-        ape_cpu.to(get_device(), dtype=input_dtype),
+        kv_full_cpu[:prefix_len].to(get_device()),
+        ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,
     )
@@ -197,16 +191,8 @@ def test_prefill_then_decode(
         seq_lens_gpu = torch.tensor(
             [cur_seq_len], dtype=torch.int64, device=get_device()
         )
-        kv_step = kv_full_cpu[prefix_len + k : prefix_len + k + 1].to(
-            get_device(), dtype=input_dtype
-        )
-        out = _run_decode(
-            ctx,
-            pool,
-            kv_step,
-            ape_cpu.to(get_device(), dtype=input_dtype),
-            seq_lens_gpu,
-        )
+        kv_step = kv_full_cpu[prefix_len + k : prefix_len + k + 1].to(get_device())
+        out = _run_decode(ctx, pool, kv_step, ape_cpu.to(get_device()), seq_lens_gpu)
         if cur_seq_len % RATIO == 0:
             final_out = out
 
@@ -214,18 +200,13 @@ def test_prefill_then_decode(
     P = seq_len - 1
     gt = _gt_compress(kv_full_cpu, ape_cpu, P=P, head_dim=ctx.head_dim)
     assert final_out is not None
-    triton.testing.assert_close(
-        final_out[0].cpu(), gt, atol=precision[input_dtype], rtol=precision[input_dtype]
-    )
+    triton.testing.assert_close(final_out[0].cpu(), gt, atol=ATOL, rtol=RTOL)
 
 
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("prefix_len", [256, 512, 768])
 @pytest.mark.parametrize("extend_len", [4, 32])
-@pytest.mark.parametrize("input_dtype", [torch.float32, torch.bfloat16])
-def test_prefill_then_extend(
-    mode: str, prefix_len: int, extend_len: int, input_dtype: torch.dtype
-) -> None:
+def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> None:
     """Prefill once, then prefill an extend that crosses one or more compress events.
 
     The first prefill ends at a swa_page boundary (only relevant for paged),
@@ -250,8 +231,8 @@ def test_prefill_then_extend(
     _run_prefill(
         ctx,
         pool,
-        kv_full_cpu[:prefix_len].to(get_device(), dtype=input_dtype),
-        ape_cpu.to(get_device(), dtype=input_dtype),
+        kv_full_cpu[:prefix_len].to(get_device()),
+        ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,
     )
@@ -261,8 +242,8 @@ def test_prefill_then_extend(
     out = _run_prefill(
         ctx,
         pool,
-        kv_full_cpu[prefix_len:].to(get_device(), dtype=input_dtype),
-        ape_cpu.to(get_device(), dtype=input_dtype),
+        kv_full_cpu[prefix_len:].to(get_device()),
+        ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,
     )
@@ -272,11 +253,7 @@ def test_prefill_then_extend(
     for plan_id, P in enumerate(range(first_event, seq_len, RATIO)):
         gt = _gt_compress(kv_full_cpu, ape_cpu, P=P, head_dim=ctx.head_dim)
         triton.testing.assert_close(
-            out[plan_id].cpu(),
-            gt,
-            atol=precision[input_dtype],
-            rtol=precision[input_dtype],
-            err_msg=f"{plan_id=}, {P=}",
+            out[plan_id].cpu(), gt, atol=ATOL, rtol=RTOL, err_msg=f"{plan_id=}, {P=}"
         )
 
 
@@ -326,8 +303,8 @@ def test_paged_buffer_intermediate() -> None:
             triton.testing.assert_close(
                 actual,
                 expected,
-                atol=precision[torch.float32],
-                rtol=precision[torch.float32],
+                atol=ATOL,
+                rtol=RTOL,
             )
 
 
@@ -373,8 +350,8 @@ def test_prefill_multibatch(mode: str) -> None:
             triton.testing.assert_close(
                 out[plan_id].cpu(),
                 gt,
-                atol=precision[torch.float32],
-                rtol=precision[torch.float32],
+                atol=ATOL,
+                rtol=RTOL,
             )
             plan_id += 1
         base += ext


### PR DESCRIPTION
### Motivation
Adds an SYCL implementation of `flash_compress4_prefill `and wires it through the C++/Torch extension so the Python API uses the native op instead of a Torch fallback implementation.

### Modifications
Register `flash_compress4_prefill `as an XPU op in the SYCL torch extension.
Add a new SYCL kernel implementation for `flash_compress4_prefill`.
Update the Python wrapper to call `torch.ops.sgl_kernel.flash_compress4_prefill`.

### Performance
The SYCL implementation significantly improves the performance of `flash_compress4_prefill `on XPU.
case | bs | num_q | num_compress | num_write | head_dim | dtype | sycl implementation time(us) | pure-PyTorch implementation time(us) | speedup (PyTorch/SYCL)
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
c4_prefill_seq4_hd512_f32_paged | 1 | 4 | 4 | 4 | 512 | f32 | 12.414 | 739.953 | 59.61x
c4_prefill_seq8_hd512_f32_paged | 1 | 8 | 8 | 8 | 512 | f32 | 14.000 | 1005.339 | 71.81x
c4_prefill_seq32_hd512_f32_paged | 1 | 32 | 32 | 32 | 512 | f32 | 13.989 | 2614.396 | 186.89x
c4_prefill_seq256_hd512_f32_paged | 1 | 256 | 256 | 256 | 512 | f32 | 17.265 | 17258.077 | 999.66x
c4_prefill_seq1024_hd512_f32_paged | 1 | 1024 | 1024 | 1024 | 512 | f32 | 42.960 | 67834.312 | 1578.55x
c4_prefill_seq4_hd512_bf16_paged | 1 | 4 | 4 | 4 | 512 | bf16 | 14.099 | 937.611 | 66.50x
c4_prefill_seq8_hd512_bf16_paged | 1 | 8 | 8 | 8 | 512 | bf16 | 15.371 | 1237.091 | 80.48x
c4_prefill_seq32_hd512_bf16_paged | 1 | 32 | 32 | 32 | 512 | bf16 | 15.472 | 2870.988 | 185.57x
c4_prefill_seq256_hd512_bf16_paged | 1 | 256 | 256 | 256 | 512 | bf16 | 16.898 | 17621.457 | 1042.82x
c4_prefill_seq1024_hd512_bf16_paged | 1 | 1024 | 1024 | 1024 | 512 | bf16 | 36.617 | 67593.838 | 1845.91x
c4_prefill_prefix256_ext4_f32_paged | 1 | 4 | 4 | 4 | 512 | f32 | 13.846 | 710.176 | 51.29x
c4_prefill_prefix256_ext4_bf16_paged | 1 | 4 | 4 | 4 | 512 | bf16 | 15.925 | 724.034 | 45.47x
c4_prefill_prefix256_ext32_f32_paged | 1 | 32 | 32 | 32 | 512 | f32 | 14.023 | 2583.112 | 184.20x
c4_prefill_prefix256_ext32_bf16_paged | 1 | 32 | 32 | 32 | 512 | bf16 | 15.706 | 2639.471 | 168.05x
c4_prefill_prefix512_ext4_f32_paged | 1 | 4 | 4 | 4 | 512 | f32 | 13.837 | 703.521 | 50.85x
c4_prefill_prefix512_ext4_bf16_paged | 1 | 4 | 4 | 4 | 512 | bf16 | 15.876 | 751.895 | 47.36x
c4_prefill_prefix512_ext32_f32_paged | 1 | 32 | 32 | 32 | 512 | f32 | 14.035 | 2920.775 | 208.10x
c4_prefill_prefix512_ext32_bf16_paged | 1 | 32 | 32 | 32 | 512 | bf16 | 15.736 | 2853.806 | 181.35x
c4_prefill_prefix768_ext4_f32_paged | 1 | 4 | 4 | 4 | 512 | f32 | 13.830 | 861.575 | 62.30x
c4_prefill_prefix768_ext4_bf16_paged | 1 | 4 | 4 | 4 | 512 | bf16 | 15.943 | 709.046 | 44.47x
c4_prefill_prefix768_ext32_f32_paged | 1 | 32 | 32 | 32 | 512 | f32 | 13.976 | 2587.092 | 185.11x
c4_prefill_prefix768_ext32_bf16_paged | 1 | 32 | 32 | 32 | 512 | bf16 | 15.711 | 2639.794 | 168.02x
c4_prefill_multibatch_hd512_f32_paged | 4 | 1547 | 1547 | 1547 | 512 | f32 | 59.353 | 106659.020 | 1797.03x
