### PR TITLE
Add fp32 support for topk_softmax

### DIFF
--- a/src/sycl/TopKSoftMax.cpp
+++ b/src/sycl/TopKSoftMax.cpp
@@ -630,7 +630,7 @@ topk_softmax(at::Tensor& topk_weights, at::Tensor& topk_indices, at::Tensor& gat
       " and n_experts=",
       n_experts);
 
-  AT_DISPATCH_REDUCED_FLOATING_TYPES(gating_output.scalar_type(), "fused_topk_softmax_kernel", [&]() {
+  DISPATCH_FLOAT_TYPES(gating_output.scalar_type(), "fused_topk_softmax_kernel", [&]() {
     TopKSoftmaxImpl::fused_topk_softmax<scalar_t>(
         gating_output.data_ptr<scalar_t>(),
         topk_weights.data_ptr<float>(),

--- a/tests/test_topk_softmax.py
+++ b/tests/test_topk_softmax.py
@@ -58,7 +58,7 @@ def fused_topk_torch_native(
     return topk_weights, topk_ids
 
 
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
 @pytest.mark.parametrize("n_token", [2, 32, 4096])
 @pytest.mark.parametrize("n_expert", [8, 32, 256])
 @pytest.mark.parametrize("n_topk", [1, 2, 4])


### PR DESCRIPTION
Some models need fp32 input for topk_softmax, such as ERNIE-4.5.