### PR TITLE
[MoE] Pick the W4A16 grouped-GEMM tile by rows-per-expert fill, not a threshold

### DIFF
--- a/src/GroupGemmW4A16Xe20.cmake
+++ b/src/GroupGemmW4A16Xe20.cmake
@@ -14,15 +14,18 @@ function(add_group_gemm_w4a16_xe20_inst POLICY ELEMENT_S ELEMENT_A SANITIZED)
     set(GROUP_GEMM_W4A16_XE20_INST_SRCS ${GROUP_GEMM_W4A16_XE20_INST_SRCS} PARENT_SCOPE)
 endfunction()
 
-# Policy menu (selected at runtime by average rows-per-expert):
-#   w4a16_policy_m_8   <_8,  _64,  _32>  — avg_m <= 4
-#   w4a16_policy_m_16  <_16, _64,  _32>  — avg_m <= 8
-#   w4a16_policy_m_32  <_32, _64,  _32>  — avg_m <= 128
-#   w4a16_policy       <_128,_256, _32>  — avg_m > 128
+# Policy menu. select_w4a16_tile_m() in GroupGemmW4A16Xe20.cpp picks one per
+# call from the average rows-per-expert:
+#   w4a16_policy_m_8         <_8,  _64,  _32>  — avg_m <= 4
+#   w4a16_policy_m_16        <_16, _64,  _32>  — avg_m <= 8
+#   w4a16_policy_m_32        <_32, _64,  _32>  — small avg_m
+#   w4a16_policy_m_64_n_128  <_64, _128, _32>  — mid avg_m
+#   w4a16_policy_m_128_n_128 <_128,_128, _32>  — large avg_m
 # group_size (32/64/128/256) is compiled into every unit as a runtime branch,
-# so it does not multiply the instance count. Total: 4 policies x 2 (int4/mxfp4)
-# x 2 (bf16/fp16 activation) = 16 units.
-foreach(policy w4a16_policy_m_8 w4a16_policy_m_16 w4a16_policy_m_32 w4a16_policy)
+# so it does not multiply the instance count. Total: 5 policies x 2 (int4/mxfp4)
+# x 2 (bf16/fp16 activation) = 20 units.
+foreach(policy w4a16_policy_m_8 w4a16_policy_m_16 w4a16_policy_m_32
+               w4a16_policy_m_64_n_128 w4a16_policy_m_128_n_128)
     foreach(act_tag bf16 fp16)
         if(act_tag STREQUAL "bf16")
             set(element_a "cutlass::bfloat16_t")

--- a/src/GroupGemmW4A16Xe20.cmake
+++ b/src/GroupGemmW4A16Xe20.cmake
@@ -16,15 +16,15 @@ endfunction()
 
 # Policy menu. select_w4a16_tile_m() in GroupGemmW4A16Xe20.cpp picks one per
 # call from the average rows-per-expert:
-#   w4a16_policy_m_8         <_8,  _64,  _32>  — avg_m <= 4
-#   w4a16_policy_m_16        <_16, _64,  _32>  — avg_m <= 8
-#   w4a16_policy_m_32        <_32, _64,  _32>  — small avg_m
+#   w4a16_policy_m_8_n_64    <_8,  _64,  _32>  — avg_m <= 4
+#   w4a16_policy_m_16_n_64   <_16, _64,  _32>  — avg_m <= 8
+#   w4a16_policy_m_32_n_64   <_32, _64,  _32>  — small avg_m
 #   w4a16_policy_m_64_n_128  <_64, _128, _32>  — mid avg_m
 #   w4a16_policy_m_128_n_128 <_128,_128, _32>  — large avg_m
 # group_size (32/64/128/256) is compiled into every unit as a runtime branch,
 # so it does not multiply the instance count. Total: 5 policies x 2 (int4/mxfp4)
 # x 2 (bf16/fp16 activation) = 20 units.
-foreach(policy w4a16_policy_m_8 w4a16_policy_m_16 w4a16_policy_m_32
+foreach(policy w4a16_policy_m_8_n_64 w4a16_policy_m_16_n_64 w4a16_policy_m_32_n_64
                w4a16_policy_m_64_n_128 w4a16_policy_m_128_n_128)
     foreach(act_tag bf16 fp16)
         if(act_tag STREQUAL "bf16")

--- a/src/jit/moe_jit.cpp
+++ b/src/jit/moe_jit.cpp
@@ -156,19 +156,23 @@ using W4A16Fn = void (*)(
     int,
     int*);
 
-// Policy name selected from avg_m (mirrors GroupGemmW4A16Xe20.cpp).
-const char* w4a16_policy(int avg_m) {
-  if (avg_m <= 4) return "w4a16_policy_m_8";
-  if (avg_m <= 8) return "w4a16_policy_m_16";
-  if (avg_m <= 128) return "w4a16_policy_m_32";
-  return "w4a16_policy";
-}
-
-int w4a16_policy_id(int avg_m) {
-  if (avg_m <= 4) return 0;
-  if (avg_m <= 8) return 1;
-  if (avg_m <= 128) return 2;
-  return 3;
+// Policy id is selected by GroupGemmW4A16Xe20.cpp so AOT and JIT dispatch use
+// the same avg_m- and gemm_n-dependent decision.
+const char* w4a16_policy(int policy_id) {
+  switch (policy_id) {
+    case 0:
+      return "w4a16_policy_m_8_n_64";
+    case 1:
+      return "w4a16_policy_m_16_n_64";
+    case 2:
+      return "w4a16_policy_m_32_n_64";
+    case 3:
+      return "w4a16_policy_m_64_n_128";
+    case 4:
+      return "w4a16_policy_m_128_n_128";
+    default:
+      return nullptr;
+  }
 }
 
 uint64_t pack_w4a16_key(int policy_id, bool is_int4, bool is_fp16, int arch) {
@@ -181,8 +185,13 @@ uint64_t pack_w4a16_key(int policy_id, bool is_int4, bool is_fp16, int arch) {
 
 jit::JitFnCache<W4A16Fn> g_w4a16_fns("W4A16 grouped GEMM");
 
-W4A16Fn resolve_w4a16(int avg_m, bool is_int4, bool is_fp16, int arch, std::string* err) {
-  const int policy_id = w4a16_policy_id(avg_m);
+W4A16Fn resolve_w4a16(int policy_id, bool is_int4, bool is_fp16, int arch, std::string* err) {
+  const char* policy = w4a16_policy(policy_id);
+  if (policy == nullptr) {
+    if (err != nullptr) *err = "invalid W4A16 policy id";
+    return nullptr;
+  }
+
   const uint64_t key = pack_w4a16_key(policy_id, is_int4, is_fp16, arch);
   auto build = [&](std::string* berr) -> void* {
     const jit::JitConfig& cfg = jit::default_config();
@@ -199,7 +208,7 @@ W4A16Fn resolve_w4a16(int avg_m, bool is_int4, bool is_fp16, int arch, std::stri
 
     jit::CompileSpec spec;
     spec.template_path = cfg.src_root + "/sycl/GroupGemmW4A16Xe20LauncherInstance.cpp.in";
-    spec.subs["POLICY"] = w4a16_policy(avg_m);
+    spec.subs["POLICY"] = policy;
     spec.subs["ELEMENT_A"] = elem_a;
     spec.subs["ELEMENT_S"] = is_int4 ? elem_a : "uint8_t";
     const jit::ArchSpec as = jit::arch_spec(static_cast<jit::Arch>(arch), "-DSGL_W4A16_JIT_ENTRY");
@@ -217,7 +226,7 @@ W4A16Fn resolve_w4a16(int avg_m, bool is_int4, bool is_fp16, int arch, std::stri
 }  // namespace
 
 bool w4a16_grouped_gemm_launch(
-    int avg_m,
+    int policy_id,
     bool is_int4,
     bool is_fp16,
     void* queue,
@@ -235,7 +244,7 @@ bool w4a16_grouped_gemm_launch(
     int* atomic_buffer,
     int arch,
     std::string* err) {
-  W4A16Fn fn = resolve_w4a16(avg_m, is_int4, is_fp16, arch, err);
+  W4A16Fn fn = resolve_w4a16(policy_id, is_int4, is_fp16, arch, err);
   if (!fn) return false;
   fn(queue,
      activations,

--- a/src/jit/moe_jit.h
+++ b/src/jit/moe_jit.h
@@ -38,11 +38,12 @@ bool grouped_gemm_launch(
     int arch = 0,  // sgl::jit::Arch code (0=BMG/Xe20, 1=XE3P/Xe35)
     std::string* err = nullptr);
 
-// Launch the W4A16 (int4 / mxfp4) grouped GEMM. The policy is selected from
-// avg_m and (ElementS, ElementA) from (is_int4, is_fp16), mirroring
-// GroupGemmW4A16Xe20.cpp. group_size is a runtime arg (not a template param).
+// Launch the W4A16 (int4 / mxfp4) grouped GEMM. policy_id is selected by
+// GroupGemmW4A16Xe20.cpp so JIT uses the exact same avg_m- and gemm_n-dependent
+// policy as AOT. (ElementS, ElementA) comes from (is_int4, is_fp16), and
+// group_size is a runtime arg (not a template param).
 bool w4a16_grouped_gemm_launch(
-    int avg_m,
+    int policy_id,
     bool is_int4,
     bool is_fp16,
     void* queue,

--- a/src/sycl/GroupGemmW4A16Xe20.cpp
+++ b/src/sycl/GroupGemmW4A16Xe20.cpp
@@ -87,10 +87,48 @@ void w4a16_launch(
 DECLARE_W4A16_POLICY(w4a16_policy_m_8)
 DECLARE_W4A16_POLICY(w4a16_policy_m_16)
 DECLARE_W4A16_POLICY(w4a16_policy_m_32)
-DECLARE_W4A16_POLICY(w4a16_policy)
+DECLARE_W4A16_POLICY(w4a16_policy_m_64_n_128)
+DECLARE_W4A16_POLICY(w4a16_policy_m_128_n_128)
 
 #undef DECLARE_W4A16_POLICY
 #undef DECLARE_W4A16_EXTERN
+
+namespace {
+
+// Rows-per-expert -> M tile, weighted by how much of that tile an expert fills.
+//
+// The grouped GEMM tiles every expert's rows independently, so a policy with an
+// M tile of T computes ceil(avg_m / T) * T rows per expert whatever avg_m is.
+// Picking the widest tile unconditionally therefore falls off a cliff just past
+// a multiple of T: at avg_m = 129 an M=128 tile does 256 rows of work for 129
+// rows of data and loses half the machine. Scoring each candidate by its peak
+// throughput times that fill factor picks the tile that finishes first.
+//
+// The peaks below are measured on Xe2 (Arc Pro B60, bf16 activations) at
+// avg_m values that fill each tile exactly, in TFLOP/s. They are only ever
+// compared against each other, so the absolute scale does not matter -- what
+// matters is that a wider tile is worth more per row but wastes more of a
+// partial tile. GPT-OSS gemm1 (N=5760, K=2880) and DeepSeek-V4 gemm1
+// (N=4096, K=4096) agree on this ordering.
+constexpr int kW4A16TileM[] = {32, 64, 128};
+constexpr float kW4A16TilePeakTflops[] = {49.0f, 64.0f, 68.0f};
+
+int select_w4a16_tile_m(int avg_m) {
+  int best_tile_m = kW4A16TileM[0];
+  float best_score = 0.0f;
+  for (size_t i = 0; i < sizeof(kW4A16TileM) / sizeof(kW4A16TileM[0]); ++i) {
+    const int tile_m = kW4A16TileM[i];
+    const int rows_computed = ((avg_m + tile_m - 1) / tile_m) * tile_m;
+    const float score = kW4A16TilePeakTflops[i] * static_cast<float>(avg_m) / static_cast<float>(rows_computed);
+    if (score > best_score) {
+      best_score = score;
+      best_tile_m = tile_m;
+    }
+  }
+  return best_tile_m;
+}
+
+}  // namespace
 
 SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
     torch::Tensor& output,                   // [total_m, N] bf16/fp16
@@ -196,6 +234,7 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
   at::Tensor atomic_buffer = at::empty({static_cast<long>(1)}, activations.options().dtype(at::kInt));
 
   const int avg_m = total_m / static_cast<int>(n_experts);
+  const int tile_m = select_w4a16_tile_m(avg_m);
   const bool is_fp16_act = activations.scalar_type() == at::ScalarType::Half;
 #define LAUNCH_W4A16(Policy)                                                                  \
   do {                                                                                        \
@@ -266,17 +305,19 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
     }                                                                                         \
   } while (0)
 
-#define DISPATCH_W4A16_POLICY()        \
-  do {                                 \
-    if (avg_m <= 4) {                  \
-      LAUNCH_W4A16(w4a16_policy_m_8);  \
-    } else if (avg_m <= 8) {           \
-      LAUNCH_W4A16(w4a16_policy_m_16); \
-    } else if (avg_m <= 128) {         \
-      LAUNCH_W4A16(w4a16_policy_m_32); \
-    } else {                           \
-      LAUNCH_W4A16(w4a16_policy);      \
-    }                                  \
+#define DISPATCH_W4A16_POLICY()               \
+  do {                                        \
+    if (avg_m <= 4) {                         \
+      LAUNCH_W4A16(w4a16_policy_m_8);         \
+    } else if (avg_m <= 8) {                  \
+      LAUNCH_W4A16(w4a16_policy_m_16);        \
+    } else if (tile_m <= 32) {                \
+      LAUNCH_W4A16(w4a16_policy_m_32);        \
+    } else if (tile_m <= 64) {                \
+      LAUNCH_W4A16(w4a16_policy_m_64_n_128);  \
+    } else {                                  \
+      LAUNCH_W4A16(w4a16_policy_m_128_n_128); \
+    }                                         \
   } while (0)
 
 #ifdef USE_MOE_JIT

--- a/src/sycl/GroupGemmW4A16Xe20.cpp
+++ b/src/sycl/GroupGemmW4A16Xe20.cpp
@@ -95,14 +95,16 @@ DECLARE_W4A16_POLICY(w4a16_policy_m_128_n_128)
 
 namespace {
 
-// Rows-per-expert -> M tile, weighted by how much of that tile an expert fills.
+// GEMM shape -> tile policy, weighted by how much of each tile the GEMM fills.
 //
 // The grouped GEMM tiles every expert's rows independently, so a policy with an
 // M tile of T computes ceil(avg_m / T) * T rows per expert whatever avg_m is.
 // Picking the widest tile unconditionally therefore falls off a cliff just past
 // a multiple of T: at avg_m = 129 an M=128 tile does 256 rows of work for 129
-// rows of data and loses half the machine. Scoring each candidate by its peak
-// throughput times that fill factor picks the tile that finishes first.
+// rows of data and loses half the machine. N tails have the same effect: a
+// policy computes ceil(gemm_n / tile_n) * tile_n columns. Scoring each candidate
+// by its peak throughput times both fill factors estimates which policy finishes
+// first.
 //
 // The peaks below are measured on Xe2 (Arc Pro B60, bf16 activations) at
 // avg_m values that fill each tile exactly, in TFLOP/s. They are only ever
@@ -111,15 +113,19 @@ namespace {
 // partial tile. GPT-OSS gemm1 (N=5760, K=2880) and DeepSeek-V4 gemm1
 // (N=4096, K=4096) agree on this ordering.
 constexpr int kW4A16TileM[] = {32, 64, 128};
+constexpr int kW4A16TileN[] = {64, 128, 128};
 constexpr float kW4A16TilePeakTflops[] = {49.0f, 64.0f, 68.0f};
 
-int select_w4a16_tile_m(int avg_m) {
+int select_w4a16_tile_m(int avg_m, int gemm_n) {
   int best_tile_m = kW4A16TileM[0];
   float best_score = 0.0f;
   for (size_t i = 0; i < sizeof(kW4A16TileM) / sizeof(kW4A16TileM[0]); ++i) {
     const int tile_m = kW4A16TileM[i];
+    const int tile_n = kW4A16TileN[i];
     const int rows_computed = ((avg_m + tile_m - 1) / tile_m) * tile_m;
-    const float score = kW4A16TilePeakTflops[i] * static_cast<float>(avg_m) / static_cast<float>(rows_computed);
+    const int columns_computed = ((gemm_n + tile_n - 1) / tile_n) * tile_n;
+    const float score = kW4A16TilePeakTflops[i] * static_cast<float>(avg_m) / static_cast<float>(rows_computed) *
+                        static_cast<float>(gemm_n) / static_cast<float>(columns_computed);
     if (score > best_score) {
       best_score = score;
       best_tile_m = tile_m;
@@ -234,7 +240,7 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
   at::Tensor atomic_buffer = at::empty({static_cast<long>(1)}, activations.options().dtype(at::kInt));
 
   const int avg_m = total_m / static_cast<int>(n_experts);
-  const int tile_m = select_w4a16_tile_m(avg_m);
+  const int tile_m = select_w4a16_tile_m(avg_m, gemm_n);
   const bool is_fp16_act = activations.scalar_type() == at::ScalarType::Half;
 #define LAUNCH_W4A16(Policy)                                                                  \
   do {                                                                                        \

--- a/src/sycl/GroupGemmW4A16Xe20.cpp
+++ b/src/sycl/GroupGemmW4A16Xe20.cpp
@@ -84,9 +84,9 @@ void w4a16_launch(
   DECLARE_W4A16_EXTERN(Policy, uint8_t, cutlass::bfloat16_t)             \
   DECLARE_W4A16_EXTERN(Policy, uint8_t, cutlass::half_t)
 
-DECLARE_W4A16_POLICY(w4a16_policy_m_8)
-DECLARE_W4A16_POLICY(w4a16_policy_m_16)
-DECLARE_W4A16_POLICY(w4a16_policy_m_32)
+DECLARE_W4A16_POLICY(w4a16_policy_m_8_n_64)
+DECLARE_W4A16_POLICY(w4a16_policy_m_16_n_64)
+DECLARE_W4A16_POLICY(w4a16_policy_m_32_n_64)
 DECLARE_W4A16_POLICY(w4a16_policy_m_64_n_128)
 DECLARE_W4A16_POLICY(w4a16_policy_m_128_n_128)
 
@@ -132,6 +132,16 @@ int select_w4a16_tile_m(int avg_m, int gemm_n) {
     }
   }
   return best_tile_m;
+}
+
+int select_w4a16_policy_id(int avg_m, int gemm_n) {
+  if (avg_m <= 4) return 0;
+  if (avg_m <= 8) return 1;
+
+  const int tile_m = select_w4a16_tile_m(avg_m, gemm_n);
+  if (tile_m <= 32) return 2;
+  if (tile_m <= 64) return 3;
+  return 4;
 }
 
 }  // namespace
@@ -240,7 +250,7 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
   at::Tensor atomic_buffer = at::empty({static_cast<long>(1)}, activations.options().dtype(at::kInt));
 
   const int avg_m = total_m / static_cast<int>(n_experts);
-  const int tile_m = select_w4a16_tile_m(avg_m, gemm_n);
+  const int policy_id = select_w4a16_policy_id(avg_m, gemm_n);
   const bool is_fp16_act = activations.scalar_type() == at::ScalarType::Half;
 #define LAUNCH_W4A16(Policy)                                                                  \
   do {                                                                                        \
@@ -311,19 +321,25 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
     }                                                                                         \
   } while (0)
 
-#define DISPATCH_W4A16_POLICY()               \
-  do {                                        \
-    if (avg_m <= 4) {                         \
-      LAUNCH_W4A16(w4a16_policy_m_8);         \
-    } else if (avg_m <= 8) {                  \
-      LAUNCH_W4A16(w4a16_policy_m_16);        \
-    } else if (tile_m <= 32) {                \
-      LAUNCH_W4A16(w4a16_policy_m_32);        \
-    } else if (tile_m <= 64) {                \
-      LAUNCH_W4A16(w4a16_policy_m_64_n_128);  \
-    } else {                                  \
-      LAUNCH_W4A16(w4a16_policy_m_128_n_128); \
-    }                                         \
+#define DISPATCH_W4A16_POLICY()                 \
+  do {                                          \
+    switch (policy_id) {                        \
+      case 0:                                   \
+        LAUNCH_W4A16(w4a16_policy_m_8_n_64);    \
+        break;                                  \
+      case 1:                                   \
+        LAUNCH_W4A16(w4a16_policy_m_16_n_64);   \
+        break;                                  \
+      case 2:                                   \
+        LAUNCH_W4A16(w4a16_policy_m_32_n_64);   \
+        break;                                  \
+      case 3:                                   \
+        LAUNCH_W4A16(w4a16_policy_m_64_n_128);  \
+        break;                                  \
+      case 4:                                   \
+        LAUNCH_W4A16(w4a16_policy_m_128_n_128); \
+        break;                                  \
+    }                                           \
   } while (0)
 
 #ifdef USE_MOE_JIT
@@ -331,7 +347,7 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
     std::string jit_err;
     TORCH_CHECK(
         sgl::moe_jit::w4a16_grouped_gemm_launch(
-            avg_m,
+            policy_id,
             is_int4,
             is_fp16_act,
             &queue,

--- a/src/sycl/kernels/moe/xe20/w4a16/gemm_xe2_policy.hpp
+++ b/src/sycl/kernels/moe/xe20/w4a16/gemm_xe2_policy.hpp
@@ -47,12 +47,16 @@ class xe_gemm_policy_base {
   using GmemTiledCopyD = void;
 };
 
-// avg_m > 128
-class w4a16_policy : public xe_gemm_policy_base {
- public:
-  using WGTile = Shape<_128, _256, _32>;
-  using SGLayout = Layout<Shape<_4, _8, _1>, Stride<_8, _1, _0>>;
-};
+// Policy menu. Every policy keeps the *per-subgroup* tile at 32x32: the 4-bit
+// mainloop needs its dequantised B fragment live alongside the accumulators, and
+// a wider per-subgroup tile overruns the 256-GRF budget (a 256x256 / 8x4 variant
+// compiles with ~190 spilled registers and runs at a third of the speed). So the
+// work-group tile is scaled by adding or removing subgroups, not by widening
+// them. The subgroup count per dimension must be a power of two -- cute's tile
+// division rejects 3 and 6.
+//
+// Which one runs is decided per call by rows-per-expert; see
+// select_w4a16_tile_m() in GroupGemmW4A16Xe20.cpp.
 
 // avg_m <= 4
 class w4a16_policy_m_8 : public xe_gemm_policy_base {
@@ -68,11 +72,31 @@ class w4a16_policy_m_16 : public xe_gemm_policy_base {
   using SGLayout = Layout<Shape<_1, _4, _1>, Stride<_4, _1, _0>>;
 };
 
-// avg_m <= 128
+// Small avg_m: the 64-wide N tile beats a 256-wide one at this M (the wide-N
+// variant measures ~35 TFLOP/s against this one's ~49).
 class w4a16_policy_m_32 : public xe_gemm_policy_base {
  public:
   using WGTile = Shape<_32, _64, _32>;
   using SGLayout = Layout<Shape<_1, _4, _1>, Stride<_4, _1, _0>>;
+};
+
+// Mid range. Covers the rows-per-expert values where an M=128 tile would
+// compute up to twice the rows an expert actually has.
+class w4a16_policy_m_64_n_128 : public xe_gemm_policy_base {
+ public:
+  using WGTile = Shape<_64, _128, _32>;
+  using SGLayout = Layout<Shape<_2, _4, _1>, Stride<_4, _1, _0>>;
+};
+
+// Large avg_m. Replaces the previous <_128,_256,_32> / 4x8 policy: at equal M
+// the 128-wide N tile is never slower and is faster wherever N is not a
+// multiple of 256 (GPT-OSS N=5760 and 2880 both leave a half tile idle),
+// measuring 68.2 vs 66.5 TFLOP/s on GPT-OSS gemm1 at avg_m=512 and 68.3 vs
+// 68.1 on DeepSeek-V4 gemm1 at avg_m=256.
+class w4a16_policy_m_128_n_128 : public xe_gemm_policy_base {
+ public:
+  using WGTile = Shape<_128, _128, _32>;
+  using SGLayout = Layout<Shape<_4, _4, _1>, Stride<_4, _1, _0>>;
 };
 
 }  // namespace moe_w4a16

--- a/src/sycl/kernels/moe/xe20/w4a16/gemm_xe2_policy.hpp
+++ b/src/sycl/kernels/moe/xe20/w4a16/gemm_xe2_policy.hpp
@@ -59,14 +59,14 @@ class xe_gemm_policy_base {
 // select_w4a16_tile_m() in GroupGemmW4A16Xe20.cpp.
 
 // avg_m <= 4
-class w4a16_policy_m_8 : public xe_gemm_policy_base {
+class w4a16_policy_m_8_n_64 : public xe_gemm_policy_base {
  public:
   using WGTile = Shape<_8, _64, _32>;
   using SGLayout = Layout<Shape<_1, _4, _1>, Stride<_4, _1, _0>>;
 };
 
 // avg_m <= 8
-class w4a16_policy_m_16 : public xe_gemm_policy_base {
+class w4a16_policy_m_16_n_64 : public xe_gemm_policy_base {
  public:
   using WGTile = Shape<_16, _64, _32>;
   using SGLayout = Layout<Shape<_1, _4, _1>, Stride<_4, _1, _0>>;
@@ -74,7 +74,7 @@ class w4a16_policy_m_16 : public xe_gemm_policy_base {
 
 // Small avg_m: the 64-wide N tile beats a 256-wide one at this M (the wide-N
 // variant measures ~35 TFLOP/s against this one's ~49).
-class w4a16_policy_m_32 : public xe_gemm_policy_base {
+class w4a16_policy_m_32_n_64 : public xe_gemm_policy_base {
  public:
   using WGTile = Shape<_32, _64, _32>;
   using SGLayout = Layout<Shape<_1, _4, _1>, Stride<_4, _1, _0>>;


### PR DESCRIPTION
    Measured on Arc Pro B60, MXFP4 bf16 activations, gemm1 TFLOP/s (gemm2 tracks
    it). GPT-OSS TP=1/EP=1, 32 experts, N=5760, K=2880:

      avg_m |  64    96   128   129   160   192   256   512
      before| 48.5  49.3  49.2  24.8  34.8  47.0  66.0  66.5
      after | 60.0  49.4  66.4  38.1  53.2  64.1  67.4  68.1