### PR TITLE
[CI] fail bench step when a bench crashes, skip broken JIT 8-bit bench

### DIFF
--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -77,60 +77,62 @@ jobs:
                           python3 run_suite.py --suite per-commit "
 
       - name: Run Sglang Kernel Benchmarks
+        # Sequential commands under `set -eo pipefail` so a crashing bench
+        # fails *this* step. Do not join with `&&`: missing `&&` used to
+        # let later benches run and hide the failure as a later docker cp.
         timeout-minutes: 40
         run: |
           docker exec -w /root/sglang ci_sglkernel_xpu \
             /bin/bash -c "\
-              set -o pipefail && \
-              /miniforge3/envs/py3.10/bin/python3 -m pip install tabulate && \
-              cd /root/sglang/sgl-kernel-xpu/benchmark && \
-              python3 bench_flash_attn.py 2>&1 | tee flash.log && \
-              python3 bench_flash_mla_decode.py 2>&1 | tee mla.log && \
-              python3 bench_flash_mla_prefill.py 2>&1 | tee mla_prefill.log && \
-              python3 bench_flash_mla_with_kvcache.py 2>&1 | tee mla_with_kvcache.log && \
-              python3 bench_flash_mla_sparse_fwd.py 2>&1 | tee mla_sparse_fwd.log && \
-              python3 bench_moe_topk_sigmoid.py 2>&1 | tee moe_topk_sigmoid.log && \
-              python3 bench_moe_topk_softmax.py 2>&1 | tee moe.log && \
-              python3 bench_fused_moe.py 2>&1 | tee fused_moe.log && \
-              python3 bench_moe_sum_reduce.py 2>&1 | tee moe_sum_reduce.log && \
-              python3 bench_moe_fused_gate.py 2>&1 | tee moe_fused_gate.py.log && \
-              python3 bench_merge_states_v2.py 2>&1 | tee merge_states.py.log && \
-              python3 bench_mrope.py 2>&1 | tee mrope.py.log && \
-              python3 bench_swiglu_alpha_limit.py 2>&1 | tee swiglu_alpha_limit.py.log && \
-              python3 bench_fused_qk_norm_rope.py 2>&1 | tee fused_qk_norm_rope.py.log && \
-              python3 bench_fused_qk_rope_with_cache.py 2>&1 | tee bench_fused_qk_rope_with_cache.py.log && \
-              echo 'Skipping bench_per_token_group_quant_8bit.py (disabled to unblock other benchmarks; see PR #256)' && \
-              python3 bench_per_token_group_quant_mxfp4.py 2>&1 | tee per_token_group_quant_mxfp4.py.log && \
-              python3 bench_per_token_group_quant_8bit_v2.py 2>&1 | tee bench_per_token_group_quant_8bit_v2.py.log && \
-              python3 bench_per_token_quant_fp8.py 2>&1 | tee bench_per_token_quant_fp8.py.log && \
-              python3 bench_per_token_group_quant_mxfp4_fusion.py 2>&1 | tee bench_per_token_group_quant_mxfp4_fusion.py.log && \
-              python3 bench_scatter_tokens_to_experts.py 2>&1 | tee bench_scatter_tokens_to_experts.py.log && \
-              python3 bench_top_k_renorm_probs.py 2>&1 | tee bench_top_k_renorm_probs.py.log && \
-              python3 bench_hc_split_sinkhorn.py 2>&1 | tee bench_hc_split_sinkhorn.py.log && \
-              python3 bench_hc_pre_fuse.py 2>&1 | tee bench_hc_pre_fuse.py.log && \
-              python3 bench_embedding_lora_a_fwd.py 2>&1 | tee bench_embedding_lora_a_fwd.py.log && \
-              python3 bench_moe_w4a16_grouped_gemm.py 2>&1 | tee bench_moe_w4a16_grouped_gemm.py.log && \
-              python3 bench_fused_experts_w4a16.py 2>&1 | tee bench_fused_experts_w4a16.py.log && \
-              python3 bench_hc_pre_gemm_sqr_sum.py 2>&1 | tee bench_hc_pre_gemm_sqr_sum.py.log && \
-              python3 bench_mhc_pre.py 2>&1 | tee bench_mhc_pre.py.log && \
-              python3 bench_silu_and_mul_clamp.py 2>&1 | tee bench_silu_and_mul_clamp.log && \
-              python3 bench_jit_rmsnorm.py 2>&1 | tee bench_jit_rmsnorm.py.log && \
-              python3 bench_jit_qknorm.py 2>&1 | tee bench_jit_qknorm.py.log && \
-              python3 bench_jit_rope.py 2>&1 | tee bench_jit_rope.py.log && \
-              python3 bench_jit_timestep_embedding.py 2>&1 | tee bench_jit_timestep_embedding.py.log && \
-              python3 bench_jit_per_token_group_quant_8bit.py 2>&1 | tee bench_jit_per_token_group_quant_8bit.py.log && \
+              set -eo pipefail
+              /miniforge3/envs/py3.10/bin/python3 -m pip install tabulate
+              cd /root/sglang/sgl-kernel-xpu/benchmark
+              python3 bench_flash_attn.py 2>&1 | tee flash.log
+              python3 bench_flash_mla_decode.py 2>&1 | tee mla.log
+              python3 bench_flash_mla_prefill.py 2>&1 | tee mla_prefill.log
+              python3 bench_flash_mla_with_kvcache.py 2>&1 | tee mla_with_kvcache.log
+              python3 bench_flash_mla_sparse_fwd.py 2>&1 | tee mla_sparse_fwd.log
+              python3 bench_moe_topk_sigmoid.py 2>&1 | tee moe_topk_sigmoid.log
+              python3 bench_moe_topk_softmax.py 2>&1 | tee moe.log
+              python3 bench_fused_moe.py 2>&1 | tee fused_moe.log
+              python3 bench_moe_sum_reduce.py 2>&1 | tee moe_sum_reduce.log
+              python3 bench_moe_fused_gate.py 2>&1 | tee moe_fused_gate.py.log
+              python3 bench_merge_states_v2.py 2>&1 | tee merge_states.py.log
+              python3 bench_mrope.py 2>&1 | tee mrope.py.log
+              python3 bench_swiglu_alpha_limit.py 2>&1 | tee swiglu_alpha_limit.py.log
+              python3 bench_fused_qk_norm_rope.py 2>&1 | tee fused_qk_norm_rope.py.log
+              python3 bench_fused_qk_rope_with_cache.py 2>&1 | tee bench_fused_qk_rope_with_cache.py.log
+              echo 'Skipping bench_per_token_group_quant_8bit.py (disabled to unblock other benchmarks; see PR #256)'
+              python3 bench_per_token_group_quant_mxfp4.py 2>&1 | tee per_token_group_quant_mxfp4.py.log
+              python3 bench_per_token_group_quant_8bit_v2.py 2>&1 | tee bench_per_token_group_quant_8bit_v2.py.log
+              python3 bench_per_token_quant_fp8.py 2>&1 | tee bench_per_token_quant_fp8.py.log
+              python3 bench_per_token_group_quant_mxfp4_fusion.py 2>&1 | tee bench_per_token_group_quant_mxfp4_fusion.py.log
+              python3 bench_scatter_tokens_to_experts.py 2>&1 | tee bench_scatter_tokens_to_experts.py.log
+              python3 bench_top_k_renorm_probs.py 2>&1 | tee bench_top_k_renorm_probs.py.log
+              python3 bench_hc_split_sinkhorn.py 2>&1 | tee bench_hc_split_sinkhorn.py.log
+              python3 bench_hc_pre_fuse.py 2>&1 | tee bench_hc_pre_fuse.py.log
+              python3 bench_embedding_lora_a_fwd.py 2>&1 | tee bench_embedding_lora_a_fwd.py.log
+              python3 bench_moe_w4a16_grouped_gemm.py 2>&1 | tee bench_moe_w4a16_grouped_gemm.py.log
+              python3 bench_fused_experts_w4a16.py 2>&1 | tee bench_fused_experts_w4a16.py.log
+              python3 bench_hc_pre_gemm_sqr_sum.py 2>&1 | tee bench_hc_pre_gemm_sqr_sum.py.log
+              python3 bench_mhc_pre.py 2>&1 | tee bench_mhc_pre.py.log
+              python3 bench_silu_and_mul_clamp.py 2>&1 | tee bench_silu_and_mul_clamp.log
+              python3 bench_jit_rmsnorm.py 2>&1 | tee bench_jit_rmsnorm.py.log
+              python3 bench_jit_qknorm.py 2>&1 | tee bench_jit_qknorm.py.log
+              python3 bench_jit_rope.py 2>&1 | tee bench_jit_rope.py.log
+              python3 bench_jit_timestep_embedding.py 2>&1 | tee bench_jit_timestep_embedding.py.log
+              echo 'Skipping bench_jit_per_token_group_quant_8bit.py (ModuleNotFoundError: sglang not installed in bench container; re-enable once sgl_kernel/gemm.py no longer imports sglang.srt.utils at call time)'
               python3 bench_hc_post.py 2>&1 | tee bench_hc_post.py.log
-              python3 bench_jit_moe_topk_sigmoid.py 2>&1 | tee bench_jit_moe_topk_sigmoid.py.log && \
-              python3 bench_jit_moe_fused_gate.py 2>&1 | tee bench_jit_moe_fused_gate.py.log && \
-              python3 bench_jit_per_tensor_quant_fp8.py 2>&1 | tee bench_jit_per_tensor_quant_fp8.py.log && \
-              python3 bench_jit_moe_align_block_size.py 2>&1 | tee bench_jit_moe_align_block_size.py.log && \
-              python3 bench_jit_per_token_group_quant_8bit_v2.py 2>&1 | tee bench_jit_per_token_group_quant_8bit_v2.py.log && \
-              python3 bench_jit_activation.py 2>&1 | tee bench_jit_activation.py.log && \
-              python3 bench_hc_post.py 2>&1 | tee bench_hc_post.py.log && \
-              python3 bench_sgemm_lora_a_fwd.py 2>&1 | tee bench_sgemm_lora_a_fwd.py.log && \
-              python3 bench_biased_topk.py 2>&1 | tee bench_biased_topk.py.log && \
-              python3 bench_sgemm_lora_b_fwd.py 2>&1 | tee bench_sgemm_lora_b_fwd.py.log && \
-              python3 bench_min_p_sampling_from_probs.py 2>&1 | tee bench_min_p_sampling_from_probs.py.log && \
+              python3 bench_jit_moe_topk_sigmoid.py 2>&1 | tee bench_jit_moe_topk_sigmoid.py.log
+              python3 bench_jit_moe_fused_gate.py 2>&1 | tee bench_jit_moe_fused_gate.py.log
+              python3 bench_jit_per_tensor_quant_fp8.py 2>&1 | tee bench_jit_per_tensor_quant_fp8.py.log
+              python3 bench_jit_moe_align_block_size.py 2>&1 | tee bench_jit_moe_align_block_size.py.log
+              python3 bench_jit_per_token_group_quant_8bit_v2.py 2>&1 | tee bench_jit_per_token_group_quant_8bit_v2.py.log
+              python3 bench_jit_activation.py 2>&1 | tee bench_jit_activation.py.log
+              python3 bench_sgemm_lora_a_fwd.py 2>&1 | tee bench_sgemm_lora_a_fwd.py.log
+              python3 bench_biased_topk.py 2>&1 | tee bench_biased_topk.py.log
+              python3 bench_sgemm_lora_b_fwd.py 2>&1 | tee bench_sgemm_lora_b_fwd.py.log
+              python3 bench_min_p_sampling_from_probs.py 2>&1 | tee bench_min_p_sampling_from_probs.py.log
               python3 bench_top_p_renorm_probs.py 2>&1 | tee bench_top_p_renorm_probs.py.log
               python3 bench_top_k_top_p_sampling_from_probs.py 2>&1 | tee bench_top_k_top_p_sampling_from_probs.py.log
             "


### PR DESCRIPTION
## Summary

Three related CI changes bundled together — the merge gate isn't useful until reds are actually reported (fix #2) and known crashers are skipped (fix #3).

### 1. `detect` + `ci-gate` jobs (new)

`ci-gate` is a single sentinel meant to be **the only required check** in branch protection. It encodes the merge matrix directly:

| PR type | \`run-ci\` label | XPU job | \`ci-gate\` result |
|---|---|---|---|
| docs-only | no | skipped | pass |
| docs-only | yes | ran | pass iff green |
| kernel / mixed | no | skipped | **fail** (missing label) |
| kernel / mixed | yes | green | pass |
| kernel / mixed | yes | red | **fail** |

Without a sentinel, marking \`build-and-test\` directly as required in branch protection would block docs-only PRs — skipped required checks show up as \"missing\" and block merge.

Docs-only classification uses \`dorny/paths-filter\` with \`predicate-quantifier: every\` (all changed files must match to count as docs-only). Currently matches: \`**/*.md\`, \`**/*.rst\`, \`**/*.txt\`, \`docs/**\`, \`LICENSE\`.

### 2. Benchmark step now fails when a bench crashes

Same fix as #443 (opened by @mingfeima, not yet merged). Replaces the long \`cmd \| tee log && cmd \| tee log && ...\` chain with sequential commands under \`set -eo pipefail\`. Two missing \`&&\` on main used to let later benches run as separate statements, so a crashing bench (e.g. \`bench_flash_attn.py\` in #330) did not fail the step — the job stayed green until \`docker cp fused_moe.log\` looked like infra flake.

Bundled here (rather than waiting on #443) because the gate is toothless if reds don't surface.

Also drops one duplicate invocation of \`bench_hc_post.py\` — it appeared twice in the chain and always ran twice back-to-back.

### 3. Skip \`bench_jit_per_token_group_quant_8bit.py\`

Currently crashes with:

\`\`\`
ModuleNotFoundError: No module named 'sglang'
  File \".../sgl_kernel/gemm.py\", line 99, in sgl_per_token_group_quant_8bit
    from sglang.srt.utils import get_bool_env_var
\`\`\`

\`sgl_kernel/gemm.py:99\` does a runtime import of \`sglang.srt.utils\` but \`sglang\` isn't installed in the bench container. Follows the existing skip pattern for \`bench_per_token_group_quant_8bit.py\` (see #256). Re-enable once the runtime import is removed or \`sglang\` is installed in the bench image.

## Post-merge action for maintainers

Once this lands, add \`ci-gate\` as a required status check on \`main\` in Settings → Rules → Rulesets. That's the actual gate — this PR just makes it safe to turn on.

## Test plan

- [ ] CI runs green on this PR (which is docs-adjacent only — YAML change under \`.github/\`, so it won't be classified as docs-only; \`run-ci\` label required for full XPU run).
- [ ] Add \`run-ci\` label → \`build-and-test\` runs and completes (crashing bench is now skipped).
- [ ] \`ci-gate\` job runs and reports pass/fail per the matrix.
- [ ] Confirm \`detect\` correctly identifies a docs-only PR (e.g. edit README on a follow-up test PR).