### PR TITLE
Remove unnecessary reshape of output for Neox style ROPE

### DIFF
--- a/src/sycl/Rope.cpp
+++ b/src/sycl/Rope.cpp
@@ -422,10 +422,6 @@ std::tuple<at::Tensor, at::Tensor> rotary_embedding_3D_kernel_impl(
   int64_t k_num_head = k_shape[1];
   int64_t k_num_head_d = k_stride[1];
   int64_t k_batch_d = k_stride[0];
-  if (is_neox_style) {
-    query_out = query_out.reshape({1, batch, q_num_head, head_size});
-    key_out = key_out.reshape({1, batch, k_num_head, head_size});
-  }
   TORCH_CHECK(cos_sin_cache.sizes()[1] == head_size, "Rotary dim doesn't match query head_size");
   TORCH_CHECK(cos_sin_cache.sizes()[1] == k_shape[2], "Rotary dim doesn't match key head_size");
   int64_t* offsets_ptr = nullptr;

--- a/tests/test_rotary_embedding.py
+++ b/tests/test_rotary_embedding.py
@@ -383,6 +383,47 @@ def test_rope(
     torch.testing.assert_close(key_ref_out, key_test_out, atol=1e-2, rtol=1e-2)
 
 
+@pytest.mark.parametrize("is_neox_style", [True, False])
+def test_rope_3d_input_shape_preserved(is_neox_style: bool):
+    """Regression test: rotary_embedding_3D_kernel_impl must not alter the
+    shape of its output tensors relative to the input (batch, num_heads,
+    head_size) tensors. A stray `reshape({1, batch, num_heads, head_size})`
+    for the is_neox_style branch used to prepend a spurious leading
+    dimension of size `1`, which corrupted downstream reshapes in callers
+    (e.g. sglang's rotary_embedding fallback for 2D q/k) whenever
+    is_neox_style=True and batch != 1."""
+    torch.manual_seed(0)
+    head_size = 64
+    batch_size = 7
+    num_q_heads = 32
+    num_kv_heads = 8
+    max_position_embeddings = 32
+
+    positions = torch.arange(batch_size, device=device)
+    query = torch.randn(
+        batch_size, num_q_heads, head_size, dtype=torch.bfloat16, device=device
+    )
+    key = torch.randn(
+        batch_size, num_kv_heads, head_size, dtype=torch.bfloat16, device=device
+    )
+    cos_sin_cache = torch.randn(
+        max_position_embeddings, head_size, dtype=torch.bfloat16, device=device
+    )
+
+    query_out, key_out = torch.ops.sgl_kernel.rotary_embedding(
+        positions, query.clone(), key.clone(), head_size, cos_sin_cache, is_neox_style
+    )
+
+    assert query_out.shape == query.shape, (
+        f"query_out shape {query_out.shape} does not match input shape "
+        f"{query.shape} for is_neox_style={is_neox_style}"
+    )
+    assert key_out.shape == key.shape, (
+        f"key_out shape {key_out.shape} does not match input shape "
+        f"{key.shape} for is_neox_style={is_neox_style}"
+    )
+
+
 def test_deepseek_v2_rope():
     torch.manual_seed(1024)
     num_head = 16


### PR DESCRIPTION
The reshape here (adding a leading `1` dimension) is wrong here because
1. The kernel uses the pointer, unrelated to the shape.
2. The shape has nothing to do the the algorithm.
3. It silently violates the "RoPE preserves tensor shape" invariant.

It's most plausibly a copy/paste leftover from some other kernel path in the codebase that legitimately deals with a  [1, batch, ...] -shaped tensor layout (e.g., a batched-request wrapper elsewhere), mistakenly attached to the `is_neox_style` conditional instead of being removed — dead code that just happened to never get exercised by the test suite (which only tests `is_neox_style=False` for the 3D path) until Llama's standard rope path hit it.

A test case is added to cover this fix.
