### PR TITLE
added profiling flag in RelWithDebugInfo mode

### DIFF
--- a/cmake/BuildFlags.cmake
+++ b/cmake/BuildFlags.cmake
@@ -24,6 +24,7 @@ endfunction()
 
 # Support GCC on Linux.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  message(STATUS "sgl-kernel-xpu build type: ${CMAKE_BUILD_TYPE}")
   set(SYCL_HOST_FLAGS)
   set(SYCL_KERNEL_OPTIONS)
   set(SYCL_COMPILE_FLAGS ${SYCL_FLAGS})
@@ -88,7 +89,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   if(CMAKE_BUILD_TYPE MATCHES Debug)
     set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -g -O0 -Rno-debug-disables-optimization)
   elseif(CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
-    set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -gline-tables-only -O2)
+    set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -g -fdebug-info-for-profiling -O2)
   endif()
 
   set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -D__INTEL_LLVM_COMPILER_VERSION=${__INTEL_LLVM_COMPILER})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,8 @@ file(GLOB host_cpp "./*.cpp" "./*.cc")
 # keep them out of the build.
 if(NOT USE_FMHA)
     list(FILTER device_cpp EXCLUDE REGEX "/flash_attention\\.cpp$")
+    # GDN (Gated DeltaNet) attention shares the USE_FMHA toggle to skip its heavy Xe20 build.
+    list(FILTER device_cpp EXCLUDE REGEX "/gdn_attention_Xe20\\.cpp$")
 endif()
 if(NOT USE_MLA)
     list(FILTER device_cpp EXCLUDE REGEX "/mla_(decode|prefill|sparse_decode)\\.cpp$")
@@ -88,12 +90,12 @@ foreach(file ${device_cpp})
 
 endforeach()
 
-include(GdnAttnXe20.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/SGEMMLoraAFwdXe20.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/SGEMMLoraBFwdXe20.cmake)
 if(USE_FMHA)
     include(FMHADecodeXe20.cmake)
     include(FMHAPrefillXe20.cmake)
+    include(GdnAttnXe20.cmake)
 endif()
 if(USE_MLA)
     include(MlaDecodeXe20.cmake)

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -495,6 +495,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   /*
    * From GDN (Gated DeltaNet) attention (Intel Xe2)
    */
+#ifdef USE_FMHA
   m.def(
       "gdn_attention(Tensor! core_attn_out, Tensor! z, Tensor projected_states_qkvz, Tensor projected_states_ba, "
       "int num_k_heads, int num_v_heads, int head_k_dim, int head_v_dim, "
@@ -512,6 +513,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "ScalarType dtype) -> int");
   m.impl(
       "gdn_attention_workspace_bytes_needed", c10::DispatchKey::BackendSelect, &gdn_attention_workspace_bytes_needed);
+#endif  // USE_FMHA
 
   /*
    * Mamba causal conv1d (XPU)


### PR DESCRIPTION
- Enable device side profiling with RelWithDebugInfo mode
- add the GDNAttn under the `USE_FMHA` flag to skip build on Xe20 when the flag is enabled.