### PR TITLE
[CI] bench_flash_attn: skip LSE for local/sink combos

### DIFF
--- a/benchmark/bench_flash_attn.py
+++ b/benchmark/bench_flash_attn.py
@@ -23,8 +23,8 @@ def flash_attn_baseline(
     v_descale=None,
 ):
     """Baseline Flash Attention implementation"""
-    # Kernel only supports LSE without local/sink masking.
-    return_lse = window_size == (-1, -1) and sinks is None
+    # Kernel only supports LSE without causal/local/sink masking.
+    return_lse = not causal and window_size == (-1, -1) and sinks is None
 
     if page_table is not None:
         result = flash_attn_with_kvcache(

--- a/benchmark/bench_flash_attn.py
+++ b/benchmark/bench_flash_attn.py
@@ -23,8 +23,11 @@ def flash_attn_baseline(
     v_descale=None,
 ):
     """Baseline Flash Attention implementation"""
+    # Kernel only supports LSE without local/sink masking.
+    return_lse = window_size == (-1, -1) and sinks is None
+
     if page_table is not None:
-        out, lse, *rest = flash_attn_with_kvcache(
+        result = flash_attn_with_kvcache(
             q,
             k_cache,
             v_cache,
@@ -38,11 +41,10 @@ def flash_attn_baseline(
             max_seqlen_q=max_seqlen_q,
             k_descale=k_descale,
             v_descale=v_descale,
-            return_softmax_lse=True,
+            return_softmax_lse=return_lse,
         )
-        return out, lse
     else:
-        out, lse, *rest = flash_attn_varlen_func(
+        result = flash_attn_varlen_func(
             q,
             k_cache,
             v_cache,
@@ -54,9 +56,14 @@ def flash_attn_baseline(
             cu_seqlens_k=cu_seqlens_k,
             max_seqlen_q=max_seqlen_q,
             max_seqlen_k=max_seqlen_k,
-            return_softmax_lse=True,
+            return_softmax_lse=return_lse,
         )
-        return out, lse
+
+    if return_lse:
+        out, lse, *_ = result
+    else:
+        out, lse = result, None
+    return out, lse
 
 
 def get_effective_attention_pairs(


### PR DESCRIPTION
## Summary
- Flash-attn decode/prefill kernels only instantiate LSE for the base (non-local, non-sink) template; requesting it elsewhere trips a `TORCH_CHECK` added in #330.
- `bench_flash_attn.py` hard-coded `return_softmax_lse=True` across a sweep that includes local windowing and sink masking, so the first benchmark iteration raises `RuntimeError: return_softmax_lse is only supported without local/sink masking`. The `&&`-chained step aborts, `fused_moe.log` is never produced, and the later `docker cp` step fails — breaking CI on every PR since 2026-08-24.
- Only request LSE when `window_size == (-1, -1)` and `sinks is None`; keep local/sink coverage.

## Test plan
- [ ] Green `PR Test (XPU)` on this PR
- [ ] Verify a downstream PR (e.g. #398, #391, #404) goes green after rebase

cc @Valentine233 (#330)