### PR TITLE
[XPU] Fix causal_conv1d_update_xpu signature for GDN speculative decode

### DIFF
--- a/python/sgl_kernel/mamba.py
+++ b/python/sgl_kernel/mamba.py
@@ -39,8 +39,10 @@ def causal_conv1d_update_xpu(
     cache_seqlens: Optional[torch.Tensor] = None,
     conv_state_indices: Optional[torch.Tensor] = None,
     pad_slot_id: int = -1,
+    **kwargs,
 ):
 
+    _ = kwargs
     unsqueeze = x.dim() == 2
     if unsqueeze:
         x = x.unsqueeze(-1)

--- a/tests/test_causal_conv1d.py
+++ b/tests/test_causal_conv1d.py
@@ -482,5 +482,57 @@ def test_causal_conv1d_varlen(
     )
 
 
+@pytest.mark.parametrize("itype", [torch.bfloat16])
+@pytest.mark.parametrize("width", [4])
+@pytest.mark.parametrize("dim", [2048])
+def test_causal_conv1d_update_ignores_spec_decode_kwargs(dim, width, itype):
+    """Extra keyword arguments must not break the XPU signature.
+
+    The GDN target-verify path in sglang passes speculative-decoding tree
+    arguments to `causal_conv1d_update`. They are not honored by the XPU
+    kernel yet, but they must be accepted instead of raising a TypeError.
+    See https://github.com/sgl-project/sglang/issues/34720.
+    """
+    rtol, atol = 1e-2, 5e-2
+
+    batch, seqlen = 2, 1
+    x = torch.randn(batch, dim, seqlen, device=device, dtype=itype)
+    x_ref = x.clone()
+    conv_state = torch.randn(batch, dim, width - 1, device=device, dtype=itype)
+    conv_state_ref = conv_state.detach().clone()
+    weight = torch.randn(dim, width, device=device, dtype=itype)
+    bias = torch.randn(dim, device=device, dtype=itype)
+
+    draft_token_num = 4
+    out = causal_conv1d_update_xpu(
+        x,
+        conv_state,
+        weight,
+        bias,
+        "silu",
+        intermediate_conv_window=torch.zeros(
+            batch, draft_token_num, dim, width - 1, device=device, dtype=itype
+        ),
+        intermediate_state_indices=torch.arange(
+            batch, dtype=torch.int32, device=device
+        ),
+        retrieve_next_token=torch.full(
+            (batch, draft_token_num), -1, dtype=torch.int64, device=device
+        ),
+        retrieve_next_sibling=torch.full(
+            (batch, draft_token_num), -1, dtype=torch.int64, device=device
+        ),
+        retrieve_parent_token=torch.zeros(
+            (batch, draft_token_num), dtype=torch.int64, device=device
+        ),
+    )
+    out_ref = causal_conv1d_update_ref(
+        x_ref, conv_state_ref, weight, bias, activation="silu"
+    )
+
+    assert torch.equal(conv_state, conv_state_ref)
+    assert torch.allclose(out, out_ref, rtol=rtol, atol=atol)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Motivation

Serving a hybrid GDN model (e.g. Qwen3.5) on XPU with speculative decoding crashes during warmup:

```
TypeError: causal_conv1d_update_xpu() got an unexpected keyword argument 'intermediate_conv_window'
```

The GDN target-verify path in sglang (`python/sglang/srt/layers/attention/linear/gdn_backend.py`) calls
`causal_conv1d_update` with five speculative-decoding tree arguments:

- `intermediate_conv_window`
- `intermediate_state_indices`
- `retrieve_next_token`
- `retrieve_next_sibling`
- `retrieve_parent_token`

`causal_conv1d_update_xpu` only accepted arguments up to `pad_slot_id`, so the call raises `TypeError`
before reaching the kernel. Only the `TARGET_VERIFY` path is affected; non-speculative decode is fine.

Fixes https://github.com/sgl-project/sglang/issues/34720

## Modifications

- `python/sgl_kernel/mamba.py`: `causal_conv1d_update_xpu` now accepts and ignores unknown keyword
  arguments via `**kwargs`, matching what `causal_conv1d_fn_xpu` in the same file already does. This
  keeps the XPU wrapper tolerant of upstream signature changes instead of hard-failing at warmup.
- `tests/test_causal_conv1d.py`: new `test_causal_conv1d_update_ignores_spec_decode_kwargs` regression
  test that reproduces the failing call site (all five kwargs) and asserts both the output and the
  in-place `conv_state` update still match the reference.

## Note for reviewers

The tree-topology arguments are accepted but **not honored** by the SYCL kernel — no intermediate conv
window is checkpointed per draft token. This unblocks the crash and is correct for linear-chain draft
topologies, but tree-based drafting (`topk > 1`) would need the checkpointing implemented in
`src/sycl/causal_conv1d.cpp` to be numerically correct. Happy to follow up with either the kernel-side
support or an explicit guard/warning for the tree case if maintainers prefer failing loudly over
silently ignoring.

## Accuracy Test

`tests/test_causal_conv1d.py` on Intel XPU — full file, including the new test:

```
761 passed in 16.33s
```

## Benchmark & Profiling

Not applicable — signature-only change, no kernel or performance impact.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation / docstrings / example tutorials as needed, per [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#write-documentations).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, following [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/developer_guide/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting in merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
