### PR TITLE
[Attn] fix SLM overflow for decode

### DIFF
--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_fp8_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_fp8_kernel.cpp.in
@@ -19,7 +19,12 @@ __attribute__((visibility("default"))) void FmhaDecodeFp8Runner<@QG_SZ@, @HEAD_D
   using TileShapeQK = cute::Shape<cute::Int<@QG_SZ@>, cute::Int<@PAGE_SIZE@>, cute::_64>;
   using TileShapePV = cute::Shape<cute::Int<@QG_SZ@>, cute::_32, cute::Int<@PAGE_SIZE@>>;
   using TileShapeOutput = cute::Shape<cute::Int<@QG_SZ@>, cute::Int<((@HEAD_DIM@ + 31) / 32) * 32>>;
-  using SubgroupLayoutQK = cute::Layout<cute::Shape<cute::_1, cute::Int<@PAGE_SIZE@ / 16>, cute::_1>>;
+  // Cap KV subgroups so the epilogue cross-subgroup reduction buffer fits in shared
+  // local memory (see kv_subgroups_for_slm); the full PAGE_SIZE/16 split overflows SLM
+  // for large head dims / GQA groups / page sizes and hangs the device.
+  static constexpr int kKvSubgroups = kv_subgroups_for_slm(
+      @PAGE_SIZE@ / 16, @QG_SZ@, ((@HEAD_DIM@ + 31) / 32) * 32);
+  using SubgroupLayoutQK = cute::Layout<cute::Shape<cute::_1, cute::Int<kKvSubgroups>, cute::_1>>;
 
   // FP8 KV cache: Q is bf16 or fp16 while K/V cache are fp8 (e4m3 or e5m2); the
   // mainloop dequantizes K/V with the per-tensor k/v descale. Sink logits are

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_kernel.cpp.in
@@ -46,7 +46,12 @@ __attribute__((visibility("default"))) void FmhaDecodeRunner<@QG_SZ@, @HEAD_DIM@
   // HEAD_DIM is not a multiple of 32 (e.g. HEAD_DIM=72 -> 96, VTiles=3). The actual O surface is
   // bounded by head_size_vo, so HW clips the OOB tail writes in the epilogue.
   using TileShapeOutput = cute::Shape<cute::Int<@QG_SZ@>, cute::Int<((@HEAD_DIM@ + 31) / 32) * 32>>;
-  using SubgroupLayoutQK = cute::Layout<cute::Shape<cute::_1, cute::Int<@PAGE_SIZE@ / 16>, cute::_1>>;
+  // Split the KV (page) tile across as many subgroups as fit the epilogue reduction
+  // SLM budget. For large head dims / GQA groups / page sizes the full split
+  // (PAGE_SIZE / 16) overflows shared local memory and hangs the device, so cap it.
+  static constexpr int kKvSubgroups = kv_subgroups_for_slm(
+      @PAGE_SIZE@ / 16, @QG_SZ@, ((@HEAD_DIM@ + 31) / 32) * 32);
+  using SubgroupLayoutQK = cute::Layout<cute::Shape<cute::_1, cute::Int<kKvSubgroups>, cute::_1>>;
 
 #if @HEAD_DIM@ == 64
     AT_DISPATCH_BOOL_NO_RETURN(params.use_sink, Sink, {

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_nopage_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_nopage_kernel.cpp.in
@@ -54,7 +54,12 @@ __attribute__((visibility("default"))) void FmhaDecodeNpRunner<@QG_SZ@, @HEAD_DI
   using TileShapeQK_NP = cute::Shape<cute::Int<@QG_SZ@>, cute::Int<@TILED_KV_NP@>, cute::_64>;
   using TileShapePV_NP = cute::Shape<cute::Int<@QG_SZ@>, cute::_32, cute::Int<@TILED_KV_NP@>>;
   using TileShapeOutput_NP = cute::Shape<cute::Int<@QG_SZ@>, cute::Int<((@HEAD_DIM@ + 31) / 32) * 32>>;
-  using SubgroupLayoutQK_NP = cute::Layout<cute::Shape<cute::_1, cute::Int<@TILED_KV_NP@ / 16>, cute::_1>>;
+  // Cap KV subgroups so the epilogue cross-subgroup reduction buffer fits in shared
+  // local memory (see kv_subgroups_for_slm); the full TILED_KV_NP/16 split overflows SLM
+  // for large head dims / GQA groups / KV tiles and hangs the device.
+  static constexpr int kKvSubgroups_NP = kv_subgroups_for_slm(
+      @TILED_KV_NP@ / 16, @QG_SZ@, ((@HEAD_DIM@ + 31) / 32) * 32);
+  using SubgroupLayoutQK_NP = cute::Layout<cute::Shape<cute::_1, cute::Int<kKvSubgroups_NP>, cute::_1>>;
   // No sink support for no_page path; always use Sink=false
   AT_DISPATCH_BOOL_NO_RETURN(params.is_local, LocalMask, {
     using Element = bfloat16_t;

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
@@ -49,6 +49,15 @@
 using namespace cute;
 namespace decode {
 
+// Device shared-local-memory budget in bytes, keyed to the target Xe arch.
+#if SYCL_INTEL_TARGET == 20
+constexpr int slm_byte_budget = 128 * 1024;  // Xe20: 128 KiB SLM
+#elif SYCL_INTEL_TARGET == 35
+constexpr int slm_byte_budget = 384 * 1024;  // Xe35: 384 KiB SLM
+#else
+#error "Unsupported SYCL_INTEL_TARGET for decode SLM budget"
+#endif
+
 // Number of subgroups the KV (page) tile is split across, capped so the epilogue
 // cross-subgroup reduction buffer fits in shared local memory.
 //
@@ -61,11 +70,16 @@ namespace decode {
 // PAGE_SIZE=128 -> 132 KiB). Reducing the subgroup count keeps the buffer within
 // budget; it only lowers KV parallelism and does not affect correctness.
 //
+// This mirrors the epilogue's SLM layout by hand; the DecodeRunner/
+// SplitDecodeKernelRunner run() paths add a static_assert on the fully
+// instantiated kernel's real SharedStorageSize as a compile-time backstop in
+// case that layout ever diverges from this formula.
+//
 // full_kv_subgroups (= PAGE_SIZE / 16) is always a power of two, so the returned
 // value is the largest power-of-two divisor that fits the budget (>= 1).
 constexpr int kv_subgroups_for_slm(int full_kv_subgroups, int qg, int head_dim_rounded) {
-  constexpr int slm_float_budget = (128 * 1024) / static_cast<int>(sizeof(float));
-  const int aligned_qg = ((qg + 15) / 16) * 16;
+  constexpr int slm_float_budget = slm_byte_budget / static_cast<int>(sizeof(float));
+  const int aligned_qg = ((qg + intel::sg_size - 1) / intel::sg_size) * intel::sg_size;
   const int floats_per_subgroup = qg * head_dim_rounded + 2 * aligned_qg;
   const int max_subgroups = slm_float_budget / floats_per_subgroup;
   int sg = full_kv_subgroups;
@@ -333,6 +347,10 @@ struct DecodeRunner {
   }
 
   cutlass::Status run(const Arguments& params, const cutlass::KernelHardwareInfo& hw_info) {
+    static_assert(
+        FMHADecodeKernel::SharedStorageSize <= slm_byte_budget,
+        "Decode kernel SharedStorage exceeds the device SLM budget; lower the KV "
+        "subgroup split (see kv_subgroups_for_slm).");
     ProblemShapeType shape = initialize(params);
 
     typename FMHADecodeKernel::Arguments arguments{
@@ -496,6 +514,10 @@ struct SplitDecodeKernelRunner {
   }
 
   cutlass::Status run(const Arguments& params, const cutlass::KernelHardwareInfo& hw_info) {
+    static_assert(
+        FMHAKernel::SharedStorageSize <= slm_byte_budget && ReductionSplitKernel::SharedStorageSize <= slm_byte_budget,
+        "Split-decode kernel SharedStorage exceeds the device SLM budget; lower the "
+        "KV subgroup split (see kv_subgroups_for_slm).");
     ProblemShapeType shape = initialize(params);
 
     typename FMHAKernel::Arguments arguments{

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
@@ -48,6 +48,33 @@
 #include "sycl/kernels/flash_attention_v2/kernel/xe_tile_scheduler.hpp"
 using namespace cute;
 namespace decode {
+
+// Number of subgroups the KV (page) tile is split across, capped so the epilogue
+// cross-subgroup reduction buffer fits in shared local memory.
+//
+// The reduction path (FMHAFwdEpilogue::SharedStorageReduceK) allocates
+//   num_sg * (qg * head_dim_rounded + 2 * aligned_qg) floats
+// of SLM (each of the num_sg subgroups stores its full partial O tile plus a
+// padded row of running sum/max). For large head dims combined with large GQA
+// query groups and large page sizes this exceeds the device SLM budget (128 KiB),
+// which hangs the device instead of failing cleanly (e.g. HEAD_DIM=512, qg=8,
+// PAGE_SIZE=128 -> 132 KiB). Reducing the subgroup count keeps the buffer within
+// budget; it only lowers KV parallelism and does not affect correctness.
+//
+// full_kv_subgroups (= PAGE_SIZE / 16) is always a power of two, so the returned
+// value is the largest power-of-two divisor that fits the budget (>= 1).
+constexpr int kv_subgroups_for_slm(int full_kv_subgroups, int qg, int head_dim_rounded) {
+  constexpr int slm_float_budget = (128 * 1024) / static_cast<int>(sizeof(float));
+  const int aligned_qg = ((qg + 15) / 16) * 16;
+  const int floats_per_subgroup = qg * head_dim_rounded + 2 * aligned_qg;
+  const int max_subgroups = slm_float_budget / floats_per_subgroup;
+  int sg = full_kv_subgroups;
+  while (sg > 1 && sg > max_subgroups) {
+    sg /= 2;
+  }
+  return sg < 1 ? 1 : sg;
+}
+
 struct Arguments {
   // The QKV matrices.
   void* __restrict__ q_ptr;

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_split_decode_fp8_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_split_decode_fp8_kernel.cpp.in
@@ -20,7 +20,12 @@ __attribute__((visibility("default"))) void FmhaSplitDecodeFp8Runner<@QG_SZ@, @H
   using TileShapeQK = cute::Shape<cute::Int<@QG_SZ@>, cute::Int<@PAGE_SIZE@>, cute::_64>;
   using TileShapePV = cute::Shape<cute::Int<@QG_SZ@>, cute::_32, cute::Int<@PAGE_SIZE@>>;
   using TileShapeOutput = cute::Shape<cute::Int<@QG_SZ@>, cute::Int<((@HEAD_DIM@ + 31) / 32) * 32>>;
-  using SubgroupLayoutQK = cute::Layout<cute::Shape<cute::_1, cute::Int<@PAGE_SIZE@ / 16>, cute::_1>>;
+  // Cap KV subgroups so the epilogue cross-subgroup reduction buffer fits in shared
+  // local memory (see kv_subgroups_for_slm); the full PAGE_SIZE/16 split overflows SLM
+  // for large head dims / GQA groups / page sizes and hangs the device.
+  static constexpr int kKvSubgroups = kv_subgroups_for_slm(
+      @PAGE_SIZE@ / 16, @QG_SZ@, ((@HEAD_DIM@ + 31) / 32) * 32);
+  using SubgroupLayoutQK = cute::Layout<cute::Shape<cute::_1, cute::Int<kKvSubgroups>, cute::_1>>;
 
   // FP8 KV cache: Q is bf16 or fp16 while K/V cache are fp8 (e4m3 or e5m2); the
   // split-KV mainloop dequantizes K/V with the per-tensor k/v descale. Sink

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_split_decode_kernel.cpp.in
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_split_decode_kernel.cpp.in
@@ -46,7 +46,12 @@ __attribute__((visibility("default"))) void FmhaSplitDecodeRunner<@QG_SZ@, @HEAD
   // HEAD_DIM is not a multiple of 32 (e.g. HEAD_DIM=72 -> 96, VTiles=3). The actual O surface is
   // bounded by head_size_vo, so HW clips the OOB tail writes in the epilogue.
   using TileShapeOutput = cute::Shape<cute::Int<@QG_SZ@>, cute::Int<((@HEAD_DIM@ + 31) / 32) * 32>>;
-  using SubgroupLayoutQK = cute::Layout<cute::Shape<cute::_1, cute::Int<@PAGE_SIZE@ / 16>, cute::_1>>;
+  // Cap KV subgroups so the epilogue cross-subgroup reduction buffer fits in shared
+  // local memory (see kv_subgroups_for_slm); the full PAGE_SIZE/16 split overflows SLM
+  // for large head dims / GQA groups / page sizes and hangs the device.
+  static constexpr int kKvSubgroups = kv_subgroups_for_slm(
+      @PAGE_SIZE@ / 16, @QG_SZ@, ((@HEAD_DIM@ + 31) / 32) * 32);
+  using SubgroupLayoutQK = cute::Layout<cute::Shape<cute::_1, cute::Int<kKvSubgroups>, cute::_1>>;
 
 #if @HEAD_DIM@ == 64
     AT_DISPATCH_BOOL_NO_RETURN(params.use_sink, Sink, {

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -974,7 +974,7 @@ def test_flash_attn_kvcache(
 @pytest.mark.parametrize(
     "dtype", [torch.bfloat16] + ([torch.float8_e4m3fn] if not DISABLE_FP8 else [])
 )
-@pytest.mark.parametrize("nheads_q,nheads_kv", [(16, 16), (16, 4)])
+@pytest.mark.parametrize("nheads_q,nheads_kv", [(16, 16), (16, 4), (16, 2)])
 @pytest.mark.parametrize("new_kv", [False])
 @pytest.mark.parametrize("causal", [False])
 @pytest.mark.parametrize("local", [True, False])

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -974,7 +974,7 @@ def test_flash_attn_kvcache(
 @pytest.mark.parametrize(
     "dtype", [torch.bfloat16] + ([torch.float8_e4m3fn] if not DISABLE_FP8 else [])
 )
-@pytest.mark.parametrize("nheads_q,nheads_kv", [(16, 16), (16, 4), (16, 2)])
+@pytest.mark.parametrize("nheads_q,nheads_kv", [(16, 16), (16, 4), (16, 1)])
 @pytest.mark.parametrize("new_kv", [False])
 @pytest.mark.parametrize("causal", [False])
 @pytest.mark.parametrize("local", [True, False])
@@ -1636,7 +1636,7 @@ def _generate_block_kvcache(
 @pytest.mark.parametrize(
     "dtype", [torch.bfloat16] + ([torch.float8_e4m3fn] if not DISABLE_FP8 else [])
 )
-@pytest.mark.parametrize("nheads_q,nheads_kv", [(16, 16), (16, 4)])
+@pytest.mark.parametrize("nheads_q,nheads_kv", [(16, 16), (16, 4), (16, 1)])
 @pytest.mark.parametrize("has_qv", [False])
 @pytest.mark.parametrize("deterministic", [False])
 @pytest.mark.parametrize("softcap", [0.0] + ([15.0] if not DISABLE_SOFTCAP else []))


### PR DESCRIPTION
Control the subgroup size to avoid SLM overflow.
Fix `UR_RESULT_ERROR_OUT_OF_RESOURCES` in https://jira.devtools.intel.com/browse/SGLANGT-1476.