### PR TITLE
[XPU] Fix ScoreBlock2D workspace OOM

### DIFF
--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
@@ -398,18 +398,18 @@ class XeFMHAFwdKernel {
       if constexpr (is_var_len) {
         auto qo_cumulative = s.seq_len_qo.cumulative_length;
         auto kv_cumulative = s.seq_len_kv.cumulative_length;
-        offset_q = s.num_heads_q * s.head_size_qk * qo_cumulative[idx_b];
+        offset_q = get<0>(p.dQ) * qo_cumulative[idx_b];
         // offset_k = s.num_heads_kv * s.head_size_qk * kv_cumulative[idx_b];
         // offset_v = s.num_heads_kv * s.head_size_vo * kv_cumulative[idx_b];
-        offset_o = s.num_heads_q * s.head_size_vo * qo_cumulative[idx_b];
+        offset_o = get<0>(p.dO) * qo_cumulative[idx_b];
         if (s.seq_len_kv_cache.cumulative_length) {
           auto kv_cumulative_cache = s.seq_len_kv_cache.cumulative_length;
           // Non-paged KV stores all batches in one contiguous ragged buffer, so each
           // batch starts at its cumulative KV offset. Paged KV uses the page table for
           // absolute addressing, so no base offset is applied here.
           if constexpr (!CollectiveMainloop::PagedKV) {
-            offset_k_cache = s.num_heads_kv * s.head_size_qk * kv_cumulative_cache[idx_b];
-            offset_v_cache = s.num_heads_kv * s.head_size_vo * kv_cumulative_cache[idx_b];
+            offset_k_cache = get<0>(p.dK_cache) * kv_cumulative_cache[idx_b];
+            offset_v_cache = get<1>(p.dV_cache) * kv_cumulative_cache[idx_b];
           }
         }
       }
@@ -433,12 +433,32 @@ class XeFMHAFwdKernel {
       auto dcV_cache = const_cast<ElementV*>(p.V_cache + offset_v_cache);
       auto dcO = const_cast<ElementO*>(p.O + offset_o);
       // NHD layout for GQA
-      auto layout_q = is_var_len ? make_ordered_layout(shape_Q, VarLenQLayoutStep_{}) : make_layout(shape_Q, p.dQ);
-      auto layout_k = is_var_len ? make_ordered_layout(shape_K, VarLenKLayoutStep_{}) : make_layout(shape_K, p.dK);
-      auto layout_v = is_var_len ? make_ordered_layout(shape_V, VarLenVLayoutStep_{}) : make_layout(shape_V, p.dV);
+      auto layout_q = [&] {
+        if constexpr (is_var_len && !CollectiveMainloop::ScoreBlock2D) {
+          return make_ordered_layout(shape_Q, VarLenQLayoutStep_{});
+        }
+        return make_layout(shape_Q, p.dQ);
+      }();
+      auto layout_k = [&] {
+        if constexpr (is_var_len && !CollectiveMainloop::ScoreBlock2D) {
+          return make_ordered_layout(shape_K, VarLenKLayoutStep_{});
+        }
+        return make_layout(shape_K, p.dK);
+      }();
+      auto layout_v = [&] {
+        if constexpr (is_var_len && !CollectiveMainloop::ScoreBlock2D) {
+          return make_ordered_layout(shape_V, VarLenVLayoutStep_{});
+        }
+        return make_layout(shape_V, p.dV);
+      }();
 
       // NHD layout for GQA
-      auto layout_o = is_var_len ? make_ordered_layout(shape_O, VarLenOLayoutStep_{}) : make_layout(shape_O, p.dO);
+      auto layout_o = [&] {
+        if constexpr (is_var_len && !CollectiveMainloop::ScoreBlock2D) {
+          return make_ordered_layout(shape_O, VarLenOLayoutStep_{});
+        }
+        return make_layout(shape_O, p.dO);
+      }();
 
       Tensor Q = make_tensor(make_gmem_ptr(dcQ), layout_q);
       Tensor K_cache = make_tensor(make_gmem_ptr(dcK_cache), layout_k);

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
@@ -177,6 +177,10 @@ class XeFMHAFwdKernel {
     // (num_heads_q, total_q). Null => don't write.
     float* softmax_lse = nullptr;
     int64_t lse_head_stride = 0;  // = total_q
+    // ScoreBlock2D processes this contiguous Q-tile interval. Non-score paths
+    // leave q_tile_count at -1 and use the complete Q extent.
+    int q_tile_start = 0;
+    int q_tile_count = -1;
   };
   using KernelParams = KernelArguments;
 
@@ -224,11 +228,17 @@ class XeFMHAFwdKernel {
         args.kernel.scale_k_ptr,
         args.kernel.scale_v_ptr,
         args.kernel.softmax_lse,
-        args.kernel.lse_head_stride};
+        args.kernel.lse_head_stride,
+        args.kernel.q_tile_start,
+        args.kernel.q_tile_count};
     auto scheduler_params =
         TileScheduler::to_underlying_arguments(args.kernel.shape, args.hw_info, TileShapeO{}, sched_num_kv_splits);
     if constexpr (CollectiveMainloop::ScoreBlock2D && StaticScoreMode_ >= 0) {
       scheduler_params.grid.x = 1;
+      scheduler_params.q_tile_start = args.kernel.q_tile_start;
+      if (args.kernel.q_tile_count > 0) {
+        scheduler_params.grid.y = args.kernel.q_tile_count;
+      }
     }
     return {
         kernel_params,
@@ -253,7 +263,9 @@ class XeFMHAFwdKernel {
         score_k_extent = size_t(args.kernel.shape.seq_len_kv_cache);
       }
       const size_t score_rows_per_wg = size_t(get<0>(TileShapeQK{}));
-      const size_t q_tiles = cute::ceil_div(score_q_extent, score_rows_per_wg);
+      const size_t total_q_tiles = cute::ceil_div(score_q_extent, score_rows_per_wg);
+      const size_t q_tiles =
+          args.kernel.q_tile_count > 0 ? cute::min(total_q_tiles, size_t(args.kernel.q_tile_count)) : total_q_tiles;
       score_k_extent = cute::round_up(score_k_extent, size_t(get<1>(TileShapeQK{})));
       return size_t(args.kernel.shape.batch) * size_t(args.kernel.shape.num_heads_q) * q_tiles * score_rows_per_wg *
              score_k_extent * sizeof(typename CollectiveMainloop::ElementScoreStore);
@@ -493,8 +505,10 @@ class XeFMHAFwdKernel {
         score_k_extent = cute::round_up(score_k_extent, int(get<1>(TileShapeQK{})));
         score_region_cols = score_k_extent;
         score_pf_q_ok = score_q_extent >= cutlass::fmha::ScoreBlock2DPolicy::ScorePrefetchQMin;
-        const int q_tiles = cute::ceil_div(score_q_extent, int(get<0>(TileShapeQK{})));
-        const size_t wg_slot = (size_t(score_batch) * s.num_heads_q + q_head_idx) * q_tiles + size_t(blk_q);
+        const int total_q_tiles = cute::ceil_div(score_q_extent, int(get<0>(TileShapeQK{})));
+        const int q_tiles = p.q_tile_count > 0 ? cute::min(total_q_tiles, p.q_tile_count) : total_q_tiles;
+        const int q_tile_slot = blk_q - p.q_tile_start;
+        const size_t wg_slot = (size_t(score_batch) * s.num_heads_q + q_head_idx) * q_tiles + size_t(q_tile_slot);
         score_head_ptr = params.mainloop.ptr_score + wg_slot * size_t(get<0>(TileShapeQK{})) * size_t(score_k_extent);
       }
 #endif

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_tile_scheduler.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_tile_scheduler.hpp
@@ -46,6 +46,7 @@ struct XeFHMAIndividualTileScheduler {
     FastDivmod divmod_num_heads;
     FastDivmod divmod_batch;
     int num_kv_splits_ = -1;
+    int q_tile_start = 0;
   };
 
   bool valid_ = true;
@@ -73,7 +74,7 @@ struct XeFHMAIndividualTileScheduler {
       grid.z *= num_kv_splits;
       num_head = shape.num_heads_kv;
     }
-    return Params{grid, {num_head}, {shape.batch * num_head}, num_kv_splits};
+    return Params{grid, {num_head}, {shape.batch * num_head}, num_kv_splits, 0};
   }
 
   template <int Num_SGs>
@@ -95,12 +96,12 @@ struct XeFHMAIndividualTileScheduler {
     if (params.num_kv_splits_ >= 1) {
       params.divmod_batch(idx_kv_split, idx_b, idx_kv_split);
       params.divmod_num_heads(idx_b, head, idx_b);
-      return make_coord(BlockIdxY(), BlockIdxX(), head, idx_b, idx_kv_split);
+      return make_coord(params.q_tile_start + BlockIdxY(), BlockIdxX(), head, idx_b, idx_kv_split);
     }
 
     idx_b = idx_kv_split;
     params.divmod_num_heads(idx_b, head, idx_b);
-    return make_coord(BlockIdxY(), BlockIdxX(), head, idx_b, (int)-1);
+    return make_coord(params.q_tile_start + BlockIdxY(), BlockIdxX(), head, idx_b, (int)-1);
   }
 
   CUTLASS_DEVICE

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -328,8 +328,8 @@ struct PrefillRunner {
   // to KV heads. The original NHD strides remain in the arguments because the
   // source tensors still contain all heads.
   template <class Kernel>
-  typename Kernel::Arguments slice_query_head_arguments(
-      typename Kernel::Arguments args, int query_head, int query_head_count) const {
+  typename Kernel::Arguments
+  slice_query_head_arguments(typename Kernel::Arguments args, int query_head, int query_head_count) const {
     const int head_group_q = args.kernel.shape.num_heads_q / args.kernel.shape.num_heads_kv;
     const int kv_head = query_head / head_group_q;
     const int head_offset_in_group = query_head % head_group_q;
@@ -412,8 +412,7 @@ struct PrefillRunner {
           batch_slice = int(cute::max(size_t(1), cap_bytes / full_batch_workspace));
           batch_slice = cute::min(batch_total, batch_slice);
         } else {
-          const int q_tiles = cute::ceil_div(
-              params.seqlen_q, int(get<0>(typename FMHAPrefillKernel::TileShapeQK{})));
+          const int q_tiles = cute::ceil_div(params.seqlen_q, int(get<0>(typename FMHAPrefillKernel::TileShapeQK{})));
           const int target_heads = cute::ceil_div(cute::max(1, hw_info.sm_count), cute::max(1, q_tiles));
           query_head_slice = cute::min(params.h, target_heads);
           const int first_head_slice = get_query_head_slice_size(0, params.h, head_group_q, query_head_slice);
@@ -437,7 +436,8 @@ struct PrefillRunner {
       if (std::getenv("FMHA_SCORE_WS_VERBOSE") != nullptr) {
         std::fprintf(
             stderr,
-            "[fmha] score workspace: batch=%d batch_slice=%d slices=%d query_head_slice=%d q_tile_rows=%d bytes=%zu (%.1f MiB)\n",
+            "[fmha] score workspace: batch=%d batch_slice=%d slices=%d query_head_slice=%d q_tile_rows=%d bytes=%zu "
+            "(%.1f MiB)\n",
             batch_total,
             batch_slice,
             num_slices,
@@ -449,8 +449,8 @@ struct PrefillRunner {
     }
     // get_workspace_size() is expressed in bytes. Keep the score workspace byte-addressed
     // so BF16/FP16 tensor options do not allocate two bytes for every requested byte.
-    auto workspace = torch::empty(
-        {static_cast<int64_t>(workspace_size)}, torch::device(torch::kXPU).dtype(torch::kByte));
+    auto workspace =
+        torch::empty({static_cast<int64_t>(workspace_size)}, torch::device(torch::kXPU).dtype(torch::kByte));
     void* workspace_ptr = workspace.data_ptr();
 
     if (!FMHAPrefillKernel::can_implement(arguments)) {

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -324,6 +324,39 @@ struct PrefillRunner {
     return args;
   }
 
+  // ScoreBlock2D slices contiguous query heads while preserving their mapping
+  // to KV heads. The original NHD strides remain in the arguments because the
+  // source tensors still contain all heads.
+  template <class Kernel>
+  typename Kernel::Arguments slice_query_head_arguments(
+      typename Kernel::Arguments args, int query_head, int query_head_count) const {
+    const int head_group_q = args.kernel.shape.num_heads_q / args.kernel.shape.num_heads_kv;
+    const int kv_head = query_head / head_group_q;
+    const int head_offset_in_group = query_head % head_group_q;
+    const int kv_head_count =
+        query_head_count <= head_group_q - head_offset_in_group ? 1 : query_head_count / head_group_q;
+    const int head_size_qk = args.kernel.shape.head_size_qk;
+    const int head_size_vo = args.kernel.shape.head_size_vo;
+
+    args.kernel.shape.num_heads_q = query_head_count;
+    args.kernel.shape.num_heads_kv = kv_head_count;
+    args.kernel.Q += size_t(query_head) * size_t(head_size_qk);
+    args.kernel.O += size_t(query_head) * size_t(head_size_vo);
+    args.kernel.K_cache += size_t(kv_head) * size_t(head_size_qk);
+    args.kernel.V_cache += size_t(kv_head) * size_t(head_size_vo);
+    return args;
+  }
+
+  static int get_query_head_slice_size(int query_head, int query_heads, int head_group_q, int requested_heads) {
+    const int heads_remaining = query_heads - query_head;
+    const int head_offset_in_group = query_head % head_group_q;
+    if (head_offset_in_group != 0 || requested_heads < head_group_q) {
+      return cute::min(requested_heads, cute::min(heads_remaining, head_group_q - head_offset_in_group));
+    }
+    // A KV-head-group-aligned slice may include multiple complete GQA groups.
+    return cute::min(heads_remaining, (requested_heads / head_group_q) * head_group_q);
+  }
+
   cutlass::Status run(const Arguments& params, const cutlass::KernelHardwareInfo& hw_info) {
     ProblemShapeType shape = initialize(params);
 
@@ -362,6 +395,7 @@ struct PrefillRunner {
 
     const int batch_total = params.b;
     int batch_slice = batch_total;
+    int query_head_slice = params.h;
     if constexpr (CollectiveMainloop::ScoreBlock2D) {
       static const int cap_mb = [] {
         if (const char* env = std::getenv("FMHA_SCORE_WS_CAP_MB")) {
@@ -369,33 +403,54 @@ struct PrefillRunner {
         }
         return DefaultScoreWorkspaceCapMiB;
       }();
-      if (cap_mb > 0 && batch_total > 1) {
+      if (cap_mb > 0) {
         const size_t cap_bytes = size_t(cap_mb) << 20;
+        const int head_group_q = params.h / params.h_k;
         auto one_batch = slice_arguments<FMHAPrefillKernel>(arguments, 0, 1);
-        const size_t per_batch = FMHAPrefillKernel::get_workspace_size(one_batch);
-        if (per_batch > 0 && per_batch * size_t(batch_total) > cap_bytes) {
+        const size_t full_batch_workspace = FMHAPrefillKernel::get_workspace_size(one_batch);
+        if (full_batch_workspace <= cap_bytes) {
+          batch_slice = int(cute::max(size_t(1), cap_bytes / full_batch_workspace));
+          batch_slice = cute::min(batch_total, batch_slice);
+        } else {
+          const int q_tiles = cute::ceil_div(
+              params.seqlen_q, int(get<0>(typename FMHAPrefillKernel::TileShapeQK{})));
+          const int target_heads = cute::ceil_div(cute::max(1, hw_info.sm_count), cute::max(1, q_tiles));
+          query_head_slice = cute::min(params.h, target_heads);
+          const int first_head_slice = get_query_head_slice_size(0, params.h, head_group_q, query_head_slice);
+          const size_t per_batch = FMHAPrefillKernel::get_workspace_size(
+              slice_query_head_arguments<FMHAPrefillKernel>(one_batch, 0, first_head_slice));
           batch_slice = int(cute::max(size_t(1), cap_bytes / per_batch));
+          batch_slice = cute::min(batch_total, batch_slice);
         }
       }
     }
     const int num_slices = cute::ceil_div(batch_total, batch_slice);
 
-    // Every slice reuses the same device-global score buffer.
-    auto workspace_shape = num_slices > 1 ? slice_arguments<FMHAPrefillKernel>(arguments, 0, batch_slice) : arguments;
-    size_t workspace_size = FMHAPrefillKernel::get_workspace_size(workspace_shape);
+    const int head_group_q = params.h / params.h_k;
+    const int first_head_slice = get_query_head_slice_size(0, params.h, head_group_q, query_head_slice);
+    // Every batch/head slice reuses the score buffer.
+    const size_t workspace_size = FMHAPrefillKernel::get_workspace_size(slice_query_head_arguments<FMHAPrefillKernel>(
+        num_slices > 1 ? slice_arguments<FMHAPrefillKernel>(arguments, 0, batch_slice) : arguments,
+        0,
+        first_head_slice));
     if constexpr (CollectiveMainloop::ScoreBlock2D) {
       if (std::getenv("FMHA_SCORE_WS_VERBOSE") != nullptr) {
         std::fprintf(
             stderr,
-            "[fmha] score workspace: batch=%d slice=%d slices=%d bytes=%zu (%.1f MiB)\n",
+            "[fmha] score workspace: batch=%d batch_slice=%d slices=%d query_head_slice=%d q_tile_rows=%d bytes=%zu (%.1f MiB)\n",
             batch_total,
             batch_slice,
             num_slices,
+            query_head_slice,
+            int(get<0>(typename FMHAPrefillKernel::TileShapeQK{})),
             workspace_size,
             double(workspace_size) / (1024.0 * 1024.0));
       }
     }
-    auto workspace = torch::empty(workspace_size, params.tensor_opts);
+    // get_workspace_size() is expressed in bytes. Keep the score workspace byte-addressed
+    // so BF16/FP16 tensor options do not allocate two bytes for every requested byte.
+    auto workspace = torch::empty(
+        {static_cast<int64_t>(workspace_size)}, torch::device(torch::kXPU).dtype(torch::kByte));
     void* workspace_ptr = workspace.data_ptr();
 
     if (!FMHAPrefillKernel::can_implement(arguments)) {
@@ -412,9 +467,14 @@ struct PrefillRunner {
 
       for (int batch_lo = 0; batch_lo < batch_total; batch_lo += batch_slice) {
         const int batch_len = cute::min(batch_slice, batch_total - batch_lo);
-        auto slice = slice_arguments<FMHAPrefillKernel>(arguments, batch_lo, batch_len);
-        launch<ScoreStoreKernel>(ScoreStoreKernel::to_underlying_arguments(slice, workspace_ptr));
-        launch<ScoreLoadKernel>(ScoreLoadKernel::to_underlying_arguments(slice, workspace_ptr));
+        auto batch_args = slice_arguments<FMHAPrefillKernel>(arguments, batch_lo, batch_len);
+        for (int query_head = 0; query_head < params.h;) {
+          const int head_count = get_query_head_slice_size(query_head, params.h, head_group_q, query_head_slice);
+          auto slice = slice_query_head_arguments<FMHAPrefillKernel>(batch_args, query_head, head_count);
+          launch<ScoreStoreKernel>(ScoreStoreKernel::to_underlying_arguments(slice, workspace_ptr));
+          launch<ScoreLoadKernel>(ScoreLoadKernel::to_underlying_arguments(slice, workspace_ptr));
+          query_head += head_count;
+        }
       }
     } else {
       launch<FMHAPrefillKernel>(FMHAPrefillKernel::to_underlying_arguments(arguments, workspace_ptr));

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -357,6 +357,17 @@ struct PrefillRunner {
     return cute::min(heads_remaining, (requested_heads / head_group_q) * head_group_q);
   }
 
+  // ScoreBlock2D reuses the same workspace for each contiguous Q-tile chunk.
+  // The scheduler receives the chunk's absolute tile start while workspace
+  // indexing uses q_tile_count as its local tile extent.
+  template <class Kernel>
+  typename Kernel::Arguments
+  slice_query_tile_arguments(typename Kernel::Arguments args, int query_tile_start, int query_tile_count) const {
+    args.kernel.q_tile_start = query_tile_start;
+    args.kernel.q_tile_count = query_tile_count;
+    return args;
+  }
+
   cutlass::Status run(const Arguments& params, const cutlass::KernelHardwareInfo& hw_info) {
     ProblemShapeType shape = initialize(params);
 
@@ -396,28 +407,65 @@ struct PrefillRunner {
     const int batch_total = params.b;
     int batch_slice = batch_total;
     int query_head_slice = params.h;
+    int query_tile_slice = -1;
+    int q_tiles = 0;
+    [[maybe_unused]] int score_workspace_cap_mb = 0;
     if constexpr (CollectiveMainloop::ScoreBlock2D) {
+      TORCH_CHECK(
+          batch_total > 0 && params.h > 0 && params.seqlen_q > 0 && params.seqlen_k > 0,
+          "ScoreBlock2D requires positive batch, query heads, and Q/K sequence lengths");
+      q_tiles = cute::ceil_div(params.seqlen_q, int(get<0>(typename FMHAPrefillKernel::TileShapeQK{})));
+      query_tile_slice = q_tiles;
       static const int cap_mb = [] {
         if (const char* env = std::getenv("FMHA_SCORE_WS_CAP_MB")) {
           return std::atoi(env);
         }
         return DefaultScoreWorkspaceCapMiB;
       }();
+      score_workspace_cap_mb = cap_mb;
       if (cap_mb > 0) {
         const size_t cap_bytes = size_t(cap_mb) << 20;
         const int head_group_q = params.h / params.h_k;
-        auto one_batch = slice_arguments<FMHAPrefillKernel>(arguments, 0, 1);
-        const size_t full_batch_workspace = FMHAPrefillKernel::get_workspace_size(one_batch);
+        const auto score_workspace_size = [&](int batches, int query_heads, int query_tiles) {
+          auto batch_args = slice_arguments<FMHAPrefillKernel>(arguments, 0, batches);
+          auto head_args = slice_query_head_arguments<FMHAPrefillKernel>(batch_args, 0, query_heads);
+          auto tile_args = slice_query_tile_arguments<FMHAPrefillKernel>(head_args, 0, query_tiles);
+          return FMHAPrefillKernel::get_workspace_size(tile_args);
+        };
+        const size_t full_batch_workspace = score_workspace_size(1, params.h, q_tiles);
         if (full_batch_workspace <= cap_bytes) {
+          // This is the PR342 launch shape: preserve every Q head and tile in
+          // one ScoreStore/ScoreLoad pair, reducing only the batch extent.
           batch_slice = int(cute::max(size_t(1), cap_bytes / full_batch_workspace));
           batch_slice = cute::min(batch_total, batch_slice);
         } else {
-          const int q_tiles = cute::ceil_div(params.seqlen_q, int(get<0>(typename FMHAPrefillKernel::TileShapeQK{})));
-          const int target_heads = cute::ceil_div(cute::max(1, hw_info.sm_count), cute::max(1, q_tiles));
-          query_head_slice = cute::min(params.h, target_heads);
-          const int first_head_slice = get_query_head_slice_size(0, params.h, head_group_q, query_head_slice);
-          const size_t per_batch = FMHAPrefillKernel::get_workspace_size(
-              slice_query_head_arguments<FMHAPrefillKernel>(one_batch, 0, first_head_slice));
+          // Preserve all Q heads where possible. A Q-tile slice keeps the
+          // large multi-head grid from PR342 and needs far fewer launches than
+          // slicing into individual GQA heads.
+          size_t one_q_tile_workspace = score_workspace_size(1, params.h, 1);
+          if (one_q_tile_workspace > cap_bytes) {
+            // An entire Q-head set cannot fit even for one Q tile. Reduce
+            // heads only as far as required by the workspace cap.
+            for (int requested_heads = params.h; requested_heads > 0;) {
+              const int candidate_heads =
+                  get_query_head_slice_size(0, params.h, head_group_q, requested_heads);
+              if (score_workspace_size(1, candidate_heads, 1) <= cap_bytes) {
+                query_head_slice = candidate_heads;
+                break;
+              }
+              requested_heads = candidate_heads - 1;
+            }
+            TORCH_CHECK(
+                query_head_slice > 0 && score_workspace_size(1, query_head_slice, 1) <= cap_bytes,
+                "ScoreBlock2D one-Q-tile workspace exceeds FMHA_SCORE_WS_CAP_MB=",
+                cap_mb,
+                "; increase the cap");
+            one_q_tile_workspace = score_workspace_size(1, query_head_slice, 1);
+          }
+
+          query_tile_slice = cute::min(q_tiles, int(cute::max(size_t(1), cap_bytes / one_q_tile_workspace)));
+          const size_t per_batch =
+              score_workspace_size(1, query_head_slice, query_tile_slice);
           batch_slice = int(cute::max(size_t(1), cap_bytes / per_batch));
           batch_slice = cute::min(batch_total, batch_slice);
         }
@@ -427,34 +475,58 @@ struct PrefillRunner {
 
     const int head_group_q = params.h / params.h_k;
     const int first_head_slice = get_query_head_slice_size(0, params.h, head_group_q, query_head_slice);
+    if (!FMHAPrefillKernel::can_implement(arguments)) {
+      return cutlass::Status::kErrorInvalidProblem;
+    }
+
     // Every batch/head slice reuses the score buffer.
-    const size_t workspace_size = FMHAPrefillKernel::get_workspace_size(slice_query_head_arguments<FMHAPrefillKernel>(
-        num_slices > 1 ? slice_arguments<FMHAPrefillKernel>(arguments, 0, batch_slice) : arguments,
-        0,
-        first_head_slice));
+    const auto workspace_shape = [&] {
+      auto head_shape = slice_query_head_arguments<FMHAPrefillKernel>(
+          num_slices > 1 ? slice_arguments<FMHAPrefillKernel>(arguments, 0, batch_slice) : arguments,
+          0,
+          first_head_slice);
+      if constexpr (CollectiveMainloop::ScoreBlock2D) {
+        return slice_query_tile_arguments<FMHAPrefillKernel>(head_shape, 0, query_tile_slice);
+      }
+      return head_shape;
+    }();
+    const size_t workspace_size = FMHAPrefillKernel::get_workspace_size(workspace_shape);
     if constexpr (CollectiveMainloop::ScoreBlock2D) {
       if (std::getenv("FMHA_SCORE_WS_VERBOSE") != nullptr) {
         std::fprintf(
             stderr,
-            "[fmha] score workspace: batch=%d batch_slice=%d slices=%d query_head_slice=%d q_tile_rows=%d bytes=%zu "
+            "[fmha] score workspace: batch=%d batch_slice=%d slices=%d query_head_slice=%d query_tile_slice=%d "
+            "q_tile_rows=%d bytes=%zu "
             "(%.1f MiB)\n",
             batch_total,
             batch_slice,
             num_slices,
             query_head_slice,
+            query_tile_slice,
             int(get<0>(typename FMHAPrefillKernel::TileShapeQK{})),
             workspace_size,
             double(workspace_size) / (1024.0 * 1024.0));
       }
     }
-    // get_workspace_size() is expressed in bytes. Keep the score workspace byte-addressed
-    // so BF16/FP16 tensor options do not allocate two bytes for every requested byte.
-    auto workspace =
-        torch::empty({static_cast<int64_t>(workspace_size)}, torch::device(torch::kXPU).dtype(torch::kByte));
-    void* workspace_ptr = workspace.data_ptr();
-
-    if (!FMHAPrefillKernel::can_implement(arguments)) {
-      return cutlass::Status::kErrorInvalidProblem;
+    // Only the HD512 ScoreBlock2D specializations own a score workspace. Other
+    // head dimensions pass nullptr, so they never create even a zero-byte XPU
+    // allocation here. `workspace` remains alive through all asynchronous
+    // ScoreStore/ScoreLoad launches and is released when this runner returns.
+    torch::Tensor workspace;
+    void* workspace_ptr = nullptr;
+    if constexpr (CollectiveMainloop::ScoreBlock2D) {
+      TORCH_CHECK(
+          score_workspace_cap_mb <= 0 || workspace_size <= (size_t(score_workspace_cap_mb) << 20),
+          "ScoreBlock2D minimum workspace (",
+          workspace_size,
+          " bytes) exceeds FMHA_SCORE_WS_CAP_MB=",
+          score_workspace_cap_mb,
+          "; increase the cap or reduce sequence length");
+      // get_workspace_size() is expressed in bytes. Keep the score workspace
+      // byte-addressed so BF16/FP16 tensor options do not allocate two bytes
+      // for every requested byte.
+      workspace = torch::empty({static_cast<int64_t>(workspace_size)}, torch::device(torch::kXPU).dtype(torch::kByte));
+      workspace_ptr = workspace.data_ptr();
     }
 
     // Initialize the workspace
@@ -470,9 +542,13 @@ struct PrefillRunner {
         auto batch_args = slice_arguments<FMHAPrefillKernel>(arguments, batch_lo, batch_len);
         for (int query_head = 0; query_head < params.h;) {
           const int head_count = get_query_head_slice_size(query_head, params.h, head_group_q, query_head_slice);
-          auto slice = slice_query_head_arguments<FMHAPrefillKernel>(batch_args, query_head, head_count);
-          launch<ScoreStoreKernel>(ScoreStoreKernel::to_underlying_arguments(slice, workspace_ptr));
-          launch<ScoreLoadKernel>(ScoreLoadKernel::to_underlying_arguments(slice, workspace_ptr));
+          auto head_args = slice_query_head_arguments<FMHAPrefillKernel>(batch_args, query_head, head_count);
+          for (int query_tile = 0; query_tile < q_tiles; query_tile += query_tile_slice) {
+            const int query_tile_count = cute::min(query_tile_slice, q_tiles - query_tile);
+            auto slice = slice_query_tile_arguments<FMHAPrefillKernel>(head_args, query_tile, query_tile_count);
+            launch<ScoreStoreKernel>(ScoreStoreKernel::to_underlying_arguments(slice, workspace_ptr));
+            launch<ScoreLoadKernel>(ScoreLoadKernel::to_underlying_arguments(slice, workspace_ptr));
+          }
           query_head += head_count;
         }
       }

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -447,8 +447,7 @@ struct PrefillRunner {
             // An entire Q-head set cannot fit even for one Q tile. Reduce
             // heads only as far as required by the workspace cap.
             for (int requested_heads = params.h; requested_heads > 0;) {
-              const int candidate_heads =
-                  get_query_head_slice_size(0, params.h, head_group_q, requested_heads);
+              const int candidate_heads = get_query_head_slice_size(0, params.h, head_group_q, requested_heads);
               if (score_workspace_size(1, candidate_heads, 1) <= cap_bytes) {
                 query_head_slice = candidate_heads;
                 break;
@@ -464,8 +463,7 @@ struct PrefillRunner {
           }
 
           query_tile_slice = cute::min(q_tiles, int(cute::max(size_t(1), cap_bytes / one_q_tile_workspace)));
-          const size_t per_batch =
-              score_workspace_size(1, query_head_slice, query_tile_slice);
+          const size_t per_batch = score_workspace_size(1, query_head_slice, query_tile_slice);
           batch_slice = int(cute::max(size_t(1), cap_bytes / per_batch));
           batch_slice = cute::min(batch_total, batch_slice);
         }

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -2334,6 +2334,40 @@ if EXTENDED_KVCACHE_TESTS:
             dtype=dtype,
         )
 
+    @pytest.mark.skipif(
+        not is_fa3_supported(),
+        reason="flash_attn at sgl-kernel is only supported on BMG and later",
+    )
+    def test_flash_attn_varlen_hd512_32k_score_workspace():
+        """Regression for the HD512 ScoreBlock2D workspace OOM reported in PR 342."""
+        from sgl_kernel.flash_attn import flash_attn_varlen_func
+
+        seqlen = 32768
+        nheads_q = 16
+        nheads_kv = 2
+        head_dim = 512
+        torch.manual_seed(0)
+
+        q = torch.randn(seqlen, nheads_q, head_dim, device=device, dtype=torch.bfloat16)
+        k = torch.randn(seqlen, nheads_kv, head_dim, device=device, dtype=torch.bfloat16)
+        v = torch.randn(seqlen, nheads_kv, head_dim, device=device, dtype=torch.bfloat16)
+        cu_seqlens = torch.tensor([0, seqlen], device=device, dtype=torch.int32)
+
+        out = flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens,
+            cu_seqlens,
+            seqlen,
+            seqlen,
+            causal=True,
+        )
+        torch.xpu.synchronize()
+        assert out.shape == (seqlen, nheads_q, head_dim)
+        assert out.dtype == torch.bfloat16
+        assert torch.isfinite(out).all()
+
 
 @pytest.mark.skipif(device.type != "xpu", reason="XPU not available")
 def test_flash_attn_with_kvcache_out_buffer():

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -2,6 +2,7 @@
 import itertools
 import math
 import os
+import re
 import sys
 
 import pytest
@@ -2342,8 +2343,9 @@ if EXTENDED_KVCACHE_TESTS:
         "batch_size,nheads_q,nheads_kv,seqlen_q,seqlen_k",
         [
             (1, 16, 2, 32768, 32768),
-            # 16 Q tiles per head: requires two query heads to cover both BMG
-            # (20 Xe-cores) and CRI (32 Xe-cores) without a 4 GiB score buffer.
+            # Non-paged HD512 uses 32 Q tiles per head. Q-tile chunking keeps
+            # one query head sufficient to cover BMG (20 Xe-cores) without a
+            # 4 GiB score buffer.
             (1, 16, 2, 4096, 32768),
             # A low-head, high-batch case must accumulate Q tiles across batch
             # slices instead of allocating all eight score matrices at once.
@@ -2354,13 +2356,14 @@ if EXTENDED_KVCACHE_TESTS:
         ],
     )
     def test_flash_attn_varlen_hd512_large_score_workspace(
-        batch_size, nheads_q, nheads_kv, seqlen_q, seqlen_k
+        batch_size, nheads_q, nheads_kv, seqlen_q, seqlen_k, monkeypatch, capfd
     ):
-        """Large ScoreBlock2D cases that require batch and GQA-head slicing."""
+        """Large ScoreBlock2D cases that require batch, GQA-head, and Q-tile slicing."""
         from sgl_kernel.flash_attn import flash_attn_varlen_func
 
         head_dim = 512
         torch.manual_seed(0)
+        monkeypatch.setenv("FMHA_SCORE_WS_VERBOSE", "1")
 
         total_q = batch_size * seqlen_q
         total_k = batch_size * seqlen_k
@@ -2394,6 +2397,15 @@ if EXTENDED_KVCACHE_TESTS:
         assert out.shape == (total_q, nheads_q, head_dim)
         assert out.dtype == torch.bfloat16
         assert torch.isfinite(out).all()
+        _, stderr = capfd.readouterr()
+        match = re.search(
+            r"query_tile_slice=(\d+) q_tile_rows=(\d+) bytes=(\d+)", stderr
+        )
+        assert match, f"missing ScoreBlock2D workspace report: {stderr}"
+        q_tile_slice, q_tile_rows, workspace_bytes = map(int, match.groups())
+        total_q_tiles = math.ceil(seqlen_q / q_tile_rows)
+        assert 1 <= q_tile_slice <= total_q_tiles
+        assert workspace_bytes <= 1024 * 1024 * 1024
 
     @pytest.mark.parametrize(
         "batch_size,nheads_q,nheads_kv",

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -2338,33 +2338,120 @@ if EXTENDED_KVCACHE_TESTS:
         not is_fa3_supported(),
         reason="flash_attn at sgl-kernel is only supported on BMG and later",
     )
-    def test_flash_attn_varlen_hd512_32k_score_workspace():
-        """Regression for the HD512 ScoreBlock2D workspace OOM reported in PR 342."""
+    @pytest.mark.parametrize(
+        "batch_size,nheads_q,nheads_kv,seqlen_q,seqlen_k",
+        [
+            (1, 16, 2, 32768, 32768),
+            # 16 Q tiles per head: requires two query heads to cover both BMG
+            # (20 Xe-cores) and CRI (32 Xe-cores) without a 4 GiB score buffer.
+            (1, 16, 2, 4096, 32768),
+            # A low-head, high-batch case must accumulate Q tiles across batch
+            # slices instead of allocating all eight score matrices at once.
+            (8, 1, 1, 4096, 32768),
+            # Exercises nested batch and GQA-head slicing: one unsliced batch
+            # needs 2 GiB and the complete problem needs 8 GiB.
+            (4, 8, 1, 4096, 32768),
+        ],
+    )
+    def test_flash_attn_varlen_hd512_large_score_workspace(
+        batch_size, nheads_q, nheads_kv, seqlen_q, seqlen_k
+    ):
+        """Large ScoreBlock2D cases that require batch and GQA-head slicing."""
         from sgl_kernel.flash_attn import flash_attn_varlen_func
 
-        seqlen = 32768
-        nheads_q = 16
-        nheads_kv = 2
         head_dim = 512
         torch.manual_seed(0)
 
-        q = torch.randn(seqlen, nheads_q, head_dim, device=device, dtype=torch.bfloat16)
-        k = torch.randn(seqlen, nheads_kv, head_dim, device=device, dtype=torch.bfloat16)
-        v = torch.randn(seqlen, nheads_kv, head_dim, device=device, dtype=torch.bfloat16)
-        cu_seqlens = torch.tensor([0, seqlen], device=device, dtype=torch.int32)
+        total_q = batch_size * seqlen_q
+        total_k = batch_size * seqlen_k
+        q = torch.randn(total_q, nheads_q, head_dim, device=device, dtype=torch.bfloat16)
+        k = torch.randn(total_k, nheads_kv, head_dim, device=device, dtype=torch.bfloat16)
+        v = torch.randn(total_k, nheads_kv, head_dim, device=device, dtype=torch.bfloat16)
+        cu_seqlens_q = torch.arange(
+            0, total_q + 1, seqlen_q, device=device, dtype=torch.int32
+        )
+        cu_seqlens_k = torch.arange(
+            0, total_k + 1, seqlen_k, device=device, dtype=torch.int32
+        )
 
         out = flash_attn_varlen_func(
             q,
             k,
             v,
-            cu_seqlens,
-            cu_seqlens,
-            seqlen,
-            seqlen,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            seqlen_q,
+            seqlen_k,
             causal=True,
         )
         torch.xpu.synchronize()
-        assert out.shape == (seqlen, nheads_q, head_dim)
+        assert out.shape == (total_q, nheads_q, head_dim)
+        assert out.dtype == torch.bfloat16
+        assert torch.isfinite(out).all()
+
+    @pytest.mark.parametrize(
+        "batch_size,nheads_q,nheads_kv",
+        [
+            (1, 16, 2),
+            (8, 1, 1),
+        ],
+    )
+    def test_flash_attn_paged_hd512_large_score_workspace(
+        batch_size, nheads_q, nheads_kv
+    ):
+        """Paged ScoreBlock2D cases that previously required a 4 GiB workspace."""
+        from sgl_kernel.flash_attn import flash_attn_with_kvcache
+
+        seqlen_q = 4096
+        seqlen_k = 32768
+        page_size = 128
+        head_dim = 512
+        pages_per_seq = seqlen_k // page_size
+        num_pages = batch_size * pages_per_seq
+        torch.manual_seed(0)
+
+        q = torch.randn(
+            batch_size * seqlen_q,
+            nheads_q,
+            head_dim,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        k_cache = torch.randn(
+            num_pages,
+            page_size,
+            nheads_kv,
+            head_dim,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        v_cache = torch.randn_like(k_cache)
+        page_table = torch.arange(
+            num_pages, device=device, dtype=torch.int32
+        ).reshape(batch_size, pages_per_seq)
+        cache_seqlens = torch.full(
+            (batch_size,), seqlen_k, device=device, dtype=torch.int32
+        )
+        cu_seqlens_q = torch.arange(
+            0,
+            batch_size * seqlen_q + 1,
+            seqlen_q,
+            device=device,
+            dtype=torch.int32,
+        )
+
+        out = flash_attn_with_kvcache(
+            q,
+            k_cache,
+            v_cache,
+            cache_seqlens=cache_seqlens,
+            page_table=page_table,
+            cu_seqlens_q=cu_seqlens_q,
+            max_seqlen_q=seqlen_q,
+            causal=True,
+        )
+        torch.xpu.synchronize()
+        assert out.shape == (batch_size * seqlen_q, nheads_q, head_dim)
         assert out.dtype == torch.bfloat16
         assert torch.isfinite(out).all()
 

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -2364,9 +2364,15 @@ if EXTENDED_KVCACHE_TESTS:
 
         total_q = batch_size * seqlen_q
         total_k = batch_size * seqlen_k
-        q = torch.randn(total_q, nheads_q, head_dim, device=device, dtype=torch.bfloat16)
-        k = torch.randn(total_k, nheads_kv, head_dim, device=device, dtype=torch.bfloat16)
-        v = torch.randn(total_k, nheads_kv, head_dim, device=device, dtype=torch.bfloat16)
+        q = torch.randn(
+            total_q, nheads_q, head_dim, device=device, dtype=torch.bfloat16
+        )
+        k = torch.randn(
+            total_k, nheads_kv, head_dim, device=device, dtype=torch.bfloat16
+        )
+        v = torch.randn(
+            total_k, nheads_kv, head_dim, device=device, dtype=torch.bfloat16
+        )
         cu_seqlens_q = torch.arange(
             0, total_q + 1, seqlen_q, device=device, dtype=torch.int32
         )
@@ -2426,9 +2432,9 @@ if EXTENDED_KVCACHE_TESTS:
             dtype=torch.bfloat16,
         )
         v_cache = torch.randn_like(k_cache)
-        page_table = torch.arange(
-            num_pages, device=device, dtype=torch.int32
-        ).reshape(batch_size, pages_per_seq)
+        page_table = torch.arange(num_pages, device=device, dtype=torch.int32).reshape(
+            batch_size, pages_per_seq
+        )
         cache_seqlens = torch.full(
             (batch_size,), seqlen_k, device=device, dtype=torch.int32
         )

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -2336,13 +2336,20 @@ if EXTENDED_KVCACHE_TESTS:
         )
 
     @pytest.mark.skipif(
-        not is_fa3_supported(),
-        reason="flash_attn at sgl-kernel is only supported on BMG and later",
+        device.type != "xpu" or not is_fa3_supported(),
+        reason="large ScoreBlock2D workspace coverage is only supported on BMG XPU",
     )
     @pytest.mark.parametrize(
         "batch_size,nheads_q,nheads_kv,seqlen_q,seqlen_k",
         [
             (1, 16, 2, 32768, 32768),
+            # These all require the 1 GiB score workspace cap to slice a
+            # 32K x 32K HD512 problem.
+            (4, 16, 2, 32768, 32768),
+            (1, 32, 4, 32768, 32768),
+            (8, 8, 1, 32768, 32768),
+            (32, 4, 1, 32768, 32768),
+            (4, 8, 2, 32768, 32768),
             # Non-paged HD512 uses 32 Q tiles per head. Q-tile chunking keeps
             # one query head sufficient to cover BMG (20 Xe-cores) without a
             # 4 GiB score buffer.


### PR DESCRIPTION
## Summary
- allocate the ScoreBlock2D workspace as bytes instead of dtype-sized elements
- slice large score workspaces across batches, GQA query heads, and Q-tile chunks while preserving enough Q-tile parallelism for BMG/CRI
- preserve original strides when rebasing sliced varlen tensors
- add extended paged and non-paged OOM regressions across large sequence, high-batch/low-head, and nested batch/head slicing cases

## Performance and workspace-cap trade-off
- `FMHA_SCORE_WS_CAP_MB` is a memory/performance knob (default: 1024 MiB). A larger score buffer lets each launch cover more Q tiles, reducing the number of ScoreStore/ScoreLoad launch pairs and their global score-buffer write/read overhead. The cost is higher peak XPU memory and a greater OOM risk.
- At `B=1, Hq/Hkv=16/2, Sq=Sk=4096, D=512` (BF16 non-paged varlen prefill), the full Q extent fits in 512 MiB: `query_tile_slice=32`, one ScoreStore/ScoreLoad pair, 51.3 ms vs. 72.3 ms without ScoreBlock2D (29.1% lower latency; 41.0% higher throughput).
- At `Sq=Sk=32768`, the 1 GiB cap allows only `query_tile_slice=8`: 32 Q-tile chunks / ScoreStore+ScoreLoad pairs. ScoreBlock2D still improves latency, 3992.4 ms vs. 5004.5 ms (20.2% lower latency; 25.4% higher throughput), but the extra launch and buffer-traffic cost reduces the realized gain. Raising the cap would reduce the chunk count, subject to available memory.
- The optimization is not a universal win for tiny/low-parallelism prefill shapes: `Sq=1` showed no material benefit, and tested `Hq<=4, Sq=16/64` cases regressed. These measurements are specific to the HD512 BF16 non-paged varlen path.

## Validation
- `FLASH_ATTENTION_KVCACHE_EXTENDED_TESTS=1 pytest -q tests/test_flash_attention.py`: 35256 passed, 4996 skipped
- large ScoreBlock2D OOM regressions: 6 passed
- Valentine 32K case: `B=1, Hq/Hkv=16/2, Sq=Sk=32768, D=512`, passed with finite BF16 output
- `python benchmark/bench_flash_attn.py`: completed on BMG GPU 0
- `pre-commit run --files <PR changed files>`: passed
- full bundled FMHA/common_ops build completed with controlled parallelism (`SGL_KERNEL_BUILD_JOBS=20`)