### PR TITLE
chore(docker): bump PYTHON_VERSION 3.10 -> 3.12

### DIFF
--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -45,7 +45,7 @@ jobs:
             /bin/bash -c '\
               set -exo pipefail && \
               . /miniforge3/bin/activate && \
-              conda activate py3.10 && \
+              conda activate py3.12 && \
               cd /root/sglang/sgl-kernel-xpu && \
               git remote set-url origin https://github.com/sgl-project/sgl-kernel-xpu.git && \
               git fetch --depth=1 origin "${PR_MERGE_REF}" && \
@@ -64,16 +64,16 @@ jobs:
       - name: Install Dependency
         timeout-minutes: 20
         run: |
-          docker exec ci_sglkernel_xpu /miniforge3/envs/py3.10/bin/python3 -m pip install --upgrade pip
-          docker exec ci_sglkernel_xpu /miniforge3/envs/py3.10/bin/python3 -m pip install pytest expecttest ray huggingface_hub
-          docker exec ci_sglkernel_xpu /bin/bash -c '/miniforge3/envs/py3.10/bin/hf auth login --token ${HF_TOKEN} '
-          docker exec ci_sglkernel_xpu /bin/bash -c "ln -sf /miniforge3/envs/py3.10/bin/python3 /usr/bin/python3"
+          docker exec ci_sglkernel_xpu /miniforge3/envs/py3.12/bin/python3 -m pip install --upgrade pip
+          docker exec ci_sglkernel_xpu /miniforge3/envs/py3.12/bin/python3 -m pip install pytest expecttest ray huggingface_hub
+          docker exec ci_sglkernel_xpu /bin/bash -c '/miniforge3/envs/py3.12/bin/hf auth login --token ${HF_TOKEN} '
+          docker exec ci_sglkernel_xpu /bin/bash -c "ln -sf /miniforge3/envs/py3.12/bin/python3 /usr/bin/python3"
 
       - name: Run Sglang Kernel Cases
         timeout-minutes: 70
         run: |
           docker exec -w /root/sglang ci_sglkernel_xpu \
-            /bin/bash -c "cd /root/sglang/sgl-kernel-xpu/tests && /miniforge3/envs/py3.10/bin/python3 -m pip install scipy && \
+            /bin/bash -c "cd /root/sglang/sgl-kernel-xpu/tests && /miniforge3/envs/py3.12/bin/python3 -m pip install scipy && \
                           python3 run_suite.py --suite per-commit "
 
       - name: Run Sglang Kernel Benchmarks
@@ -82,7 +82,7 @@ jobs:
           docker exec -w /root/sglang ci_sglkernel_xpu \
             /bin/bash -c "\
               set -o pipefail && \
-              /miniforge3/envs/py3.10/bin/python3 -m pip install tabulate && \
+              /miniforge3/envs/py3.12/bin/python3 -m pip install tabulate && \
               cd /root/sglang/sgl-kernel-xpu/benchmark && \
               python3 bench_flash_attn.py 2>&1 | tee flash.log && \
               python3 bench_flash_mla_decode.py 2>&1 | tee mla.log && \

--- a/.github/workflows/sgl-kernel-nightly.yml
+++ b/.github/workflows/sgl-kernel-nightly.yml
@@ -72,21 +72,21 @@ jobs:
       - name: Install runner extras + HF login
         timeout-minutes: 20
         run: |
-          docker exec sgl_kernel_nightly /miniforge3/envs/py3.10/bin/python3 -m pip install --upgrade pip
-          docker exec sgl_kernel_nightly /miniforge3/envs/py3.10/bin/python3 -m pip install pytest expecttest ray huggingface_hub scipy tabulate
-          docker exec sgl_kernel_nightly /bin/bash -c '/miniforge3/envs/py3.10/bin/hf auth login --token ${HF_TOKEN}'
-          docker exec sgl_kernel_nightly /bin/bash -c "ln -sf /miniforge3/envs/py3.10/bin/python3 /usr/bin/python3"
+          docker exec sgl_kernel_nightly /miniforge3/envs/py3.12/bin/python3 -m pip install --upgrade pip
+          docker exec sgl_kernel_nightly /miniforge3/envs/py3.12/bin/python3 -m pip install pytest expecttest ray huggingface_hub scipy tabulate
+          docker exec sgl_kernel_nightly /bin/bash -c '/miniforge3/envs/py3.12/bin/hf auth login --token ${HF_TOKEN}'
+          docker exec sgl_kernel_nightly /bin/bash -c "ln -sf /miniforge3/envs/py3.12/bin/python3 /usr/bin/python3"
 
       - name: Verify pre-installed sgl-kernel wheel
         run: |
-          docker exec sgl_kernel_nightly /miniforge3/envs/py3.10/bin/python3 -c \
+          docker exec sgl_kernel_nightly /miniforge3/envs/py3.12/bin/python3 -c \
             "import sgl_kernel; print('sgl_kernel loaded from', sgl_kernel.__file__)"
 
       - name: sgl-kernel-test (nightly kernel suite)
         timeout-minutes: 240
         run: |
           docker exec -w /root/sglang/sgl-kernel-xpu/tests sgl_kernel_nightly \
-            /miniforge3/envs/py3.10/bin/python3 run_nightly_suite.py \
+            /miniforge3/envs/py3.12/bin/python3 run_nightly_suite.py \
               --suite sgl-kernel-test \
               --timeout-per-file 7200 \
             || TEST_EXIT_CODE=$?
@@ -97,7 +97,7 @@ jobs:
         timeout-minutes: 60
         run: |
           docker exec -w /root/sglang/sgl-kernel-xpu/tests sgl_kernel_nightly \
-            /miniforge3/envs/py3.10/bin/python3 run_nightly_suite.py \
+            /miniforge3/envs/py3.12/bin/python3 run_nightly_suite.py \
               --suite sgl-kernel-benchmark \
               --timeout-per-file 1800 \
             || BENCH_EXIT_CODE=$?

--- a/Dockerfile.xpu_kernel
+++ b/Dockerfile.xpu_kernel
@@ -1,6 +1,6 @@
 # If the device is Battlemage, we need to set UBUNTU_VERSION to 24.10
 
-# Usage: docker build --build-arg UBUNTU_VERSION=24.04 --build-arg PYTHON_VERSION=3.10 -t sglang:xpu_kernel -f  Dockerfile.xpu --no-cache .
+# Usage: docker build --build-arg UBUNTU_VERSION=24.04 --build-arg PYTHON_VERSION=3.12 -t sglang:xpu_kernel -f  Dockerfile.xpu --no-cache .
 
 
 # Set default Ubuntu version to 24.04
@@ -9,7 +9,7 @@ FROM intel/deep-learning-essentials:2026.0.0-devel-ubuntu24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Define build arguments
-ARG PYTHON_VERSION=3.10
+ARG PYTHON_VERSION=3.12
 
 # Set environment variables
 


### PR DESCRIPTION
## Summary
Bumps the Python interpreter used by `Dockerfile.xpu_kernel` and the two CI workflow files that reference the miniforge3 conda env path from **3.10 → 3.12**, so the image and the CI runners stay consistent.

- `Dockerfile.xpu_kernel`: `ARG PYTHON_VERSION` and the usage-comment example.
- `.github/workflows/pr-test-xpu.yml`: `conda activate py3.12` and every `/miniforge3/envs/py3.12/...` path.
- `.github/workflows/sgl-kernel-nightly.yml`: same `conda activate` + `/miniforge3/envs/py3.12/...` paths.

Total: 3 files, 16 insertions, 16 deletions — mechanical rename only, no behavior change.

`.github/workflows/release-docker-xpu-kernel-nightly.yml` is **not** touched — it has no Python version reference; the version comes solely from the Dockerfile's `ARG PYTHON_VERSION`.

## Test plan
- [x] Built the image locally from this branch's Dockerfile with `PYTHON_VERSION=3.12`.
- [x] `sgl-kernel-xpu/tests/run_suite.py --suite per-commit`: **46/46 files passed, 0 failures**.
- [x] All 38 `benchmark/bench_*.py` scripts: **all rc=0**.

## Recommended merge order (avoids a broken CI window)

The three files must land together, and the published image `intel/sgl-kernel-xpu-dev:latest` must be bumped to Python 3.12 **before** `main` starts using the new `/miniforge3/envs/py3.12/...` paths. Otherwise pr-test-xpu / sgl-kernel-nightly will fail against the old py3.10 image for the ~30–45 min it takes to rebuild.

**Order:**
1. **Pre-build & push the new image from this branch** — trigger `release-docker-xpu-kernel-nightly.yml` via `workflow_dispatch` with `ref: bump-dockerfile-python-3.12`. This publishes `intel/sgl-kernel-xpu-dev:latest` (and a dated tag) built from this branch's Dockerfile (Python 3.12).
2. **Wait for that release run to finish** and confirm the new `:latest` is on Docker Hub.
3. **Merge this PR.** Both consumers (`pr-test-xpu.yml`, `sgl-kernel-nightly.yml`) will pull the new image and find `/miniforge3/envs/py3.12/...` waiting for them — no broken window.

If step 1 is skipped and this PR is merged first, expect pr-test-xpu / sgl-kernel-nightly runs to fail until the next scheduled or manually-triggered `release-docker-xpu-kernel-nightly.yml` completes.