### PR TITLE
tests: retry per-file timeout as an infra failure, not a real one

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,10 +19,17 @@ MAX_INFRA_RETRIES = int(os.environ.get("SGL_KERNEL_INFRA_RETRIES", "1"))
 # Wait for the GPU engine reset / L0 teardown to settle before retrying.
 _XPU_RECOVER_WAIT = float(os.environ.get("SGL_KERNEL_XPU_RECOVER_WAIT", "20"))
 
+# Longer wait after a hard timeout: a hung kernel leaves the L0 context and
+# engine in a worse state than a plain segfault, so give the driver more time
+# to tear it down before the retry starts allocating again.
+_XPU_TIMEOUT_RECOVER_WAIT = float(
+    os.environ.get("SGL_KERNEL_XPU_TIMEOUT_RECOVER_WAIT", "60")
+)
 
-def _recover_xpu() -> None:
+
+def _recover_xpu(wait: float = _XPU_RECOVER_WAIT) -> None:
     """Wait for the XPU to reset; log health via xpu-smi if available."""
-    time.sleep(_XPU_RECOVER_WAIT)
+    time.sleep(wait)
     try:
         subprocess.run(
             ["xpu-smi", "health", "-d", "0"],
@@ -112,6 +119,8 @@ def run_unittest_files(files: List[TestFile], timeout_per_file: float):
             return process.returncode
 
         # Negative return code = killed by signal (GPU fault); retry.
+        # TimeoutError = watchdog fired (likely XPU wedge); retry after a
+        # longer recovery wait.
         # Positive return code = real test failure; do not retry.
         crashed = False
         for attempt in range(MAX_INFRA_RETRIES + 1):
@@ -126,6 +135,16 @@ def run_unittest_files(files: List[TestFile], timeout_per_file: float):
                     f"\nTimeout after {timeout_per_file} seconds when running {filename}\n",
                     flush=True,
                 )
+                if attempt < MAX_INFRA_RETRIES:
+                    print(
+                        f"\n{filename} hit timeout (likely an XPU wedge). "
+                        f"Waiting {_XPU_TIMEOUT_RECOVER_WAIT:.0f}s for device "
+                        f"recovery, then retrying "
+                        f"(attempt {attempt + 1}/{MAX_INFRA_RETRIES}).\n",
+                        flush=True,
+                    )
+                    _recover_xpu(wait=_XPU_TIMEOUT_RECOVER_WAIT)
+                    continue
                 crashed = True
                 break
 


### PR DESCRIPTION
## Summary

The XPU CI harness already retries a test file whose child was **signal-killed** (SIGSEGV / SIGABRT — treated as a GPU/driver fault, not a test failure). It does **not** retry a file that trips the **per-file watchdog** (`timeout_per_file`, default 1800s). This PR puts `TimeoutError` on the same retry path.

## Motivation

Looking at recent failures on `pr-test-xpu.yml`, at least one PR (`port-inkling-attn-prologue-to-sglang-xpu-ops`, run `30972844174`) failed with:

```
Timeout after 1800 seconds when running test_biased_topk.py
Fail. Time elapsed: 1817.31s
##[error]Process completed with exit code 255.
```

`test_biased_topk.py` has an `estimated_time=60` and passes in ~10s normally. Re-running the same PR immediately after (run `30978959182`) went green with **zero code changes** — the same shape as the signal-kill flakes we already retry: an earlier file wedges the L0 context or leaks the XPU engine, and the next unrelated file waits on the device until the watchdog fires.

## Change

- Add a retry branch for `TimeoutError` inside `run_unittest_files`, gated on `MAX_INFRA_RETRIES` (already env-controlled via `SGL_KERNEL_INFRA_RETRIES`, defaults to 1). At most 2 total attempts per file.
- Only the timeout branch and the existing signal-kill branch retry. A **positive** pytest exit code (assertion failure, exit 4 "no tests collected", exit 2 usage error) still fails on the first attempt — real bugs don't burn CI on futile retries.
- Give the timeout path its own recovery wait (`_XPU_TIMEOUT_RECOVER_WAIT`, default 60s) because a hung-then-killed kernel needs longer to fully release the L0 context and reset the engine than a plain segfault (20s). Tunable via `SGL_KERNEL_XPU_TIMEOUT_RECOVER_WAIT` without a code change.

## Cost / risk

- Happy path: **0 added time**.
- Real test-assertion failure: **0 added time** (positive exit code doesn't retry).
- Actual timeout flake: one extra `timeout_per_file` per hung file, plus 60s of recovery wait. Only paid when a file actually hangs.
- No new deps, no behaviour change outside the timeout branch.

## Test plan

- [ ] Green on this repo's own PR CI (which exercises `run_suite.py --suite per-commit`).
- [ ] Manually verify the retry path fires by setting `--timeout-per-file=1` locally — expect one recovery log + one retry attempt, then a final "still hung" failure.
- [ ] Confirm `SGL_KERNEL_INFRA_RETRIES=0` disables both retry paths (signal-kill and timeout) as before.