### PR TITLE
[XPU] Fix paged FMHA prefetch bounds and expand coverage

### DIFF
--- a/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_mainloop.hpp
+++ b/src/sycl/kernels/flash_attention_v2/collective/xe_fmha_fwd_mainloop.hpp
@@ -507,7 +507,10 @@ struct FMHAFwdMainloop<
 
       page_idx = next_page_idx;
       if constexpr (!ScoreBlock2D) {
-        next_page_idx = K + 1;
+        // The final iteration has no next K prefetch, but translating K + 1
+        // still dereferences the page table. Clamp it to the last valid tile
+        // so page_size=128 does not read one entry past the page table.
+        next_page_idx = cute::min(K + 1, k_end - 1);
         if constexpr (PagedKV) {
           next_page_idx = get_physical_k_tile(next_page_idx, l_coord, seq_len_kv_cache);
         }

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -66,9 +66,7 @@ DISABLE_PACKGQA = True
 DISABLE_FP16 = True
 DISABLE_FP8 = True
 
-EXTENDED_KVCACHE_TESTS = (
-    os.getenv("FLASH_ATTENTION_KVCACHE_EXTENDED_TESTS") == "1"
-)
+EXTENDED_KVCACHE_TESTS = os.getenv("FLASH_ATTENTION_KVCACHE_EXTENDED_TESTS") == "1"
 KVCACHE_BATCH_SIZES = [5]
 KVCACHE_HEAD_CONFIGS = [(16, 16), (16, 4), (8, 1)]
 KVCACHE_SEQLEN_CONFIGS = [
@@ -159,9 +157,16 @@ if EXTENDED_KVCACHE_TESTS:
         ["e4m3", "e5m2"],
         ["scalar", "expanded"],
     )
-    for batch_size, heads, seqlens, d, page_size, causal, dtype_name, layout in (
-        fp8_common
-    ):
+    for (
+        batch_size,
+        heads,
+        seqlens,
+        d,
+        page_size,
+        causal,
+        dtype_name,
+        layout,
+    ) in fp8_common:
         FP8_KVCACHE_CROSS_MATRIX_CASES.append(
             (
                 batch_size,
@@ -2186,10 +2191,7 @@ def test_flash_attn_varlen_output(
 if EXTENDED_KVCACHE_TESTS:
 
     @pytest.mark.parametrize(
-        (
-            "nheads_q,nheads_kv,seqlen_q,seqlen_k,d,"
-            "causal,local,dtype_name"
-        ),
+        ("nheads_q,nheads_kv,seqlen_q,seqlen_k,d," "causal,local,dtype_name"),
         VARLEN_CROSS_MATRIX_CASES,
     )
     def test_flash_attn_varlen_cross_matrix(

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -66,6 +66,131 @@ DISABLE_PACKGQA = True
 DISABLE_FP16 = True
 DISABLE_FP8 = True
 
+EXTENDED_KVCACHE_TESTS = (
+    os.getenv("FLASH_ATTENTION_KVCACHE_EXTENDED_TESTS") == "1"
+)
+KVCACHE_BATCH_SIZES = [5]
+KVCACHE_HEAD_CONFIGS = [(16, 16), (16, 4), (8, 1)]
+KVCACHE_SEQLEN_CONFIGS = [
+    (3, 1024),
+    (64, 800),
+    (64, 256),
+    (3, 799),
+    (64, 2048),
+    (128, 128),
+    (256, 512),  # To test appending KV with more than 1 block
+    (512, 512),  # HD512 paged GQA resource regression
+    (2048, 3577),  # Enough tile to test persistent scheduler
+]
+
+KVCACHE_CROSS_MATRIX_CASES = []
+VARLEN_CROSS_MATRIX_CASES = []
+FP8_KVCACHE_CROSS_MATRIX_CASES = []
+if EXTENDED_KVCACHE_TESTS:
+    cross_matrix_seqlens = [
+        # (query length, cache capacity, actual cache length)
+        (33, 128, 33),
+        (63, 128, 63),
+        (65, 128, 65),
+        (97, 128, 97),
+        (65, 256, 65),
+        (127, 256, 127),
+        (129, 256, 129),
+        (193, 256, 193),
+        (255, 512, 255),
+        (257, 512, 257),
+        (385, 512, 385),
+        (257, 1024, 257),
+        (511, 1024, 511),
+        (513, 1024, 513),
+        (769, 1024, 769),
+    ]
+    cross_matrix_heads = [(16, 16)] + [(ratio, 1) for ratio in range(2, 17)]
+    cross_matrix_common = itertools.product(
+        [1, 5],
+        cross_matrix_heads,
+        cross_matrix_seqlens,
+        [64, 128, 256, 512],
+        [(False, False), (True, False)],
+    )
+    for batch_size, heads, seqlens, d, mask in cross_matrix_common:
+        for page_size in (64, 128):
+            for dtype_name in ("bf16", "fp16"):
+                KVCACHE_CROSS_MATRIX_CASES.append(
+                    (batch_size, *heads, *seqlens, d, page_size, *mask, dtype_name)
+                )
+    for cache_seqlen in (639, 640, 641, 767, 768):
+        KVCACHE_CROSS_MATRIX_CASES.append(
+            (5, 8, 1, 513, 1024, cache_seqlen, 512, 128, True, False, "bf16")
+        )
+    for heads, seqlens, d, mask, dtype_name in itertools.product(
+        [(16, 16), (2, 1), (8, 1), (16, 1)],
+        cross_matrix_seqlens[::2],
+        [64, 128, 256, 512],
+        [(False, False), (True, False)],
+        ["bf16", "fp16"],
+    ):
+        VARLEN_CROSS_MATRIX_CASES.append(
+            (*heads, seqlens[0], seqlens[1], d, *mask, dtype_name)
+        )
+    fp8_seqlens = [
+        (1, 128, 1),
+        (33, 128, 33),
+        (63, 128, 63),
+        (65, 128, 65),
+        (97, 128, 97),
+        (127, 256, 127),
+        (129, 256, 129),
+        (193, 256, 193),
+        (255, 512, 255),
+        (257, 512, 257),
+        (385, 512, 385),
+        (511, 1024, 511),
+        (513, 1024, 513),
+        (769, 1024, 769),
+    ]
+    fp8_common = itertools.product(
+        [1, 5],
+        [(16, 16), (2, 1), (4, 1), (8, 1), (16, 1)],
+        fp8_seqlens,
+        [64, 128, 256, 512],
+        [64, 128],
+        [False, True],
+        ["e4m3", "e5m2"],
+        ["scalar", "expanded"],
+    )
+    for batch_size, heads, seqlens, d, page_size, causal, dtype_name, layout in (
+        fp8_common
+    ):
+        FP8_KVCACHE_CROSS_MATRIX_CASES.append(
+            (
+                batch_size,
+                *heads,
+                *seqlens,
+                d,
+                page_size,
+                causal,
+                dtype_name,
+                layout,
+            )
+        )
+    for cache_seqlen in (639, 640, 641, 767, 768):
+        FP8_KVCACHE_CROSS_MATRIX_CASES.append(
+            (
+                5,
+                8,
+                1,
+                513,
+                1024,
+                cache_seqlen,
+                512,
+                128,
+                True,
+                "e4m3",
+                "expanded",
+            )
+        )
+
 
 # Adapted from https://github.com/Dao-AILab/flash-attention/blob/main/hopper/padding.py
 def unpad_input(hidden_states, attention_mask, unused_mask=None):
@@ -480,7 +605,8 @@ def generate_qkv(
     [torch.bfloat16, torch.float16]
     + ([torch.float8_e4m3fn] if not DISABLE_FP8 else []),
 )
-@pytest.mark.parametrize("nheads_q,nheads_kv", [(16, 16), (16, 4)])
+@pytest.mark.parametrize("batch_size", KVCACHE_BATCH_SIZES)
+@pytest.mark.parametrize("nheads_q,nheads_kv", KVCACHE_HEAD_CONFIGS)
 @pytest.mark.parametrize("new_kv", [False])
 @pytest.mark.parametrize("causal,local", [(False, True), (False, False), (True, False)])
 @pytest.mark.parametrize("use_sinks", [True, False])
@@ -502,19 +628,7 @@ def generate_qkv(
 @pytest.mark.parametrize("has_batch_idx", [False])
 @pytest.mark.parametrize("varlen_q", [True])
 @pytest.mark.parametrize("d", [64, 128, 256, 512])
-@pytest.mark.parametrize(
-    "seqlen_q,seqlen_k",
-    [
-        (3, 1024),
-        (64, 800),
-        (64, 256),
-        (3, 799),
-        (64, 2048),
-        (128, 128),
-        (256, 512),  # To test appending KV with more than 1 block
-        (2048, 3577),  # Enough tile to test persistent scheduler
-    ],
-)
+@pytest.mark.parametrize("seqlen_q,seqlen_k", KVCACHE_SEQLEN_CONFIGS)
 def test_flash_attn_kvcache(
     seqlen_q,
     seqlen_k,
@@ -531,9 +645,11 @@ def test_flash_attn_kvcache(
     local,
     use_sinks,
     new_kv,
+    batch_size,
     nheads_q,
     nheads_kv,
     dtype,
+    cache_seqlen=None,
 ):
     from sgl_kernel.flash_attn import flash_attn_with_kvcache
 
@@ -552,7 +668,6 @@ def test_flash_attn_kvcache(
         pytest.skip("use_sinks is only supported when d == 64")
     # set seed
     torch.random.manual_seed(0)
-    batch_size = 5
     batch_size_cache = batch_size if not has_batch_idx else batch_size * 2
     assert nheads_q % nheads_kv == 0
 
@@ -693,14 +808,23 @@ def test_flash_attn_kvcache(
                 dtype,
                 dtype_ref,
             )
-        cache_seqlens = torch.randint(
-            seqlen_q,
-            # If we don't use seqlen_q in the case of causal and rotary, cos/sin won't be long enough
-            seqlen_k,
-            (batch_size,),
-            dtype=torch.int32,
-            device=device,
-        )
+        if cache_seqlen is not None:
+            assert seqlen_q <= cache_seqlen < seqlen_k
+            cache_seqlens = torch.full(
+                (batch_size,),
+                cache_seqlen,
+                dtype=torch.int32,
+                device=device,
+            )
+        else:
+            cache_seqlens = torch.randint(
+                seqlen_q,
+                # If we don't use seqlen_q in the case of causal and rotary, cos/sin won't be long enough
+                seqlen_k,
+                (batch_size,),
+                dtype=torch.int32,
+                device=device,
+            )
         if has_leftpad:
             cache_leftpad = torch.cat(
                 [
@@ -967,6 +1091,56 @@ def test_flash_attn_kvcache(
                 assert (out - out_ref).abs().mean().item() <= mult_mean * (
                     out_pt - out_ref
                 ).abs().mean().item()
+
+
+if EXTENDED_KVCACHE_TESTS:
+
+    @pytest.mark.parametrize(
+        (
+            "batch_size,nheads_q,nheads_kv,seqlen_q,seqlen_k,cache_seqlen,d,"
+            "page_size,causal,local,dtype_name"
+        ),
+        KVCACHE_CROSS_MATRIX_CASES,
+    )
+    def test_flash_attn_kvcache_cross_matrix(
+        batch_size,
+        nheads_q,
+        nheads_kv,
+        seqlen_q,
+        seqlen_k,
+        cache_seqlen,
+        d,
+        page_size,
+        causal,
+        local,
+        dtype_name,
+    ):
+        dtype = {
+            "bf16": torch.bfloat16,
+            "fp16": torch.float16,
+        }[dtype_name]
+        test_flash_attn_kvcache(
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            d=d,
+            varlen_q=page_size is not None,
+            has_batch_idx=False,
+            has_leftpad=False,
+            page_size=page_size,
+            rotary_fraction=0.0,
+            rotary_interleaved=False,
+            has_rotary_seqlens=False,
+            seqlen_new_eq_seqlen_q=True,
+            causal=causal,
+            local=local,
+            use_sinks=False,
+            new_kv=False,
+            batch_size=batch_size,
+            nheads_q=nheads_q,
+            nheads_kv=nheads_kv,
+            dtype=dtype,
+            cache_seqlen=cache_seqlen,
+        )
 
 
 @pytest.mark.skipif(
@@ -1500,7 +1674,9 @@ def test_flash_attn_decode_kvcache(
 @pytest.mark.parametrize("seqlen_q", [1, 32, 64])
 @pytest.mark.parametrize("seqlen_k", [256, 512])
 @pytest.mark.parametrize("descale_layout", ["scalar", "expanded"])
+@pytest.mark.parametrize("batch_size", [3])
 def test_flash_attn_fp8_kvcache(
+    batch_size,
     seqlen_k,
     seqlen_q,
     page_size,
@@ -1511,6 +1687,7 @@ def test_flash_attn_fp8_kvcache(
     q_dtype,
     causal,
     descale_layout,
+    cache_seqlen=None,
 ):
     """Attention with an fp8 (e4m3 or e5m2) paged KV cache.
 
@@ -1527,7 +1704,6 @@ def test_flash_attn_fp8_kvcache(
     assert nheads_q % nheads_kv == 0
 
     torch.manual_seed(0)
-    batch_size = 3
     softmax_scale = d**-0.5
     # Largest finite magnitude representable by each fp8 format.
     fp8_max = 448.0 if fp8_dtype == torch.float8_e4m3fn else 57344.0
@@ -1568,8 +1744,11 @@ def test_flash_attn_fp8_kvcache(
         batch_size * num_blocks_per_seq, dtype=torch.int32, device=device
     ).reshape(batch_size, num_blocks_per_seq)
 
+    if cache_seqlen is None:
+        cache_seqlen = seqlen_k
+    assert seqlen_q <= cache_seqlen <= seqlen_k
     cache_seqlens = torch.full(
-        (batch_size,), seqlen_k, dtype=torch.int32, device=device
+        (batch_size,), cache_seqlen, dtype=torch.int32, device=device
     )
 
     q = torch.randn(batch_size, seqlen_q, nheads_q, d, device=device, dtype=q_dtype)
@@ -1595,6 +1774,10 @@ def test_flash_attn_fp8_kvcache(
         k_cache,
         v_cache,
         softmax_scale,
+        key_padding_mask=(
+            rearrange(torch.arange(seqlen_k, device=device), "s -> 1 s")
+            < rearrange(cache_seqlens, "b -> b 1")
+        ),
         causal=causal,
         k_descale=k_descale_ref,
         v_descale=v_descale_ref,
@@ -1618,6 +1801,49 @@ def test_flash_attn_fp8_kvcache(
     else:
         assert max_diff <= 1e-1
         assert mean_diff <= 2e-2
+
+
+if EXTENDED_KVCACHE_TESTS:
+
+    @pytest.mark.parametrize(
+        (
+            "batch_size,nheads_q,nheads_kv,seqlen_q,seqlen_k,cache_seqlen,d,"
+            "page_size,causal,dtype_name,"
+            "descale_layout"
+        ),
+        FP8_KVCACHE_CROSS_MATRIX_CASES,
+    )
+    def test_flash_attn_fp8_kvcache_cross_matrix(
+        batch_size,
+        nheads_q,
+        nheads_kv,
+        seqlen_q,
+        seqlen_k,
+        cache_seqlen,
+        d,
+        page_size,
+        causal,
+        dtype_name,
+        descale_layout,
+    ):
+        fp8_dtype = {
+            "e4m3": torch.float8_e4m3fn,
+            "e5m2": torch.float8_e5m2,
+        }[dtype_name]
+        test_flash_attn_fp8_kvcache(
+            batch_size=batch_size,
+            seqlen_k=seqlen_k,
+            seqlen_q=seqlen_q,
+            page_size=page_size,
+            d=d,
+            nheads_q=nheads_q,
+            nheads_kv=nheads_kv,
+            fp8_dtype=fp8_dtype,
+            q_dtype=torch.bfloat16,
+            causal=causal,
+            descale_layout=descale_layout,
+            cache_seqlen=cache_seqlen,
+        )
 
 
 def _generate_block_kvcache(
@@ -1955,6 +2181,45 @@ def test_flash_attn_varlen_output(
         assert (dv - dv_ref).abs().max().item() <= rtol * (
             dv_pt - dv_ref
         ).abs().max().item() + dv_atol
+
+
+if EXTENDED_KVCACHE_TESTS:
+
+    @pytest.mark.parametrize(
+        (
+            "nheads_q,nheads_kv,seqlen_q,seqlen_k,d,"
+            "causal,local,dtype_name"
+        ),
+        VARLEN_CROSS_MATRIX_CASES,
+    )
+    def test_flash_attn_varlen_cross_matrix(
+        nheads_q,
+        nheads_kv,
+        seqlen_q,
+        seqlen_k,
+        d,
+        causal,
+        local,
+        dtype_name,
+    ):
+        dtype = {
+            "bf16": torch.bfloat16,
+            "fp16": torch.float16,
+        }[dtype_name]
+        test_flash_attn_varlen_output(
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            d=d,
+            add_unused_qkv=False,
+            causal=causal,
+            local=local,
+            softcap=0.0,
+            deterministic=False,
+            has_qv=False,
+            nheads_q=nheads_q,
+            nheads_kv=nheads_kv,
+            dtype=dtype,
+        )
 
 
 @pytest.mark.skipif(device.type != "xpu", reason="XPU not available")

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -108,7 +108,7 @@ if EXTENDED_KVCACHE_TESTS:
         [1, 5],
         cross_matrix_heads,
         cross_matrix_seqlens,
-        [64, 128, 256, 512],
+        [64, 96, 128, 192, 256, 512],
         [(False, False), (True, False)],
     )
     for batch_size, heads, seqlens, d, mask in cross_matrix_common:
@@ -121,16 +121,25 @@ if EXTENDED_KVCACHE_TESTS:
         KVCACHE_CROSS_MATRIX_CASES.append(
             (5, 8, 1, 513, 1024, cache_seqlen, 512, 128, True, False, "bf16")
         )
+    varlen_cross_matrix_seqlens = [
+        (seqlen_q, seqlen_k) for seqlen_q, seqlen_k, _ in cross_matrix_seqlens[::2]
+    ] + [
+        # Varlen has no page-size requirement. Exercise K tails explicitly.
+        (33, 127),
+        (65, 129),
+        (129, 255),
+        (257, 511),
+        (513, 1023),
+        (769, 1001),
+    ]
     for heads, seqlens, d, mask, dtype_name in itertools.product(
         [(16, 16), (2, 1), (8, 1), (16, 1)],
-        cross_matrix_seqlens[::2],
+        varlen_cross_matrix_seqlens,
         [64, 128, 256, 512],
         [(False, False), (True, False)],
         ["bf16", "fp16"],
     ):
-        VARLEN_CROSS_MATRIX_CASES.append(
-            (*heads, seqlens[0], seqlens[1], d, *mask, dtype_name)
-        )
+        VARLEN_CROSS_MATRIX_CASES.append((*heads, *seqlens, d, *mask, dtype_name))
     fp8_seqlens = [
         (1, 128, 1),
         (33, 128, 33),
@@ -153,7 +162,7 @@ if EXTENDED_KVCACHE_TESTS:
         fp8_seqlens,
         [64, 128, 256, 512],
         [64, 128],
-        [False, True],
+        [False],
         ["e4m3", "e5m2"],
         ["scalar", "expanded"],
     )
@@ -178,6 +187,19 @@ if EXTENDED_KVCACHE_TESTS:
                 dtype_name,
                 layout,
             )
+        )
+    fp8_causal_smoke = itertools.product(
+        # Cover the separate causal decode and prefill kernel paths without
+        # duplicating the full FP8 quantization/descale matrix.
+        [(1, 128, 1), (129, 256, 129)],
+        [256, 512],
+        [64, 128],
+        ["e4m3", "e5m2"],
+        ["scalar", "expanded"],
+    )
+    for seqlens, d, page_size, dtype_name, layout in fp8_causal_smoke:
+        FP8_KVCACHE_CROSS_MATRIX_CASES.append(
+            (1, 8, 1, *seqlens, d, page_size, True, dtype_name, layout)
         )
     for cache_seqlen in (639, 640, 641, 767, 768):
         FP8_KVCACHE_CROSS_MATRIX_CASES.append(


### PR DESCRIPTION
## Summary

Fix the paged FMHA prefill final-tile page-table bounds issue and expand opt-in XPU FMHA coverage.

This page-table out-of-bounds bug was discovered recently through the expanded test coverage, but it is a pre-existing issue rather than a regression from PR #342. Earlier UT coverage did not repeatedly exercise the final-K-tile/page-boundary combination, so it remained undetected. The same failure reproduces on PR #319 and PR #252. The bounds fix is now included here.

- Clamp the speculative next K-tile index before page-table translation in the non-ScoreBlock2D paged prefill path. This prevents a final-iteration `K + 1` page-table access beyond the valid cache range.
- Extend the BF16/FP16 paged KV-cache matrix to head dimensions `64/96/128/192/256/512`.
- Focus the FP8 broad matrix on FP8 dtype and descale coverage, while retaining causal decode/prefill smoke coverage and long-sequence causal canaries.
- Add non-paged varlen K-tail coverage with non-power-of-two lengths.

The extended matrix remains opt-in via `FLASH_ATTENTION_KVCACHE_EXTENDED_TESTS=1`.

## Validation

- The six original paged/GQA hang repro shapes passed reference validation on GPUs 1, 2, and 3.
- Full extended suite on GPU 0: `32003 passed, 1896 skipped in 633.34s`.
- `black-jupyter --files tests/test_flash_attention.py` passes.

## Notes

The page-table bounds fix addresses the confirmed final-K-tile out-of-bounds path. The earlier resource-pressure experiment that held multiple K-block score fragments is not present in this branch.