### PR TITLE
Relax the data type requirements for W4A16 MoE input weights and scales

### DIFF
--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -690,7 +690,7 @@ void moe_grouped_mm_nt_xe20(
     double gemm1_limit = 7.0);
 
 // Unified int4/mxfp4 W4A16 MoE grouped GEMM.
-// `packed_weights` is int8 [E, N, K/2] with two 4-bit values per byte.
+// `packed_weights` is int8 or uint8 [E, N, K/2] with two 4-bit values per byte.
 // `scales` is [E, N, K/group_size], N-outer: activation-dtype direct
 // multiplier for int4, or an E8M0 exponent represented as uint8 or
 // float8_e8m0fnu for mxfp4 (decoded in registers). `zeros` is an optional

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -691,9 +691,10 @@ void moe_grouped_mm_nt_xe20(
 
 // Unified int4/mxfp4 W4A16 MoE grouped GEMM.
 // `packed_weights` is int8 [E, N, K/2] with two 4-bit values per byte.
-// `scales` is [E, N, K/group_size], N-outer: bfloat16 direct multiplier for
-// int4, or uint8 E8M0 exponent for mxfp4 (decoded in registers). `zeros` is
-// an optional [E, N, K/group_size] bfloat16 tensor (int4-only) holding the
+// `scales` is [E, N, K/group_size], N-outer: activation-dtype direct
+// multiplier for int4, or an E8M0 exponent represented as uint8 or
+// float8_e8m0fnu for mxfp4 (decoded in registers). `zeros` is an optional
+// [E, N, K/group_size] activation-dtype tensor (int4-only) holding the
 // raw per-group zero-point in code units; when supplied, weights dequant as
 // `(code - zp) * scale` instead of requiring the zero-point to be pre-folded
 // into a signed 4-bit code (which overflows for non-symmetric zero-points).

--- a/python/sgl_kernel/moe.py
+++ b/python/sgl_kernel/moe.py
@@ -445,7 +445,7 @@ def fused_experts(
     - use_fp8_w8a8 (bool): If True, use fp8 arithmetic to compute the inner
         products for w1 and w2. Defaults to False.
     - use_mxfp4_w4a16 (bool): If True, w1 and w2 are in MXFP4 packed format
-        (int8, two E2M1 nibbles per byte) with corresponding E8M0 block
+        (int8 or uint8, two E2M1 nibbles per byte) with corresponding E8M0 block
         scales supplied via w1_scale and w2_scale. Scales may be represented
         as uint8 exponent bytes or torch.float8_e8m0fnu.
         Routes through moe_grouped_mm_nt_xe20_w4a16, which dequantizes B
@@ -453,7 +453,7 @@ def fused_experts(
         activations — no dequantized weight tensor is materialized on device.
         Defaults to False.
     - use_int4_w4a16 (bool): If True, w1 and w2 are in INT4 packed format
-        (int8, two 4-bit values per byte) with BF16 or FP16 block scales
+        (int8 or uint8, two 4-bit values per byte) with BF16 or FP16 block scales
         (direct multiplier) matching hidden_states.dtype, supplied via
         w1_scale and w2_scale. Zero-points are optional and, if the checkpoint
         has them, must be supplied raw (unfolded) via w1_zp/w2_zp -- see below. Shares the
@@ -512,7 +512,7 @@ def fused_experts(
         "relu2",
     ), f"Only silu, gelu and relu2 are supported but got {activation}"
 
-    # Unified 4-bit W4A16 MoE (mxfp4 or int4). Weights are packed int8
+    # Unified 4-bit W4A16 MoE (mxfp4 or int4). Weights are packed int8/uint8
     # [E, N, K/2]; scales are [E, N, K/group_size] N-outer. For mxfp4 the
     # scale is an E8M0 byte (uint8 or float8_e8m0fnu); for int4 it is a direct multiplier
     # with the same dtype as hidden_states. int4 may optionally carry an explicit per-group
@@ -527,11 +527,11 @@ def fused_experts(
     ), "use_mxfp4_w4a16 and use_int4_w4a16 are mutually exclusive"
     if use_4bit_w4a16:
         assert (
-            w1.dtype == torch.int8
-        ), "4-bit W4A16 requires w1 to be int8 (packed [E, N, K/2])"
+            w1.dtype == torch.int8 or w1.dtype == torch.uint8
+        ), "4-bit W4A16 requires w1 to be int8 or uint8 (packed [E, N, K/2])"
         assert (
-            w2.dtype == torch.int8
-        ), "4-bit W4A16 requires w2 to be int8 (packed [E, N, K/2])"
+            w2.dtype == torch.int8 or w2.dtype == torch.uint8
+        ), "4-bit W4A16 requires w2 to be int8 or uint8 (packed [E, N, K/2])"
         assert w1_scale is not None, "w1_scale must be provided for 4-bit W4A16"
         assert w2_scale is not None, "w2_scale must be provided for 4-bit W4A16"
         if use_mxfp4_w4a16:

--- a/python/sgl_kernel/moe.py
+++ b/python/sgl_kernel/moe.py
@@ -445,8 +445,9 @@ def fused_experts(
     - use_fp8_w8a8 (bool): If True, use fp8 arithmetic to compute the inner
         products for w1 and w2. Defaults to False.
     - use_mxfp4_w4a16 (bool): If True, w1 and w2 are in MXFP4 packed format
-        (int8, two E2M1 nibbles per byte) with corresponding uint8 E8M0
-        block scales supplied via w1_scale and w2_scale.
+        (int8, two E2M1 nibbles per byte) with corresponding E8M0 block
+        scales supplied via w1_scale and w2_scale. Scales may be represented
+        as uint8 exponent bytes or torch.float8_e8m0fnu.
         Routes through moe_grouped_mm_nt_xe20_w4a16, which dequantizes B
         per-tile in registers and feeds W4A16 DPAS with BF16 or FP16
         activations — no dequantized weight tensor is materialized on device.
@@ -513,7 +514,7 @@ def fused_experts(
 
     # Unified 4-bit W4A16 MoE (mxfp4 or int4). Weights are packed int8
     # [E, N, K/2]; scales are [E, N, K/group_size] N-outer. For mxfp4 the
-    # scale is a uint8 E8M0 exponent; for int4 it is a direct multiplier
+    # scale is an E8M0 byte (uint8 or float8_e8m0fnu); for int4 it is a direct multiplier
     # with the same dtype as hidden_states. int4 may optionally carry an explicit per-group
     # zero-point (w1_zp/w2_zp, same shape/dtype as the scale) applied as
     # `(code - zp) * scale` in-kernel -- this is NOT folded into the packed
@@ -534,9 +535,11 @@ def fused_experts(
         assert w1_scale is not None, "w1_scale must be provided for 4-bit W4A16"
         assert w2_scale is not None, "w2_scale must be provided for 4-bit W4A16"
         if use_mxfp4_w4a16:
+            mxfp4_scale_dtypes = (torch.uint8, torch.float8_e8m0fnu)
             assert (
-                w1_scale.dtype == torch.uint8 and w2_scale.dtype == torch.uint8
-            ), "mxfp4 scales must be uint8 (E8M0 exponent)"
+                w1_scale.dtype in mxfp4_scale_dtypes
+                and w2_scale.dtype in mxfp4_scale_dtypes
+            ), "mxfp4 scales must be uint8 or float8_e8m0fnu (E8M0 exponent)"
             assert (
                 w1_zp is None and w2_zp is None
             ), "w1_zp/w2_zp are not supported for use_mxfp4_w4a16 (mxfp4 has no zero-point)"

--- a/src/GroupGemmW4A16Xe20.cmake
+++ b/src/GroupGemmW4A16Xe20.cmake
@@ -4,7 +4,8 @@ set(GROUP_GEMM_W4A16_XE20_INST_SRCS)
 file(MAKE_DIRECTORY ${GROUP_GEMM_W4A16_XE20_GEN_DIR})
 
 # Generate one translation unit per (policy, ElementS, ElementA) combo.
-# For int4, ELEMENT_S matches ELEMENT_A; for mxfp4 it is uint8_t (E8M0).
+# For int4, ELEMENT_S matches ELEMENT_A. For mxfp4, both accepted tensor
+# dtypes share the same E8M0 byte encoding, which the kernel reads as uint8_t.
 function(add_group_gemm_w4a16_xe20_inst POLICY ELEMENT_S ELEMENT_A SANITIZED)
     set(GEN_SRC
         "${GROUP_GEMM_W4A16_XE20_GEN_DIR}/GroupGemmW4A16Xe20_inst_${POLICY}_${SANITIZED}.cpp")
@@ -30,7 +31,7 @@ foreach(policy w4a16_policy_m_8 w4a16_policy_m_16 w4a16_policy_m_32 w4a16_policy
         endif()
         # int4: scale and activation use the same dtype.
         add_group_gemm_w4a16_xe20_inst(${policy} "${element_a}" "${element_a}" "int4_${act_tag}")
-        # mxfp4: scale is a uint8 E8M0 exponent.
+        # mxfp4: read the raw E8M0 byte from uint8 or float8_e8m0fnu tensors.
         add_group_gemm_w4a16_xe20_inst(${policy} "uint8_t" "${element_a}" "mxfp4_${act_tag}")
     endforeach()
 endforeach()

--- a/src/sycl/GroupGemmW4A16Xe20.cpp
+++ b/src/sycl/GroupGemmW4A16Xe20.cpp
@@ -92,7 +92,7 @@ DECLARE_W4A16_POLICY(w4a16_policy)
 SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
     torch::Tensor& output,                   // [total_m, N] bf16/fp16
     const torch::Tensor& activations,        // [total_m, K] bf16 or fp16
-    const torch::Tensor& packed_weights,     // [E, N, K/2] int8 (two 4-bit values per byte)
+    const torch::Tensor& packed_weights,     // [E, N, K/2] int8/uint8 (two 4-bit values per byte)
     const torch::Tensor& scales,             // [E, N, K/group_size]: int4=activation dtype, mxfp4=E8M0 byte
     const std::optional<at::Tensor>& zeros,  // [E, N, K/group_size], same dtype as int4 scales, optional
     const std::optional<at::Tensor>& bias,   // [E, N] float32, optional
@@ -133,7 +133,10 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
   const int gemm_n = pw_shape[1];
   TORCH_CHECK(pw_shape[0] == n_experts, "packed_weights.size(0) must equal n_experts");
   TORCH_CHECK(pw_shape[2] == gemm_k / 2, "packed_weights.size(2) must equal K/2 (two 4-bit values per byte)");
-  TORCH_CHECK(packed_weights.scalar_type() == at::ScalarType::Char, "packed_weights must be int8");
+  TORCH_CHECK(
+      packed_weights.scalar_type() == at::ScalarType::Char ||
+          packed_weights.scalar_type() == at::ScalarType::Byte,
+      "packed_weights must be int8 or uint8");
 
   TORCH_CHECK(
       group_size == 32 || group_size == 64 || group_size == 128 || group_size == 256,

--- a/src/sycl/GroupGemmW4A16Xe20.cpp
+++ b/src/sycl/GroupGemmW4A16Xe20.cpp
@@ -93,7 +93,7 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
     torch::Tensor& output,                   // [total_m, N] bf16/fp16
     const torch::Tensor& activations,        // [total_m, K] bf16 or fp16
     const torch::Tensor& packed_weights,     // [E, N, K/2] int8 (two 4-bit values per byte)
-    const torch::Tensor& scales,             // [E, N, K/group_size]: int4=activation dtype, mxfp4=uint8
+    const torch::Tensor& scales,             // [E, N, K/group_size]: int4=activation dtype, mxfp4=E8M0 byte
     const std::optional<at::Tensor>& zeros,  // [E, N, K/group_size], same dtype as int4 scales, optional
     const std::optional<at::Tensor>& bias,   // [E, N] float32, optional
     const torch::Tensor& rows_per_expert,    // [E] int32 per-expert row counts
@@ -149,7 +149,10 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
   if (is_int4) {
     TORCH_CHECK(scales.scalar_type() == activations.scalar_type(), "int4 scales dtype must match activations dtype");
   } else {
-    TORCH_CHECK(scales.scalar_type() == at::ScalarType::Byte, "mxfp4 scales must be uint8 (E8M0 exponent)");
+    TORCH_CHECK(
+        scales.scalar_type() == at::ScalarType::Byte ||
+            scales.scalar_type() == at::ScalarType::Float8_e8m0fnu,
+        "mxfp4 scales must be uint8 or float8_e8m0fnu (E8M0 exponent)");
   }
 
   TORCH_CHECK(n_experts > 0, "n_experts must be positive");

--- a/src/sycl/GroupGemmW4A16Xe20.cpp
+++ b/src/sycl/GroupGemmW4A16Xe20.cpp
@@ -134,8 +134,7 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
   TORCH_CHECK(pw_shape[0] == n_experts, "packed_weights.size(0) must equal n_experts");
   TORCH_CHECK(pw_shape[2] == gemm_k / 2, "packed_weights.size(2) must equal K/2 (two 4-bit values per byte)");
   TORCH_CHECK(
-      packed_weights.scalar_type() == at::ScalarType::Char ||
-          packed_weights.scalar_type() == at::ScalarType::Byte,
+      packed_weights.scalar_type() == at::ScalarType::Char || packed_weights.scalar_type() == at::ScalarType::Byte,
       "packed_weights must be int8 or uint8");
 
   TORCH_CHECK(
@@ -153,8 +152,7 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
     TORCH_CHECK(scales.scalar_type() == activations.scalar_type(), "int4 scales dtype must match activations dtype");
   } else {
     TORCH_CHECK(
-        scales.scalar_type() == at::ScalarType::Byte ||
-            scales.scalar_type() == at::ScalarType::Float8_e8m0fnu,
+        scales.scalar_type() == at::ScalarType::Byte || scales.scalar_type() == at::ScalarType::Float8_e8m0fnu,
         "mxfp4 scales must be uint8 or float8_e8m0fnu (E8M0 exponent)");
   }
 

--- a/tests/test_fused_experts_mxfp4_dsv4_shapes.py
+++ b/tests/test_fused_experts_mxfp4_dsv4_shapes.py
@@ -48,7 +48,9 @@ def _torch_mxfp4_moe_reference(
     for expert in flat_ids.unique().cpu().tolist():
         mask = flat_ids == expert
         expert_w1 = dequantize_mxfp4_2d(
-            w1_packed[expert], w1_scale[expert], dtype=hidden_states.dtype
+            w1_packed[expert],
+            w1_scale[expert].view(torch.uint8),
+            dtype=hidden_states.dtype,
         )
         gate_up = routed_inputs[mask] @ expert_w1.transpose(0, 1)
         del expert_w1
@@ -62,7 +64,9 @@ def _torch_mxfp4_moe_reference(
             intermediate = F.silu(gate) * up
 
         expert_w2 = dequantize_mxfp4_2d(
-            w2_packed[expert], w2_scale[expert], dtype=hidden_states.dtype
+            w2_packed[expert],
+            w2_scale[expert].view(torch.uint8),
+            dtype=hidden_states.dtype,
         )
         routed_outputs[mask] = intermediate @ expert_w2.transpose(0, 1)
         del expert_w2
@@ -128,8 +132,8 @@ def test_fused_experts_dsv4_shape(
       x.shape                 = [47, 4096]       bfloat16
       w13_weight.shape        = [256, 512, 2048] int8   (E, 2*I, H/2)
       w2_weight.shape         = [256, 4096, 128] int8   (E, H, I/2)
-      w13_weight_scale        = [256, 512, 128]  uint8 E8M0
-      w2_weight_scale         = [256, 4096, 8]   uint8 E8M0
+      w13_weight_scale        = [256, 512, 128]  float8_e8m0fnu
+      w2_weight_scale         = [256, 4096, 8]   float8_e8m0fnu
       topk_weights.shape      = [47, 6]          float32
       topk_ids.shape          = [47, 6]          int64
       activation='silu', routed_scaling_factor=1.5, swiglu_limit=10
@@ -152,9 +156,10 @@ def test_fused_experts_dsv4_shape(
     )
     w2_packed, w2_scale_u8 = _build_packed_weights(num_experts, hidden, intermediate)
 
-    # Keep raw E8M0 scales for both the W4A16 kernel and reference decoder.
-    w1_scale = w1_scale_u8.to("xpu")
-    w2_scale = w2_scale_u8.to("xpu")
+    # Exercise the production float8_e8m0fnu representation. The W4A16 kernel
+    # consumes its raw E8M0 byte encoding without a numeric dtype conversion.
+    w1_scale = w1_scale_u8.view(torch.float8_e8m0fnu).to("xpu")
+    w2_scale = w2_scale_u8.view(torch.float8_e8m0fnu).to("xpu")
     w1_packed_xpu = w1_packed.view(torch.int8).to("xpu")
     w2_packed_xpu = w2_packed.view(torch.int8).to("xpu")
 

--- a/tests/test_moe_gemm.py
+++ b/tests/test_moe_gemm.py
@@ -344,13 +344,7 @@ def _make_int4_weight(
     return _pack_int4_codes(packed_codes).view(weight_dtype), scales, zeros, dequantized
 
 
-@pytest.mark.parametrize("explicit_zero", [False, True])
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("group_size", [32, 64, 128, 256])
-@pytest.mark.parametrize("weight_dtype", [torch.int8, torch.uint8])
-def test_moe_grouped_mm_nt_xe20_int4_zero_point(
-    explicit_zero, dtype, group_size, weight_dtype
-):
+def _check_int4_grouped_mm(explicit_zero, dtype, group_size, weight_dtype):
     torch.manual_seed(0)
     num_experts, rows_per_expert, gemm_n, gemm_k = 8, 2, 128, 256
     total_m = num_experts * rows_per_expert
@@ -394,12 +388,28 @@ def test_moe_grouped_mm_nt_xe20_int4_zero_point(
 
 @pytest.mark.parametrize("explicit_zero", [False, True])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("group_size", [32, 64, 128, 256])
+def test_moe_grouped_mm_nt_xe20_int4_zero_point(explicit_zero, dtype, group_size):
+    _check_int4_grouped_mm(explicit_zero, dtype, group_size, torch.int8)
+
+
+def test_moe_grouped_mm_nt_xe20_int4_uint8_weights():
+    """uint8-packed int4 weights hold the same nibbles as the int8 packing, so
+    one representative case covers the relaxed dtype acceptance without
+    crossing it into the whole parameter matrix."""
+    _check_int4_grouped_mm(
+        explicit_zero=True,
+        dtype=torch.bfloat16,
+        group_size=32,
+        weight_dtype=torch.uint8,
+    )
+
+
+@pytest.mark.parametrize("explicit_zero", [False, True])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("with_bias", [False, True])
 @pytest.mark.parametrize("activation", ["silu", "relu2"])
-@pytest.mark.parametrize("weight_dtype", [torch.int8, torch.uint8])
-def test_fused_experts_int4_w4a16(
-    explicit_zero, dtype, with_bias, activation, weight_dtype
-):
+def test_fused_experts_int4_w4a16(explicit_zero, dtype, with_bias, activation):
     torch.manual_seed(1)
     num_tokens, topk, num_experts = 5, 2, 8
     hidden_size, intermediate_size, group_size = 128, 64, 32
@@ -413,7 +423,6 @@ def test_fused_experts_int4_w4a16(
         group_size,
         dtype,
         explicit_zero,
-        weight_dtype=weight_dtype,
     )
     w2, w2_scale, w2_zero, w2_reference = _make_int4_weight(
         num_experts,
@@ -422,7 +431,6 @@ def test_fused_experts_int4_w4a16(
         group_size,
         dtype,
         explicit_zero,
-        weight_dtype=weight_dtype,
     )
     topk_ids = torch.tensor([[0, 1], [2, 3], [4, 5], [6, 7], [0, 2]], dtype=torch.int64)
     topk_weights = torch.rand(num_tokens, topk, dtype=torch.float32)
@@ -606,8 +614,10 @@ def test_moe_gemm_mxfp4_weights(
     )
 
     # ---- fused_experts with packed MXFP4 weights on XPU ----
-    # This case keeps scales as raw uint8 E8M0 bytes; float8_e8m0fnu coverage
-    # is provided by the DSV4 and direct grouped-GEMM tests below.
+    # Feed the packing helper's native tensors straight through: uint8 packed
+    # weights plus raw uint8 E8M0 block scales. The int8 weight and
+    # float8_e8m0fnu scale representations are covered by the op-level dtype
+    # test at the bottom of this file.
     device = "xpu"
     kernel_output = fused_experts(
         a.to(device),
@@ -752,8 +762,8 @@ def _build_moe_gemm_inputs(
     gemm_n: int,
     gemm_k: int,
     dtype: torch.dtype,
-    weight_dtype: torch.dtype,
-    scale_dtype: torch.dtype,
+    weight_dtype: torch.dtype = torch.int8,
+    scale_dtype: torch.dtype = torch.uint8,
     seed: int = 0,
 ):
     """Construct (activations, dequantized_weights, mxfp4_packed, mxfp4_scales,
@@ -792,27 +802,15 @@ def _build_moe_gemm_inputs(
     }
 
 
-@pytest.mark.parametrize("num_tokens_per_expert", [2, 6, 33, 129])
-@pytest.mark.parametrize("num_experts", [8])
-@pytest.mark.parametrize("hidden_size", [1024])
-@pytest.mark.parametrize("intermediate_size", [512])
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("weight_dtype", [torch.int8, torch.uint8])
-@pytest.mark.parametrize("scale_dtype", [torch.uint8, torch.float8_e8m0fnu])
-def test_moe_grouped_mm_nt_xe20_w4a16_mxfp4_op(
+def _check_mxfp4_grouped_mm(
     num_tokens_per_expert,
     num_experts,
     hidden_size,
     intermediate_size,
     dtype,
-    weight_dtype,
-    scale_dtype,
+    weight_dtype=torch.int8,
+    scale_dtype=torch.uint8,
 ):
-    """Compare the unified MXFP4 op with GEMM on dequantized weights.
-
-    gemm_k = hidden_size (activation's inner dim)
-    gemm_n = 2*intermediate_size (w1 style).
-    """
     gemm_k = hidden_size
     gemm_n = 2 * intermediate_size
     assert gemm_n % 2 == 0
@@ -855,6 +853,50 @@ def test_moe_grouped_mm_nt_xe20_w4a16_mxfp4_op(
 
     torch.testing.assert_close(
         inputs["output_reference"], inputs["output_mxfp4"], rtol=1e-1, atol=1e-2
+    )
+
+
+@pytest.mark.parametrize("num_tokens_per_expert", [2, 6, 33, 129])
+@pytest.mark.parametrize("num_experts", [8])
+@pytest.mark.parametrize("hidden_size", [1024])
+@pytest.mark.parametrize("intermediate_size", [512])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_moe_grouped_mm_nt_xe20_w4a16_mxfp4_op(
+    num_tokens_per_expert,
+    num_experts,
+    hidden_size,
+    intermediate_size,
+    dtype,
+):
+    """Compare the unified MXFP4 op with GEMM on dequantized weights.
+
+    gemm_k = hidden_size (activation's inner dim)
+    gemm_n = 2*intermediate_size (w1 style).
+    """
+    _check_mxfp4_grouped_mm(
+        num_tokens_per_expert=num_tokens_per_expert,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        dtype=dtype,
+    )
+
+
+@pytest.mark.parametrize("weight_dtype", [torch.int8, torch.uint8])
+@pytest.mark.parametrize("scale_dtype", [torch.uint8, torch.float8_e8m0fnu])
+def test_moe_grouped_mm_nt_xe20_w4a16_mxfp4_input_dtypes(weight_dtype, scale_dtype):
+    """The op accepts both packed-weight dtypes (int8/uint8) and both E8M0
+    scale dtypes (uint8/float8_e8m0fnu). All four spellings carry identical
+    bits, so a single shape is enough to cover the dtype acceptance paths.
+    """
+    _check_mxfp4_grouped_mm(
+        num_tokens_per_expert=33,
+        num_experts=8,
+        hidden_size=1024,
+        intermediate_size=512,
+        dtype=torch.bfloat16,
+        weight_dtype=weight_dtype,
+        scale_dtype=scale_dtype,
     )
 
 

--- a/tests/test_moe_gemm.py
+++ b/tests/test_moe_gemm.py
@@ -303,6 +303,7 @@ def _make_int4_weight(
     dtype: torch.dtype,
     explicit_zero: bool,
     permutations: torch.Tensor | None = None,
+    weight_dtype: torch.dtype = torch.int8,
 ):
     assert input_size % group_size == 0
     if explicit_zero:
@@ -340,13 +341,16 @@ def _make_int4_weight(
             permutations[:, None, :].expand(-1, output_size, -1),
         )
 
-    return _pack_int4_codes(packed_codes).view(torch.int8), scales, zeros, dequantized
+    return _pack_int4_codes(packed_codes).view(weight_dtype), scales, zeros, dequantized
 
 
 @pytest.mark.parametrize("explicit_zero", [False, True])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("group_size", [32, 64, 128, 256])
-def test_moe_grouped_mm_nt_xe20_int4_zero_point(explicit_zero, dtype, group_size):
+@pytest.mark.parametrize("weight_dtype", [torch.int8, torch.uint8])
+def test_moe_grouped_mm_nt_xe20_int4_zero_point(
+    explicit_zero, dtype, group_size, weight_dtype
+):
     torch.manual_seed(0)
     num_experts, rows_per_expert, gemm_n, gemm_k = 8, 2, 128, 256
     total_m = num_experts * rows_per_expert
@@ -359,6 +363,7 @@ def test_moe_grouped_mm_nt_xe20_int4_zero_point(explicit_zero, dtype, group_size
         group_size,
         dtype,
         explicit_zero,
+        weight_dtype=weight_dtype,
     )
     expected = torch.cat(
         [
@@ -391,7 +396,10 @@ def test_moe_grouped_mm_nt_xe20_int4_zero_point(explicit_zero, dtype, group_size
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("with_bias", [False, True])
 @pytest.mark.parametrize("activation", ["silu", "relu2"])
-def test_fused_experts_int4_w4a16(explicit_zero, dtype, with_bias, activation):
+@pytest.mark.parametrize("weight_dtype", [torch.int8, torch.uint8])
+def test_fused_experts_int4_w4a16(
+    explicit_zero, dtype, with_bias, activation, weight_dtype
+):
     torch.manual_seed(1)
     num_tokens, topk, num_experts = 5, 2, 8
     hidden_size, intermediate_size, group_size = 128, 64, 32
@@ -405,6 +413,7 @@ def test_fused_experts_int4_w4a16(explicit_zero, dtype, with_bias, activation):
         group_size,
         dtype,
         explicit_zero,
+        weight_dtype=weight_dtype,
     )
     w2, w2_scale, w2_zero, w2_reference = _make_int4_weight(
         num_experts,
@@ -413,6 +422,7 @@ def test_fused_experts_int4_w4a16(explicit_zero, dtype, with_bias, activation):
         group_size,
         dtype,
         explicit_zero,
+        weight_dtype=weight_dtype,
     )
     topk_ids = torch.tensor([[0, 1], [2, 3], [4, 5], [6, 7], [0, 2]], dtype=torch.int64)
     topk_weights = torch.rand(num_tokens, topk, dtype=torch.float32)
@@ -544,7 +554,7 @@ def test_moe_gemm_mxfp4_weights(
     """Test fused_experts with MXFP4-packed expert weights (W4A16).
 
     Weights are quantized to MXFP4 on CPU and passed to fused_experts as packed
-    int8 tensors together with their UE8M0 block scales via the
+    uint8 tensors together with their UE8M0 block scales via the
     ``use_mxfp4_w4a16=True`` flag. Scales may use either the uint8 or
     float8_e8m0fnu representation. Activations remain in BF16 throughout.
 
@@ -601,8 +611,8 @@ def test_moe_gemm_mxfp4_weights(
     device = "xpu"
     kernel_output = fused_experts(
         a.to(device),
-        w1_packed.view(torch.int8).to(device),
-        w2_packed.view(torch.int8).to(device),
+        w1_packed.to(device),
+        w2_packed.to(device),
         topk_weight.to(device),
         topk_ids.to(device),
         None,
@@ -742,6 +752,7 @@ def _build_moe_gemm_inputs(
     gemm_n: int,
     gemm_k: int,
     dtype: torch.dtype,
+    weight_dtype: torch.dtype,
     scale_dtype: torch.dtype,
     seed: int = 0,
 ):
@@ -764,7 +775,7 @@ def _build_moe_gemm_inputs(
     w_dq_cpu = _dequantize_weights_mxfp4(w_packed_cpu, w_scale_cpu, dtype=dtype)
 
     w_dq_xpu = w_dq_cpu.to("xpu")
-    w_packed_xpu = w_packed_cpu.view(torch.int8).to("xpu")
+    w_packed_xpu = w_packed_cpu.view(weight_dtype).to("xpu")
     w_scale_xpu = w_scale_cpu.view(scale_dtype).to("xpu")
 
     output_reference = torch.empty((total_m, gemm_n), dtype=dtype, device="xpu")
@@ -786,6 +797,7 @@ def _build_moe_gemm_inputs(
 @pytest.mark.parametrize("hidden_size", [1024])
 @pytest.mark.parametrize("intermediate_size", [512])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("weight_dtype", [torch.int8, torch.uint8])
 @pytest.mark.parametrize("scale_dtype", [torch.uint8, torch.float8_e8m0fnu])
 def test_moe_grouped_mm_nt_xe20_w4a16_mxfp4_op(
     num_tokens_per_expert,
@@ -793,6 +805,7 @@ def test_moe_grouped_mm_nt_xe20_w4a16_mxfp4_op(
     hidden_size,
     intermediate_size,
     dtype,
+    weight_dtype,
     scale_dtype,
 ):
     """Compare the unified MXFP4 op with GEMM on dequantized weights.
@@ -811,6 +824,7 @@ def test_moe_grouped_mm_nt_xe20_w4a16_mxfp4_op(
         gemm_n=gemm_n,
         gemm_k=gemm_k,
         dtype=dtype,
+        weight_dtype=weight_dtype,
         scale_dtype=scale_dtype,
     )
 

--- a/tests/test_moe_gemm.py
+++ b/tests/test_moe_gemm.py
@@ -544,8 +544,9 @@ def test_moe_gemm_mxfp4_weights(
     """Test fused_experts with MXFP4-packed expert weights (W4A16).
 
     Weights are quantized to MXFP4 on CPU and passed to fused_experts as packed
-    uint8 tensors together with their UE8M0 block scales via the
-    ``use_mxfp4_w4a16=True`` flag.  Activations remain in BF16 throughout.
+    int8 tensors together with their UE8M0 block scales via the
+    ``use_mxfp4_w4a16=True`` flag. Scales may use either the uint8 or
+    float8_e8m0fnu representation. Activations remain in BF16 throughout.
 
     The reference is torch_naive_moe run with the *dequantised* BF16 weights
     so that both code paths see identical effective weights; any numerical
@@ -595,8 +596,8 @@ def test_moe_gemm_mxfp4_weights(
     )
 
     # ---- fused_experts with packed MXFP4 weights on XPU ----
-    # fused_experts expects packed weights as int8 (bitwise identical to the
-    # uint8 reference packing) and raw uint8 E8M0 block scales.
+    # This case keeps scales as raw uint8 E8M0 bytes; float8_e8m0fnu coverage
+    # is provided by the DSV4 and direct grouped-GEMM tests below.
     device = "xpu"
     kernel_output = fused_experts(
         a.to(device),
@@ -741,6 +742,7 @@ def _build_moe_gemm_inputs(
     gemm_n: int,
     gemm_k: int,
     dtype: torch.dtype,
+    scale_dtype: torch.dtype,
     seed: int = 0,
 ):
     """Construct (activations, dequantized_weights, mxfp4_packed, mxfp4_scales,
@@ -761,10 +763,9 @@ def _build_moe_gemm_inputs(
     w_packed_cpu, w_scale_cpu = _quantize_weights_mxfp4(weights_cpu)
     w_dq_cpu = _dequantize_weights_mxfp4(w_packed_cpu, w_scale_cpu, dtype=dtype)
 
-    # Unified W4A16 contract: int8 packed weights and raw uint8 E8M0 scales.
     w_dq_xpu = w_dq_cpu.to("xpu")
     w_packed_xpu = w_packed_cpu.view(torch.int8).to("xpu")
-    w_scale_xpu = w_scale_cpu.to("xpu")
+    w_scale_xpu = w_scale_cpu.view(scale_dtype).to("xpu")
 
     output_reference = torch.empty((total_m, gemm_n), dtype=dtype, device="xpu")
     output_mxfp4 = torch.empty((total_m, gemm_n), dtype=dtype, device="xpu")
@@ -785,12 +786,14 @@ def _build_moe_gemm_inputs(
 @pytest.mark.parametrize("hidden_size", [1024])
 @pytest.mark.parametrize("intermediate_size", [512])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("scale_dtype", [torch.uint8, torch.float8_e8m0fnu])
 def test_moe_grouped_mm_nt_xe20_w4a16_mxfp4_op(
     num_tokens_per_expert,
     num_experts,
     hidden_size,
     intermediate_size,
     dtype,
+    scale_dtype,
 ):
     """Compare the unified MXFP4 op with GEMM on dequantized weights.
 
@@ -808,6 +811,7 @@ def test_moe_grouped_mm_nt_xe20_w4a16_mxfp4_op(
         gemm_n=gemm_n,
         gemm_k=gemm_k,
         dtype=dtype,
+        scale_dtype=scale_dtype,
     )
 
     rows_per_expert = num_tokens_per_expert


### PR DESCRIPTION
With reference to PR https://github.com/sgl-project/sglang/pull/33682 and https://github.com/sgl-project/sglang/pull/33373, this PR relaxes the data type requirements for W4A16 MoE input weights and scales. Scales now support `float8_e8m0fnu` and `uint8`, while weights support `int8` and `uint8`.  