### PR TITLE
[CI] fail the benchmark step when a bench script crashes, don't wait …

### DIFF
--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -76,61 +76,64 @@ jobs:
             /bin/bash -c "cd /root/sglang/sgl-kernel-xpu/tests && /miniforge3/envs/py3.10/bin/python3 -m pip install scipy && \
                           python3 run_suite.py --suite per-commit "
 
+      # Sequential commands under `set -eo pipefail` so a crashing bench
+      # fails *this* step. Do not join with `&&`: a missing `&&` used to
+      # let later benches run and hide the failure as a later `docker cp`.
       - name: Run Sglang Kernel Benchmarks
         timeout-minutes: 40
         run: |
           docker exec -w /root/sglang ci_sglkernel_xpu \
             /bin/bash -c "\
-              set -o pipefail && \
-              /miniforge3/envs/py3.10/bin/python3 -m pip install tabulate && \
-              cd /root/sglang/sgl-kernel-xpu/benchmark && \
-              python3 bench_flash_attn.py 2>&1 | tee flash.log && \
-              python3 bench_flash_mla_decode.py 2>&1 | tee mla.log && \
-              python3 bench_flash_mla_prefill.py 2>&1 | tee mla_prefill.log && \
-              python3 bench_flash_mla_with_kvcache.py 2>&1 | tee mla_with_kvcache.log && \
-              python3 bench_flash_mla_sparse_fwd.py 2>&1 | tee mla_sparse_fwd.log && \
-              python3 bench_moe_topk_sigmoid.py 2>&1 | tee moe_topk_sigmoid.log && \
-              python3 bench_moe_topk_softmax.py 2>&1 | tee moe.log && \
-              python3 bench_fused_moe.py 2>&1 | tee fused_moe.log && \
-              python3 bench_moe_sum_reduce.py 2>&1 | tee moe_sum_reduce.log && \
-              python3 bench_moe_fused_gate.py 2>&1 | tee moe_fused_gate.py.log && \
-              python3 bench_merge_states_v2.py 2>&1 | tee merge_states.py.log && \
-              python3 bench_mrope.py 2>&1 | tee mrope.py.log && \
-              python3 bench_swiglu_alpha_limit.py 2>&1 | tee swiglu_alpha_limit.py.log && \
-              python3 bench_fused_qk_norm_rope.py 2>&1 | tee fused_qk_norm_rope.py.log && \
-              python3 bench_fused_qk_rope_with_cache.py 2>&1 | tee bench_fused_qk_rope_with_cache.py.log && \
-              echo 'Skipping bench_per_token_group_quant_8bit.py (disabled to unblock other benchmarks; see PR #256)' && \
-              python3 bench_per_token_group_quant_mxfp4.py 2>&1 | tee per_token_group_quant_mxfp4.py.log && \
-              python3 bench_per_token_group_quant_8bit_v2.py 2>&1 | tee bench_per_token_group_quant_8bit_v2.py.log && \
-              python3 bench_per_token_quant_fp8.py 2>&1 | tee bench_per_token_quant_fp8.py.log && \
-              python3 bench_per_token_group_quant_mxfp4_fusion.py 2>&1 | tee bench_per_token_group_quant_mxfp4_fusion.py.log && \
-              python3 bench_scatter_tokens_to_experts.py 2>&1 | tee bench_scatter_tokens_to_experts.py.log && \
-              python3 bench_top_k_renorm_probs.py 2>&1 | tee bench_top_k_renorm_probs.py.log && \
-              python3 bench_hc_split_sinkhorn.py 2>&1 | tee bench_hc_split_sinkhorn.py.log && \
-              python3 bench_hc_pre_fuse.py 2>&1 | tee bench_hc_pre_fuse.py.log && \
-              python3 bench_embedding_lora_a_fwd.py 2>&1 | tee bench_embedding_lora_a_fwd.py.log && \
-              python3 bench_moe_w4a16_grouped_gemm.py 2>&1 | tee bench_moe_w4a16_grouped_gemm.py.log && \
-              python3 bench_fused_experts_w4a16.py 2>&1 | tee bench_fused_experts_w4a16.py.log && \
-              python3 bench_hc_pre_gemm_sqr_sum.py 2>&1 | tee bench_hc_pre_gemm_sqr_sum.py.log && \
-              python3 bench_mhc_pre.py 2>&1 | tee bench_mhc_pre.py.log && \
-              python3 bench_silu_and_mul_clamp.py 2>&1 | tee bench_silu_and_mul_clamp.log && \
-              python3 bench_jit_rmsnorm.py 2>&1 | tee bench_jit_rmsnorm.py.log && \
-              python3 bench_jit_qknorm.py 2>&1 | tee bench_jit_qknorm.py.log && \
-              python3 bench_jit_rope.py 2>&1 | tee bench_jit_rope.py.log && \
-              python3 bench_jit_timestep_embedding.py 2>&1 | tee bench_jit_timestep_embedding.py.log && \
-              python3 bench_jit_per_token_group_quant_8bit.py 2>&1 | tee bench_jit_per_token_group_quant_8bit.py.log && \
+              set -eo pipefail
+              /miniforge3/envs/py3.10/bin/python3 -m pip install tabulate
+              cd /root/sglang/sgl-kernel-xpu/benchmark
+              python3 bench_flash_attn.py 2>&1 | tee flash.log
+              python3 bench_flash_mla_decode.py 2>&1 | tee mla.log
+              python3 bench_flash_mla_prefill.py 2>&1 | tee mla_prefill.log
+              python3 bench_flash_mla_with_kvcache.py 2>&1 | tee mla_with_kvcache.log
+              python3 bench_flash_mla_sparse_fwd.py 2>&1 | tee mla_sparse_fwd.log
+              python3 bench_moe_topk_sigmoid.py 2>&1 | tee moe_topk_sigmoid.log
+              python3 bench_moe_topk_softmax.py 2>&1 | tee moe.log
+              python3 bench_fused_moe.py 2>&1 | tee fused_moe.log
+              python3 bench_moe_sum_reduce.py 2>&1 | tee moe_sum_reduce.log
+              python3 bench_moe_fused_gate.py 2>&1 | tee moe_fused_gate.py.log
+              python3 bench_merge_states_v2.py 2>&1 | tee merge_states.py.log
+              python3 bench_mrope.py 2>&1 | tee mrope.py.log
+              python3 bench_swiglu_alpha_limit.py 2>&1 | tee swiglu_alpha_limit.py.log
+              python3 bench_fused_qk_norm_rope.py 2>&1 | tee fused_qk_norm_rope.py.log
+              python3 bench_fused_qk_rope_with_cache.py 2>&1 | tee bench_fused_qk_rope_with_cache.py.log
+              echo 'Skipping bench_per_token_group_quant_8bit.py (disabled to unblock other benchmarks; see PR #256)'
+              python3 bench_per_token_group_quant_mxfp4.py 2>&1 | tee per_token_group_quant_mxfp4.py.log
+              python3 bench_per_token_group_quant_8bit_v2.py 2>&1 | tee bench_per_token_group_quant_8bit_v2.py.log
+              python3 bench_per_token_quant_fp8.py 2>&1 | tee bench_per_token_quant_fp8.py.log
+              python3 bench_per_token_group_quant_mxfp4_fusion.py 2>&1 | tee bench_per_token_group_quant_mxfp4_fusion.py.log
+              python3 bench_scatter_tokens_to_experts.py 2>&1 | tee bench_scatter_tokens_to_experts.py.log
+              python3 bench_top_k_renorm_probs.py 2>&1 | tee bench_top_k_renorm_probs.py.log
+              python3 bench_hc_split_sinkhorn.py 2>&1 | tee bench_hc_split_sinkhorn.py.log
+              python3 bench_hc_pre_fuse.py 2>&1 | tee bench_hc_pre_fuse.py.log
+              python3 bench_embedding_lora_a_fwd.py 2>&1 | tee bench_embedding_lora_a_fwd.py.log
+              python3 bench_moe_w4a16_grouped_gemm.py 2>&1 | tee bench_moe_w4a16_grouped_gemm.py.log
+              python3 bench_fused_experts_w4a16.py 2>&1 | tee bench_fused_experts_w4a16.py.log
+              python3 bench_hc_pre_gemm_sqr_sum.py 2>&1 | tee bench_hc_pre_gemm_sqr_sum.py.log
+              python3 bench_mhc_pre.py 2>&1 | tee bench_mhc_pre.py.log
+              python3 bench_silu_and_mul_clamp.py 2>&1 | tee bench_silu_and_mul_clamp.log
+              python3 bench_jit_rmsnorm.py 2>&1 | tee bench_jit_rmsnorm.py.log
+              python3 bench_jit_qknorm.py 2>&1 | tee bench_jit_qknorm.py.log
+              python3 bench_jit_rope.py 2>&1 | tee bench_jit_rope.py.log
+              python3 bench_jit_timestep_embedding.py 2>&1 | tee bench_jit_timestep_embedding.py.log
+              python3 bench_jit_per_token_group_quant_8bit.py 2>&1 | tee bench_jit_per_token_group_quant_8bit.py.log
               python3 bench_hc_post.py 2>&1 | tee bench_hc_post.py.log
-              python3 bench_jit_moe_topk_sigmoid.py 2>&1 | tee bench_jit_moe_topk_sigmoid.py.log && \
-              python3 bench_jit_moe_fused_gate.py 2>&1 | tee bench_jit_moe_fused_gate.py.log && \
-              python3 bench_jit_per_tensor_quant_fp8.py 2>&1 | tee bench_jit_per_tensor_quant_fp8.py.log && \
-              python3 bench_jit_moe_align_block_size.py 2>&1 | tee bench_jit_moe_align_block_size.py.log && \
-              python3 bench_jit_per_token_group_quant_8bit_v2.py 2>&1 | tee bench_jit_per_token_group_quant_8bit_v2.py.log && \
-              python3 bench_jit_activation.py 2>&1 | tee bench_jit_activation.py.log && \
-              python3 bench_hc_post.py 2>&1 | tee bench_hc_post.py.log && \
-              python3 bench_sgemm_lora_a_fwd.py 2>&1 | tee bench_sgemm_lora_a_fwd.py.log && \
-              python3 bench_biased_topk.py 2>&1 | tee bench_biased_topk.py.log && \
-              python3 bench_sgemm_lora_b_fwd.py 2>&1 | tee bench_sgemm_lora_b_fwd.py.log && \
-              python3 bench_min_p_sampling_from_probs.py 2>&1 | tee bench_min_p_sampling_from_probs.py.log && \
+              python3 bench_jit_moe_topk_sigmoid.py 2>&1 | tee bench_jit_moe_topk_sigmoid.py.log
+              python3 bench_jit_moe_fused_gate.py 2>&1 | tee bench_jit_moe_fused_gate.py.log
+              python3 bench_jit_per_tensor_quant_fp8.py 2>&1 | tee bench_jit_per_tensor_quant_fp8.py.log
+              python3 bench_jit_moe_align_block_size.py 2>&1 | tee bench_jit_moe_align_block_size.py.log
+              python3 bench_jit_per_token_group_quant_8bit_v2.py 2>&1 | tee bench_jit_per_token_group_quant_8bit_v2.py.log
+              python3 bench_jit_activation.py 2>&1 | tee bench_jit_activation.py.log
+              python3 bench_hc_post.py 2>&1 | tee bench_hc_post.py.log
+              python3 bench_sgemm_lora_a_fwd.py 2>&1 | tee bench_sgemm_lora_a_fwd.py.log
+              python3 bench_biased_topk.py 2>&1 | tee bench_biased_topk.py.log
+              python3 bench_sgemm_lora_b_fwd.py 2>&1 | tee bench_sgemm_lora_b_fwd.py.log
+              python3 bench_min_p_sampling_from_probs.py 2>&1 | tee bench_min_p_sampling_from_probs.py.log
               python3 bench_top_p_renorm_probs.py 2>&1 | tee bench_top_p_renorm_probs.py.log
               python3 bench_top_k_top_p_sampling_from_probs.py 2>&1 | tee bench_top_k_top_p_sampling_from_probs.py.log
             "

--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -85,6 +85,7 @@ jobs:
           docker exec -w /root/sglang ci_sglkernel_xpu \
             /bin/bash -c "\
               set -eo pipefail
+              export PYTHONPATH=/root/sglang/python
               /miniforge3/envs/py3.10/bin/python3 -m pip install tabulate
               cd /root/sglang/sgl-kernel-xpu/benchmark
               python3 bench_flash_attn.py 2>&1 | tee flash.log


### PR DESCRIPTION
## Summary
- `Run Sglang Kernel Benchmarks` used a long `cmd | tee log && ...` chain. Two missing `&&` turned later benches into a new bash statement, so a crashing bench (e.g. `bench_flash_attn.py` in #330) did not fail that step.
- The job stayed green until `Copy logs from container` (`docker cp fused_moe.log`), which looks like infra rather than a kernel regression.
- Run benches sequentially under `set -eo pipefail` so a non-zero `python3 bench_*.py | tee` fails **this** step. Adding a new bench without `&&` cannot hide a failure again.

