### PR TITLE
[Fix] normalize hc_post post tensor from 3d to 2d

### DIFF
--- a/src/sycl/HCPost.cpp
+++ b/src/sycl/HCPost.cpp
@@ -165,11 +165,12 @@ SGL_KERNEL_EXPORT void hc_post(
   TORCH_CHECK(residual.size(2) == D, "residual D mismatch");
 
   at::Tensor post_layer_mix_2d = post_layer_mix;
-  if (post_layer_mix.dim() == 3 && post_layer_mix.size(-1) == 1) {
-    post_layer_mix_2d = post_layer_mix.squeeze(-1);
+  if (post_layer_mix_2d.dim() == 3) {
+    TORCH_CHECK(post_layer_mix_2d.size(2) == 1, "post_layer_mix last dim must be 1 when rank=3");
+    post_layer_mix_2d = post_layer_mix_2d.squeeze(-1);
   }
 
-  TORCH_CHECK(post_layer_mix_2d.dim() == 2, "post_layer_mix must be 2D [T, HC]");
+  TORCH_CHECK(post_layer_mix_2d.dim() == 2, "post_layer_mix must be [T, HC] or [T, HC, 1]");
   TORCH_CHECK(post_layer_mix_2d.size(0) == T, "post_layer_mix T mismatch");
   TORCH_CHECK(post_layer_mix_2d.size(1) == 4, "post_layer_mix must have 4 elements (HC=4)");
 

--- a/src/sycl/HCPost.cpp
+++ b/src/sycl/HCPost.cpp
@@ -164,9 +164,14 @@ SGL_KERNEL_EXPORT void hc_post(
   TORCH_CHECK(residual.size(1) == 4, "residual must have 4 channels (HC=4)");
   TORCH_CHECK(residual.size(2) == D, "residual D mismatch");
 
-  TORCH_CHECK(post_layer_mix.dim() == 2, "post_layer_mix must be 2D [T, HC]");
-  TORCH_CHECK(post_layer_mix.size(0) == T, "post_layer_mix T mismatch");
-  TORCH_CHECK(post_layer_mix.size(1) == 4, "post_layer_mix must have 4 elements (HC=4)");
+  at::Tensor post_layer_mix_2d = post_layer_mix;
+  if (post_layer_mix.dim() == 3 && post_layer_mix.size(-1) == 1) {
+    post_layer_mix_2d = post_layer_mix.squeeze(-1);
+  }
+
+  TORCH_CHECK(post_layer_mix_2d.dim() == 2, "post_layer_mix must be 2D [T, HC]");
+  TORCH_CHECK(post_layer_mix_2d.size(0) == T, "post_layer_mix T mismatch");
+  TORCH_CHECK(post_layer_mix_2d.size(1) == 4, "post_layer_mix must have 4 elements (HC=4)");
 
   TORCH_CHECK(comb_res_mix.dim() == 3, "comb_res_mix must be 3D [T, HC, HC]");
   TORCH_CHECK(comb_res_mix.size(0) == T, "comb_res_mix T mismatch");
@@ -182,5 +187,5 @@ SGL_KERNEL_EXPORT void hc_post(
 
   constexpr int VEC_SIZE = 4;
   TORCH_CHECK(D % VEC_SIZE == 0, "D must be a multiple of VEC_SIZE (", VEC_SIZE, "), got D=", D);
-  launch_hc_post_kernel<VEC_SIZE>(q, x, residual, post_layer_mix, comb_res_mix, out, T, D);
+  launch_hc_post_kernel<VEC_SIZE>(q, x, residual, post_layer_mix_2d, comb_res_mix, out, T, D);
 }


### PR DESCRIPTION
This patch normalizes the post_layer_mix tensor at the XPU hc_post entry point before the SYCL kernel validates dimensions.

When sglang passes inputs shaped like (T, HC, 1), the XPU kernel previously rejected it because it requires post_layer_mix to be 2D: (T, HC). The CUDA path already squeezes the last dimension before launching the kernel (https://github.com/sgl-project/sglang/blob/main/python/sglang/kernels/ops/layernorm/mhc.py#L1054), so the XPU path needed the same contract enforcement to match.