### PR TITLE
Implement topk_transform_ragged with SYCL

### DIFF
--- a/benchmark/bench_topk_transform.py
+++ b/benchmark/bench_topk_transform.py
@@ -7,8 +7,9 @@ from sgl_kernel import (
     fast_topk_transform_fused,
     fast_topk_transform_ragged_fused,
     fast_topk_v2,
-    topk_transform_512,
-    topk_transform_512_v2,
+    topk_transform,
+    topk_transform_paged,
+    topk_transform_ragged,
 )
 
 # Sweep configuration (skip bs=1 per request).
@@ -258,6 +259,16 @@ topk_transform_configs = [
     )
 ]
 
+ragged_v2_configs = [
+    (bs, topk, seq_len, has_row_starts)
+    for bs, topk, seq_len, has_row_starts in product(
+        batch_size_range,
+        [512, 1024, 2048],
+        seq_len_range,
+        has_row_starts_range,
+    )
+]
+
 
 @triton.testing.perf_report(
     triton.testing.Benchmark(
@@ -268,13 +279,13 @@ topk_transform_configs = [
         line_names=["SGL Kernel"],
         styles=[("blue", "-")],
         ylabel="Time (ms)",
-        plot_name="topk-transform-512-performance",
+        plot_name="topk-transform-performance",
         args={},
     )
 )
-def benchmark_topk_transform_512(bs, topk, seq_len, page_size, provider):
+def benchmark_topk_transform(bs, topk, seq_len, page_size, provider):
     print(
-        f"benchmark topk_transform_512 {provider} bs={bs} topk={topk} "
+        f"benchmark topk_transform {provider} bs={bs} topk={topk} "
         f"seq_len={seq_len} page_size={page_size}"
     )
     torch.xpu.manual_seed_all(42)
@@ -290,7 +301,67 @@ def benchmark_topk_transform_512(bs, topk, seq_len, page_size, provider):
     )
     out_page = torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
 
-    fn = lambda: topk_transform_512(
+    fn = lambda: topk_transform(score, lengths, page_table, out_page, page_size, None)
+
+    for _ in range(5):
+        fn()
+    torch.xpu.synchronize()
+
+    quantiles = [0.5, 0.25, 0.75]
+    ms, _, _ = triton.testing.do_bench(fn, quantiles=quantiles, return_mode="median")
+
+    torch.xpu.empty_cache()
+
+    total_bytes = score.numel() * score.element_size()
+    bandwidth_gb_s = total_bytes / (ms / 1e3) / 1e9
+
+    all_results.append(
+        {
+            "op": "topk_transform",
+            "bs": bs,
+            "topk": topk,
+            "seq_len": seq_len,
+            "page_size": page_size,
+            "provider": provider,
+            "bandwidth_gb_s": bandwidth_gb_s,
+            "ms": ms,
+        }
+    )
+    return ms
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["bs", "topk", "seq_len", "page_size"],
+        x_vals=topk_transform_configs,
+        line_arg="provider",
+        line_vals=["sgl_kernel"],
+        line_names=["SGL Kernel"],
+        styles=[("blue", "-")],
+        ylabel="Time (ms)",
+        plot_name="topk-transform-paged-performance",
+        args={},
+    )
+)
+def benchmark_topk_transform_paged(bs, topk, seq_len, page_size, provider):
+    print(
+        f"benchmark topk_transform_paged {provider} bs={bs} topk={topk} "
+        f"seq_len={seq_len} page_size={page_size}"
+    )
+    torch.xpu.manual_seed_all(42)
+
+    score = torch.randn(bs, seq_len, dtype=torch.float32, device="xpu")
+    lengths = torch.full((bs,), seq_len, dtype=torch.int32, device="xpu")
+    num_pages = (seq_len + page_size - 1) // page_size
+    page_table = (
+        torch.arange(0, num_pages, dtype=torch.int32, device="xpu")
+        .unsqueeze(0)
+        .expand(bs, -1)
+        .contiguous()
+    )
+    out_page = torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
+
+    fn = lambda: topk_transform_paged(
         score, lengths, page_table, out_page, page_size, None
     )
 
@@ -308,7 +379,7 @@ def benchmark_topk_transform_512(bs, topk, seq_len, page_size, provider):
 
     all_results.append(
         {
-            "op": "topk_transform_512",
+            "op": "topk_transform_paged",
             "bs": bs,
             "topk": topk,
             "seq_len": seq_len,
@@ -323,38 +394,40 @@ def benchmark_topk_transform_512(bs, topk, seq_len, page_size, provider):
 
 @triton.testing.perf_report(
     triton.testing.Benchmark(
-        x_names=["bs", "topk", "seq_len", "page_size"],
-        x_vals=topk_transform_configs,
+        x_names=["bs", "topk", "seq_len", "has_row_starts"],
+        x_vals=ragged_v2_configs,
         line_arg="provider",
         line_vals=["sgl_kernel"],
         line_names=["SGL Kernel"],
         styles=[("blue", "-")],
         ylabel="Time (ms)",
-        plot_name="topk-transform-512-v2-performance",
+        plot_name="topk-transform-ragged-performance",
         args={},
     )
 )
-def benchmark_topk_transform_512_v2(bs, topk, seq_len, page_size, provider):
+def benchmark_topk_transform_ragged(bs, topk, seq_len, has_row_starts, provider):
     print(
-        f"benchmark topk_transform_512_v2 {provider} bs={bs} topk={topk} "
-        f"seq_len={seq_len} page_size={page_size}"
+        f"benchmark topk_transform_ragged {provider} bs={bs} topk={topk} "
+        f"seq_len={seq_len} has_row_starts={has_row_starts}"
     )
     torch.xpu.manual_seed_all(42)
 
-    score = torch.randn(bs, seq_len, dtype=torch.float32, device="xpu")
-    lengths = torch.full((bs,), seq_len, dtype=torch.int32, device="xpu")
-    num_pages = (seq_len + page_size - 1) // page_size
-    page_table = (
-        torch.arange(0, num_pages, dtype=torch.int32, device="xpu")
-        .unsqueeze(0)
-        .expand(bs, -1)
-        .contiguous()
+    score = torch.randn(
+        bs,
+        seq_len + (2048 if has_row_starts else 0),
+        dtype=torch.float32,
+        device="xpu",
     )
-    out_page = torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
-    metadata = torch.empty((bs + 1, 2), dtype=torch.int32, device="xpu")
+    if has_row_starts:
+        row_starts = torch.randint(0, 2048, (bs,), dtype=torch.int32, device="xpu")
+    else:
+        row_starts = None
+    lengths = torch.full((bs,), seq_len, dtype=torch.int32, device="xpu")
+    out_offsets = torch.randint(0, 1024, (bs,), dtype=torch.int32, device="xpu")
+    out_indices = torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
 
-    fn = lambda: topk_transform_512_v2(
-        score, lengths, page_table, out_page, page_size, metadata, None
+    fn = lambda: topk_transform_ragged(
+        score, lengths, out_indices, out_offsets, row_starts
     )
 
     for _ in range(5):
@@ -371,11 +444,11 @@ def benchmark_topk_transform_512_v2(bs, topk, seq_len, page_size, provider):
 
     all_results.append(
         {
-            "op": "topk_transform_512_v2",
+            "op": "topk_transform_ragged",
             "bs": bs,
             "topk": topk,
             "seq_len": seq_len,
-            "page_size": page_size,
+            "has_row_starts": has_row_starts,
             "provider": provider,
             "bandwidth_gb_s": bandwidth_gb_s,
             "ms": ms,
@@ -388,8 +461,9 @@ if __name__ == "__main__":
     benchmark_fast_topk_v2.run(print_data=False)
     benchmark_fast_topk_transform_fused.run(print_data=False)
     benchmark_fast_topk_transform_ragged_fused.run(print_data=False)
-    benchmark_topk_transform_512.run(print_data=False)
-    benchmark_topk_transform_512_v2.run(print_data=False)
+    benchmark_topk_transform.run(print_data=False)
+    benchmark_topk_transform_paged.run(print_data=False)
+    benchmark_topk_transform_ragged.run(print_data=False)
     print("Benchmark finished!")
 
     df = pd.DataFrame(all_results)

--- a/benchmark/bench_topk_transform.py
+++ b/benchmark/bench_topk_transform.py
@@ -360,9 +360,10 @@ def benchmark_topk_transform_paged(bs, topk, seq_len, page_size, provider):
         .contiguous()
     )
     out_page = torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
+    metadata = torch.empty((0,), dtype=torch.int32, device="cpu")
 
     fn = lambda: topk_transform_paged(
-        score, lengths, page_table, out_page, page_size, None
+        score, lengths, page_table, out_page, page_size, metadata
     )
 
     for _ in range(5):

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -944,25 +944,25 @@ void top_p_sampling_from_probs(
     bool deterministic,
     std::optional<at::Generator> gen);
 
-void fast_topk_interface(
-    const at::Tensor& score, at::Tensor& indices, const at::Tensor& lengths, std::optional<at::Tensor> row_starts_opt);
+at::Tensor
+fast_topk(const at::Tensor& score, const at::Tensor& lengths, int64_t topk, std::optional<at::Tensor> row_starts_opt);
 
-void fast_topk_transform_interface(
+at::Tensor fast_topk_transform_fused(
     const at::Tensor& score,
     const at::Tensor& lengths,
-    at::Tensor& dst_page_table,
     const at::Tensor& src_page_table,
     const at::Tensor& cu_seqlens_q,
+    int64_t topk,
     std::optional<at::Tensor> row_starts_opt);
 
-void fast_topk_transform_ragged_interface(
+at::Tensor fast_topk_transform_ragged_fused(
     const at::Tensor& score,
     const at::Tensor& lengths,
-    at::Tensor& topk_indices_ragged,
     const at::Tensor& topk_indices_offset,
+    int64_t topk,
     std::optional<at::Tensor> row_starts_opt);
 
-void topk_transform_512_interface(
+void topk_transform(
     const at::Tensor& scores,
     const at::Tensor& seq_lens,
     const at::Tensor& page_tables,
@@ -970,14 +970,20 @@ void topk_transform_512_interface(
     int64_t page_size,
     std::optional<at::Tensor> out_raw_indices_opt);
 
-void topk_transform_512_v2_interface(
+void topk_transform_paged(
     const at::Tensor& scores,
     const at::Tensor& seq_lens,
-    const at::Tensor& page_tables,
+    std::optional<at::Tensor> page_tables_opt,
     at::Tensor& out_page_indices,
     int64_t page_size,
-    const at::Tensor& metadata,
-    std::optional<at::Tensor> out_raw_indices_opt);
+    const at::Tensor& metadata);
+
+void topk_transform_ragged(
+    const at::Tensor& scores,
+    const at::Tensor& seq_lens,
+    at::Tensor& out_indices,
+    const at::Tensor& out_offsets,
+    std::optional<at::Tensor> row_starts_opt);
 
 /*
  * Compress plan and execution kernels

--- a/python/sgl_kernel/__init__.py
+++ b/python/sgl_kernel/__init__.py
@@ -173,8 +173,9 @@ from sgl_kernel.top_k import (
     fast_topk_transform_fused,
     fast_topk_transform_ragged_fused,
     fast_topk_v2,
-    topk_transform_512,
-    topk_transform_512_v2,
+    topk_transform,
+    topk_transform_paged,
+    topk_transform_ragged,
 )
 from sgl_kernel.utils import get_device_capability, is_xe2_arch
 from sgl_kernel.version import __version__

--- a/python/sgl_kernel/top_k.py
+++ b/python/sgl_kernel/top_k.py
@@ -23,13 +23,7 @@ def fast_topk_v2(
     Returns:
         The topk indices tensor of shape (B, topk)
     """
-    if topk != 2048:
-        raise ValueError("fast_topk_v2 only supports topk=2048")
-    if score.dim() != 2:
-        raise ValueError("score must be a 2D tensor")
-    topk_indices = score.new_empty((score.size(0), topk), dtype=torch.int32)
-    torch.ops.sgl_kernel.fast_topk.default(score, topk_indices, lengths, row_starts)
-    return topk_indices
+    return torch.ops.sgl_kernel.fast_topk(score, lengths, topk, row_starts)
 
 
 def fast_topk_transform_fused(
@@ -58,15 +52,9 @@ def fast_topk_transform_fused(
     Returns:
         The topk indices tensor of shape (B, topk)
     """
-    if topk != 2048:
-        raise ValueError("fast_topk_transform_fused only supports topk=2048")
-    if score.dim() != 2:
-        raise ValueError("score must be a 2D tensor")
-    dst_page_table = score.new_empty((score.shape[0], topk), dtype=torch.int32)
-    torch.ops.sgl_kernel.fast_topk_transform_fused.default(
-        score, lengths, dst_page_table, page_table_size_1, cu_seqlens_q, row_starts
+    return torch.ops.sgl_kernel.fast_topk_transform_fused(
+        score, lengths, page_table_size_1, cu_seqlens_q, topk, row_starts
     )
-    return dst_page_table
 
 
 def fast_topk_transform_ragged_fused(
@@ -95,18 +83,12 @@ def fast_topk_transform_ragged_fused(
     Returns:
         The topk indices tensor of shape (B, topk)
     """
-    if topk != 2048:
-        raise ValueError("fast_topk_transform_ragged_fused only supports topk=2048")
-    if score.dim() != 2:
-        raise ValueError("score must be a 2D tensor")
-    topk_indices_ragged = score.new_empty((score.shape[0], topk), dtype=torch.int32)
-    torch.ops.sgl_kernel.fast_topk_transform_ragged_fused.default(
-        score, lengths, topk_indices_ragged, topk_indices_offset, row_starts
+    return torch.ops.sgl_kernel.fast_topk_transform_ragged_fused(
+        score, lengths, topk_indices_offset, topk, row_starts
     )
-    return topk_indices_ragged
 
 
-def topk_transform_512(
+def topk_transform(
     scores: torch.Tensor,
     seq_lens: torch.Tensor,
     page_tables: torch.Tensor,
@@ -114,26 +96,43 @@ def topk_transform_512(
     page_size: int,
     out_raw_indices: Optional[torch.Tensor] = None,
 ) -> None:
-    torch.ops.sgl_kernel.topk_transform_512.default(
+    torch.ops.sgl_kernel.topk_transform(
         scores, seq_lens, page_tables, out_page_indices, page_size, out_raw_indices
     )
 
 
-def topk_transform_512_v2(
+def topk_transform_paged(
     scores: torch.Tensor,
     seq_lens: torch.Tensor,
-    page_tables: torch.Tensor,
+    page_tables: Optional[torch.Tensor],
     out_page_indices: torch.Tensor,
     page_size: int,
     metadata: torch.Tensor,
-    out_raw_indices: Optional[torch.Tensor] = None,
 ) -> None:
-    torch.ops.sgl_kernel.topk_transform_512_v2.default(
-        scores,
-        seq_lens,
-        page_tables,
-        out_page_indices,
-        page_size,
-        metadata,
-        out_raw_indices,
+    torch.ops.sgl_kernel.topk_transform_paged(
+        scores, seq_lens, page_tables, out_page_indices, page_size, metadata
+    )
+
+
+def topk_transform_ragged(
+    scores: torch.Tensor,
+    seq_lens: torch.Tensor,
+    out_indices: torch.Tensor,
+    out_offsets: torch.Tensor,
+    row_starts: Optional[torch.Tensor] = None,
+) -> None:
+    """
+    Ragged (prefill) top-k: select inside a per-row window and rebase the
+    selected positions onto the flattened KV.
+    Args:
+        scores: The score tensor of shape (B, L).
+        seq_lens: The per-row window length of shape (B,).
+        out_indices: The output tensor of shape (B, topk). topk is inferred
+            from out_indices.size(1).
+        out_offsets: Added to every selected position of shape (B,).
+        row_starts: The start column of each row's window of shape (B).
+            Defaults to 0 for every row when omitted.
+    """
+    torch.ops.sgl_kernel.topk_transform_ragged(
+        scores, seq_lens, out_indices, out_offsets, row_starts
     )

--- a/src/sycl/TopKTransform.cpp
+++ b/src/sycl/TopKTransform.cpp
@@ -881,7 +881,7 @@ SGL_KERNEL_EXPORT void topk_transform_ragged(
     at::Tensor& out_indices,
     const at::Tensor& out_offsets,
     std::optional<at::Tensor> row_starts_opt) {
-  CHECK_INPUT(scores);
+  CHECK_DEVICE(scores);
   CHECK_DEVICE(seq_lens);
   CHECK_DEVICE(out_indices);
   CHECK_DEVICE(out_offsets);

--- a/src/sycl/TopKTransform.cpp
+++ b/src/sycl/TopKTransform.cpp
@@ -11,7 +11,9 @@
 #include "sgl_kernel_export.h"
 
 namespace {
-constexpr int kTopK = 2048;
+// Runtime topk values must be in (0, kMaxTopK]. Shared-memory staging buffers
+// are sized against kMaxTopK, so every supported runtime value is safe.
+constexpr int kMaxTopK = 2048;
 constexpr int kThreadsPerBlock = 1024;
 constexpr int kRadix = 256;
 constexpr int kHistPad = 128;  // padding so suffix-sum can read [tx + j] safely
@@ -83,10 +85,7 @@ inline void run_cumsum(sycl::nd_item<1>& item, int32_t* s_histogram_buf /* [2][k
 }
 
 inline void
-radix_topk(sycl::nd_item<1>& item, const float* input, int32_t* index, int row_start, int length, int topk = kTopK) {
-  // ``topk`` is a runtime parameter (must satisfy 0 < topk <= kTopK). The
-  // shared-memory staging buffers are sized against the compile-time ``kTopK``,
-  // so any topk within that bound is safe.
+radix_topk(sycl::nd_item<1>& item, const float* input, int32_t* index, int row_start, int length, int topk = kMaxTopK) {
   auto g = item.get_group();
 
   int32_t* s_histogram_buf = *sycl::ext::oneapi::group_local_memory_for_overwrite<int32_t[2 * kHistStride]>(g);
@@ -272,7 +271,7 @@ radix_topk(sycl::nd_item<1>& item, const float* input, int32_t* index, int row_s
   }
 }
 
-inline void trivial_topk(sycl::nd_item<1>& item, int32_t* indices, int length, int topk = kTopK) {
+inline void trivial_topk(sycl::nd_item<1>& item, int32_t* indices, int length, int topk = kMaxTopK) {
   const int tx = static_cast<int>(item.get_local_id(0));
   for (int i = tx; i < topk; i += kThreadsPerBlock) {
     indices[i] = (i < length) ? i : -1;
@@ -280,7 +279,7 @@ inline void trivial_topk(sycl::nd_item<1>& item, int32_t* indices, int length, i
 }
 
 inline void trivial_topk_transform(
-    sycl::nd_item<1>& item, int length, int32_t* dst_page_entry, const int32_t* src_page_entry, int topk = kTopK) {
+    sycl::nd_item<1>& item, int length, int32_t* dst_page_entry, const int32_t* src_page_entry, int topk = kMaxTopK) {
   const int tx = static_cast<int>(item.get_local_id(0));
   for (int i = tx; i < topk; i += kThreadsPerBlock) {
     dst_page_entry[i] = (i < length) ? src_page_entry[i] : -1;
@@ -288,7 +287,7 @@ inline void trivial_topk_transform(
 }
 
 inline void trivial_topk_transform_ragged(
-    sycl::nd_item<1>& item, int length, int32_t* dst_indices_entry, int32_t offset, int topk = kTopK) {
+    sycl::nd_item<1>& item, int length, int32_t* dst_indices_entry, int32_t offset, int topk = kMaxTopK) {
   const int tx = static_cast<int>(item.get_local_id(0));
   for (int i = tx; i < topk; i += kThreadsPerBlock) {
     dst_indices_entry[i] = (i < length) ? (i + offset) : -1;
@@ -345,7 +344,8 @@ FastTopKParams get_params(
   if (indices_opt.has_value()) {
     const auto& indices = indices_opt.value();
     TORCH_CHECK(indices.dim() == 2 && indices.is_contiguous());
-    TORCH_CHECK(indices.size(0) == B && indices.size(1) == kTopK);
+    TORCH_CHECK(indices.size(0) == B, "indices.size(0) must equal score.size(0)");
+    TORCH_CHECK(indices.size(1) == kMaxTopK, "topk (indices.size(1)) must equal ", kMaxTopK);
     TORCH_CHECK(indices.scalar_type() == at::kInt, "indices must be int32");
     indices_ptr = indices.data_ptr<int32_t>();
   }
@@ -370,10 +370,10 @@ struct FastTopKKernel : public __SYCL_KER_CONFIG_CONVENTION__ {
     const int64_t bid = static_cast<int64_t>(item.get_group(0));
     const int row_start = params.row_starts ? params.row_starts[bid] : 0;
     const int length = params.lengths[bid];
-    int32_t* indice = params.indices + bid * kTopK;
+    int32_t* indice = params.indices + bid * kMaxTopK;
     const float* score = params.input + bid * params.input_stride;
 
-    if (length <= kTopK) {
+    if (length <= kMaxTopK) {
       trivial_topk(item, indice, length);
     } else {
       radix_topk(item, score, indice, row_start, length);
@@ -393,7 +393,7 @@ struct FastTopKTransformFusedDecodeKernel : public __SYCL_KER_CONFIG_CONVENTION_
       : params(p), dst_page_table(dst), src_page_table(src), src_stride(stride) {}
 
   void sycl_ker_config_convention(sycl::handler& cgh) {
-    s_indices_ = sycl::local_accessor<int32_t, 1>(kTopK, cgh);
+    s_indices_ = sycl::local_accessor<int32_t, 1>(kMaxTopK, cgh);
   }
 
   [[sycl::reqd_sub_group_size(32)]] void operator()(sycl::nd_item<1> item) const {
@@ -401,10 +401,10 @@ struct FastTopKTransformFusedDecodeKernel : public __SYCL_KER_CONFIG_CONVENTION_
     const int tid = static_cast<int>(item.get_local_id(0));
     const int length = params.lengths[bid];
     const int32_t* src_entry = src_page_table + bid * src_stride;
-    int32_t* dst_entry = dst_page_table + bid * kTopK;
+    int32_t* dst_entry = dst_page_table + bid * kMaxTopK;
     const float* score = params.input + bid * params.input_stride;
 
-    if (length <= kTopK) {
+    if (length <= kMaxTopK) {
       trivial_topk_transform(item, length, dst_entry, src_entry);
       return;
     }
@@ -413,7 +413,7 @@ struct FastTopKTransformFusedDecodeKernel : public __SYCL_KER_CONFIG_CONVENTION_
 
     radix_topk(item, score, s_idx, /*row_start=*/0, length);
 
-    static_assert(kTopK == 2 * kThreadsPerBlock, "kTopK must be 2 * kThreadsPerBlock");
+    static_assert(kMaxTopK == 2 * kThreadsPerBlock, "kMaxTopK must be 2 * kThreadsPerBlock");
     const int i0 = tid;
     const int i1 = tid + kThreadsPerBlock;
     const int p0 = s_idx[i0];
@@ -439,7 +439,7 @@ struct FastTopKTransformFusedPrefillKernel : public __SYCL_KER_CONFIG_CONVENTION
       : params(p), dst_page_table(dst), src_page_table(src), src_stride(stride), cu_seqlens_q(cu_q), prefill_bs(pbs) {}
 
   void sycl_ker_config_convention(sycl::handler& cgh) {
-    s_indices_ = sycl::local_accessor<int32_t, 1>(kTopK, cgh);
+    s_indices_ = sycl::local_accessor<int32_t, 1>(kMaxTopK, cgh);
     s_src_row_ = sycl::local_accessor<int32_t, 1>(1, cgh);
   }
 
@@ -448,7 +448,7 @@ struct FastTopKTransformFusedPrefillKernel : public __SYCL_KER_CONFIG_CONVENTION
     const int tid = static_cast<int>(item.get_local_id(0));
     const int length = params.lengths[bid];
     const int row_start = params.row_starts ? params.row_starts[bid] : 0;
-    int32_t* dst_entry = dst_page_table + bid * kTopK;
+    int32_t* dst_entry = dst_page_table + bid * kMaxTopK;
     const float* score = params.input + bid * params.input_stride;
 
     int32_t* s_src_row = s_src_row_.get_multi_ptr<sycl::access::decorated::no>().get();
@@ -475,7 +475,7 @@ struct FastTopKTransformFusedPrefillKernel : public __SYCL_KER_CONFIG_CONVENTION
 
     const int32_t* src_entry = src_page_table + s_src_row[0] * src_stride;
 
-    if (length <= kTopK) {
+    if (length <= kMaxTopK) {
       trivial_topk_transform(item, length, dst_entry, src_entry);
       return;
     }
@@ -484,7 +484,7 @@ struct FastTopKTransformFusedPrefillKernel : public __SYCL_KER_CONFIG_CONVENTION
 
     radix_topk(item, score, s_idx, row_start, length);
 
-    static_assert(kTopK == 2 * kThreadsPerBlock, "kTopK must be 2 * kThreadsPerBlock");
+    static_assert(kMaxTopK == 2 * kThreadsPerBlock, "kMaxTopK must be 2 * kThreadsPerBlock");
     const int i0 = tid;
     const int i1 = tid + kThreadsPerBlock;
     const int p0 = s_idx[i0];
@@ -505,7 +505,7 @@ struct FastTopKTransformRaggedFusedKernel : public __SYCL_KER_CONFIG_CONVENTION_
       : params(p), topk_indices_ragged(out), topk_indices_offset(off) {}
 
   void sycl_ker_config_convention(sycl::handler& cgh) {
-    s_indices_ = sycl::local_accessor<int32_t, 1>(kTopK, cgh);
+    s_indices_ = sycl::local_accessor<int32_t, 1>(kMaxTopK, cgh);
   }
 
   [[sycl::reqd_sub_group_size(32)]] void operator()(sycl::nd_item<1> item) const {
@@ -513,11 +513,11 @@ struct FastTopKTransformRaggedFusedKernel : public __SYCL_KER_CONFIG_CONVENTION_
     const int tid = static_cast<int>(item.get_local_id(0));
     const int row_start = params.row_starts ? params.row_starts[bid] : 0;
     const int length = params.lengths[bid];
-    int32_t* dst_entry = topk_indices_ragged + bid * kTopK;
+    int32_t* dst_entry = topk_indices_ragged + bid * kMaxTopK;
     const float* score = params.input + bid * params.input_stride;
     const int32_t offset = topk_indices_offset[bid];
 
-    if (length <= kTopK) {
+    if (length <= kMaxTopK) {
       trivial_topk_transform_ragged(item, length, dst_entry, offset);
       return;
     }
@@ -526,7 +526,7 @@ struct FastTopKTransformRaggedFusedKernel : public __SYCL_KER_CONFIG_CONVENTION_
 
     radix_topk(item, score, s_idx, row_start, length);
 
-    static_assert(kTopK == 2 * kThreadsPerBlock, "kTopK must be 2 * kThreadsPerBlock");
+    static_assert(kMaxTopK == 2 * kThreadsPerBlock, "kMaxTopK must be 2 * kThreadsPerBlock");
     const int i0 = tid;
     const int i1 = tid + kThreadsPerBlock;
     dst_entry[i0] = s_idx[i0] + offset;
@@ -534,7 +534,7 @@ struct FastTopKTransformRaggedFusedKernel : public __SYCL_KER_CONFIG_CONVENTION_
   }
 };
 
-struct TopKTransform512Kernel : public __SYCL_KER_CONFIG_CONVENTION__ {
+struct TopKTransformPagedKernel : public __SYCL_KER_CONFIG_CONVENTION__ {
   const float* score;
   const int32_t* seq_lens;
   const int32_t* page_tables;
@@ -547,7 +547,7 @@ struct TopKTransform512Kernel : public __SYCL_KER_CONFIG_CONVENTION__ {
 
   sycl::local_accessor<int32_t, 1> s_indices_;
 
-  TopKTransform512Kernel(
+  TopKTransformPagedKernel(
       const float* score,
       const int32_t* seq_lens,
       const int32_t* page_tables,
@@ -568,20 +568,24 @@ struct TopKTransform512Kernel : public __SYCL_KER_CONFIG_CONVENTION__ {
         topk(topk) {}
 
   void sycl_ker_config_convention(sycl::handler& cgh) {
-    s_indices_ = sycl::local_accessor<int32_t, 1>(kTopK, cgh);
+    s_indices_ = sycl::local_accessor<int32_t, 1>(kMaxTopK, cgh);
   }
 
   [[sycl::reqd_sub_group_size(32)]] void operator()(sycl::nd_item<1> item) const {
     const int64_t bid = static_cast<int64_t>(item.get_group(0));
     const int tid = static_cast<int>(item.get_local_id(0));
     const int length = seq_lens[bid];
-    const int32_t* src_pt = page_tables + bid * page_table_row_stride;
+    const int32_t* src_pt = page_tables ? (page_tables + bid * page_table_row_stride) : nullptr;
     int32_t* dst_pi = out_page_indices + bid * static_cast<int64_t>(topk);
     int32_t* dst_ri = out_raw_indices ? (out_raw_indices + bid * static_cast<int64_t>(topk)) : nullptr;
     const float* row_score = score + bid * score_row_stride;
 
     if (length <= topk) {
-      trivial_topk_transform_paged(item, length, topk, dst_pi, src_pt, dst_ri, page_bits);
+      if (src_pt) {
+        trivial_topk_transform_paged(item, length, topk, dst_pi, src_pt, dst_ri, page_bits);
+      } else {
+        trivial_topk(item, dst_pi, length, topk);
+      }
       return;
     }
 
@@ -592,24 +596,84 @@ struct TopKTransform512Kernel : public __SYCL_KER_CONFIG_CONVENTION__ {
     const int32_t page_mask = (1 << page_bits) - 1;
     for (int i = tid; i < topk; i += kThreadsPerBlock) {
       const int p = s_idx[i];
-      const int32_t page_id = src_pt[p >> page_bits];
-      dst_pi[i] = (page_id << page_bits) | (p & page_mask);
-      if (dst_ri) dst_ri[i] = p;
+      if (src_pt) {
+        const int32_t page_id = src_pt[p >> page_bits];
+        dst_pi[i] = (page_id << page_bits) | (p & page_mask);
+        if (dst_ri) dst_ri[i] = p;
+      } else {
+        dst_pi[i] = p;
+      }
+    }
+  }
+};
+
+struct TopKTransformRaggedKernel : public __SYCL_KER_CONFIG_CONVENTION__ {
+  const float* score;
+  const int32_t* seq_lens;
+  const int32_t* row_starts;
+  const int32_t* out_offsets;
+  int32_t* topk_indices;
+  int64_t score_row_stride;
+  int topk;
+
+  sycl::local_accessor<int32_t, 1> s_indices_;
+
+  TopKTransformRaggedKernel(
+      const float* score,
+      const int32_t* seq_lens,
+      const int32_t* row_starts,
+      const int32_t* out_offsets,
+      int32_t* topk_indices,
+      int64_t score_row_stride,
+      int topk)
+      : score(score),
+        seq_lens(seq_lens),
+        row_starts(row_starts),
+        out_offsets(out_offsets),
+        topk_indices(topk_indices),
+        score_row_stride(score_row_stride),
+        topk(topk) {}
+
+  void sycl_ker_config_convention(sycl::handler& cgh) {
+    s_indices_ = sycl::local_accessor<int32_t, 1>(kMaxTopK, cgh);
+  }
+
+  [[sycl::reqd_sub_group_size(32)]] void operator()(sycl::nd_item<1> item) const {
+    const int64_t bid = static_cast<int64_t>(item.get_group(0));
+    const int row_start = row_starts ? row_starts[bid] : 0;
+    const int length = seq_lens[bid];
+    const int32_t offset = out_offsets[bid];
+    int32_t* dst_entry = topk_indices + bid * static_cast<int64_t>(topk);
+    const float* row_score = score + bid * score_row_stride;
+
+    if (length <= topk) {
+      trivial_topk_transform_ragged(item, length, dst_entry, offset, topk);
+      return;
+    }
+
+    int32_t* s_idx = s_indices_.get_multi_ptr<sycl::access::decorated::no>().get();
+
+    radix_topk(item, row_score, s_idx, row_start, length, topk);
+
+    const int tid = static_cast<int>(item.get_local_id(0));
+    for (int i = tid; i < topk; i += kThreadsPerBlock) {
+      dst_entry[i] = s_idx[i] + offset;
     }
   }
 };
 
 }  // namespace
 
-SGL_KERNEL_EXPORT void fast_topk_interface(
-    const at::Tensor& score, at::Tensor& indices, const at::Tensor& lengths, std::optional<at::Tensor> row_starts_opt) {
+SGL_KERNEL_EXPORT at::Tensor
+fast_topk(const at::Tensor& score, const at::Tensor& lengths, int64_t topk, std::optional<at::Tensor> row_starts_opt) {
   CHECK_INPUT(score);
-  CHECK_DEVICE(indices);
   CHECK_DEVICE(lengths);
   if (row_starts_opt.has_value()) {
     CHECK_DEVICE(row_starts_opt.value());
   }
+  TORCH_CHECK(topk == kMaxTopK, "fast_topk only supports topk=", kMaxTopK);
 
+  at::Tensor indices = at::empty({score.size(0), kMaxTopK}, score.options().dtype(at::kInt));
   const auto params = get_params(score, lengths, row_starts_opt, indices);
   const int64_t B = score.size(0);
 
@@ -619,39 +683,38 @@ SGL_KERNEL_EXPORT void fast_topk_interface(
   FastTopKKernel kernel(params);
   sycl_kernel_submit(
       sycl::range<1>(static_cast<size_t>(B) * kThreadsPerBlock), sycl::range<1>(kThreadsPerBlock), queue, kernel);
+  return indices;
 }
 
-SGL_KERNEL_EXPORT void fast_topk_transform_interface(
+SGL_KERNEL_EXPORT at::Tensor fast_topk_transform_fused(
     const at::Tensor& score,
     const at::Tensor& lengths,
-    at::Tensor& dst_page_table,
     const at::Tensor& src_page_table,
     const at::Tensor& cu_seqlens_q,
+    int64_t topk,
     std::optional<at::Tensor> row_starts_opt) {
   CHECK_INPUT(score);
   CHECK_DEVICE(lengths);
-  CHECK_DEVICE(dst_page_table);
   CHECK_DEVICE(src_page_table);
   CHECK_DEVICE(cu_seqlens_q);
   if (row_starts_opt.has_value()) {
     CHECK_DEVICE(row_starts_opt.value());
   }
+  TORCH_CHECK(topk == kMaxTopK, "fast_topk_transform_fused only supports topk=", kMaxTopK);
 
   const auto params = get_params(score, lengths, row_starts_opt);
   const int64_t B = score.size(0);
 
-  TORCH_CHECK(dst_page_table.dim() == 2 && dst_page_table.is_contiguous());
   TORCH_CHECK(src_page_table.dim() == 2 && src_page_table.stride(1) == 1);
   TORCH_CHECK(cu_seqlens_q.dim() == 1 && cu_seqlens_q.is_contiguous());
-  TORCH_CHECK(dst_page_table.scalar_type() == at::kInt);
   TORCH_CHECK(src_page_table.scalar_type() == at::kInt);
   TORCH_CHECK(cu_seqlens_q.scalar_type() == at::kInt);
 
   const int64_t prefill_bs = cu_seqlens_q.size(0) - 1;
-  TORCH_CHECK(dst_page_table.size(0) == B);
-  TORCH_CHECK(dst_page_table.size(1) == kTopK);
   TORCH_CHECK(src_page_table.size(0) == prefill_bs);
   TORCH_CHECK(prefill_bs <= B);
+
+  at::Tensor dst_page_table = at::empty({B, kMaxTopK}, score.options().dtype(at::kInt));
 
   auto stream = at::xpu::getCurrentXPUStream();
   auto& queue = stream.queue();
@@ -674,31 +737,30 @@ SGL_KERNEL_EXPORT void fast_topk_transform_interface(
     sycl_kernel_submit(
         sycl::range<1>(static_cast<size_t>(B) * kThreadsPerBlock), sycl::range<1>(kThreadsPerBlock), queue, kernel);
   }
+  return dst_page_table;
 }
 
-SGL_KERNEL_EXPORT void fast_topk_transform_ragged_interface(
+SGL_KERNEL_EXPORT at::Tensor fast_topk_transform_ragged_fused(
     const at::Tensor& score,
     const at::Tensor& lengths,
-    at::Tensor& topk_indices_ragged,
     const at::Tensor& topk_indices_offset,
+    int64_t topk,
     std::optional<at::Tensor> row_starts_opt) {
   CHECK_INPUT(score);
   CHECK_DEVICE(lengths);
-  CHECK_DEVICE(topk_indices_ragged);
   CHECK_DEVICE(topk_indices_offset);
   if (row_starts_opt.has_value()) {
     CHECK_DEVICE(row_starts_opt.value());
   }
+  TORCH_CHECK(topk == kMaxTopK, "fast_topk_transform_ragged_fused only supports topk=", kMaxTopK);
 
   const auto params = get_params(score, lengths, row_starts_opt);
   const int64_t B = score.size(0);
-  TORCH_CHECK(topk_indices_ragged.dim() == 2 && topk_indices_ragged.is_contiguous());
   TORCH_CHECK(topk_indices_offset.dim() == 1 && topk_indices_offset.is_contiguous());
-  TORCH_CHECK(topk_indices_ragged.size(0) == B);
-  TORCH_CHECK(topk_indices_ragged.size(1) == kTopK);
   TORCH_CHECK(topk_indices_offset.size(0) == B);
-  TORCH_CHECK(topk_indices_ragged.scalar_type() == at::kInt);
   TORCH_CHECK(topk_indices_offset.scalar_type() == at::kInt);
+
+  at::Tensor topk_indices_ragged = at::empty({B, kMaxTopK}, score.options().dtype(at::kInt));
 
   auto stream = at::xpu::getCurrentXPUStream();
   auto& queue = stream.queue();
@@ -707,19 +769,22 @@ SGL_KERNEL_EXPORT void fast_topk_transform_ragged_interface(
       params, topk_indices_ragged.data_ptr<int32_t>(), topk_indices_offset.data_ptr<int32_t>());
   sycl_kernel_submit(
       sycl::range<1>(static_cast<size_t>(B) * kThreadsPerBlock), sycl::range<1>(kThreadsPerBlock), queue, kernel);
+  return topk_indices_ragged;
 }
 
 namespace {
-void topk_transform_512_launch(
+void topk_transform_paged_launch(
     const at::Tensor& scores,
     const at::Tensor& seq_lens,
-    const at::Tensor& page_tables,
+    std::optional<at::Tensor> page_tables_opt,
     at::Tensor& out_page_indices,
     int64_t page_size,
     std::optional<at::Tensor> out_raw_indices_opt) {
   CHECK_DEVICE(scores);
   CHECK_DEVICE(seq_lens);
-  CHECK_DEVICE(page_tables);
+  if (page_tables_opt.has_value()) {
+    CHECK_DEVICE(page_tables_opt.value());
+  }
   CHECK_DEVICE(out_page_indices);
   if (out_raw_indices_opt.has_value()) {
     CHECK_DEVICE(out_raw_indices_opt.value());
@@ -741,17 +806,20 @@ void topk_transform_512_launch(
   TORCH_CHECK(seq_lens_flat.is_contiguous(), "seq_lens must be contiguous after squeeze");
   TORCH_CHECK(seq_lens_flat.scalar_type() == at::kInt, "seq_lens must be int32");
 
-  TORCH_CHECK(page_tables.dim() == 2, "page_tables must be 2D");
-  TORCH_CHECK(page_tables.size(0) == B, "page_tables.size(0) must equal scores.size(0)");
-  TORCH_CHECK(page_tables.stride(1) == 1, "page_tables must have unit last-dim stride");
-  TORCH_CHECK(page_tables.scalar_type() == at::kInt, "page_tables must be int32");
+  if (page_tables_opt.has_value()) {
+    const auto& page_tables = page_tables_opt.value();
+    TORCH_CHECK(page_tables.dim() == 2, "page_tables must be 2D");
+    TORCH_CHECK(page_tables.size(0) == B, "page_tables.size(0) must equal scores.size(0)");
+    TORCH_CHECK(page_tables.stride(1) == 1, "page_tables must have unit last-dim stride");
+    TORCH_CHECK(page_tables.scalar_type() == at::kInt, "page_tables must be int32");
+  }
 
   TORCH_CHECK(out_page_indices.dim() == 2, "out_page_indices must be 2D");
   TORCH_CHECK(out_page_indices.is_contiguous(), "out_page_indices must be contiguous");
   TORCH_CHECK(out_page_indices.size(0) == B, "out_page_indices.size(0) must equal scores.size(0)");
   TORCH_CHECK(out_page_indices.scalar_type() == at::kInt, "out_page_indices must be int32");
   const int64_t topk = out_page_indices.size(1);
-  TORCH_CHECK(0 < topk && topk <= kTopK, "topk (out_page_indices.size(1)) must be in (0, ", kTopK, "]");
+  TORCH_CHECK(0 < topk && topk <= kMaxTopK, "topk (out_page_indices.size(1)) must be in (0, ", kMaxTopK, "]");
   TORCH_CHECK(page_size > 0, "page_size must be positive");
   TORCH_CHECK((page_size & (page_size - 1)) == 0, "page_size must be a power of 2");
   const int page_bits = __builtin_ctzll(static_cast<uint64_t>(page_size));
@@ -770,14 +838,14 @@ void topk_transform_512_launch(
   auto stream = at::xpu::getCurrentXPUStream();
   auto& queue = stream.queue();
 
-  TopKTransform512Kernel kernel(
+  TopKTransformPagedKernel kernel(
       scores.data_ptr<float>(),
       seq_lens_flat.data_ptr<int32_t>(),
-      page_tables.data_ptr<int32_t>(),
+      page_tables_opt.has_value() ? page_tables_opt->data_ptr<int32_t>() : nullptr,
       out_page_indices.data_ptr<int32_t>(),
       out_raw_ptr,
       scores.stride(0),
-      page_tables.stride(0),
+      page_tables_opt.has_value() ? page_tables_opt->stride(0) : 0,
       page_bits,
       static_cast<int>(topk));
   sycl_kernel_submit(
@@ -786,24 +854,77 @@ void topk_transform_512_launch(
 
 }  // namespace
 
-SGL_KERNEL_EXPORT void topk_transform_512_interface(
+SGL_KERNEL_EXPORT void topk_transform(
     const at::Tensor& scores,
     const at::Tensor& seq_lens,
     const at::Tensor& page_tables,
     at::Tensor& out_page_indices,
     int64_t page_size,
     std::optional<at::Tensor> out_raw_indices_opt) {
-  topk_transform_512_launch(scores, seq_lens, page_tables, out_page_indices, page_size, out_raw_indices_opt);
+  topk_transform_paged_launch(scores, seq_lens, page_tables, out_page_indices, page_size, out_raw_indices_opt);
 }
 
-SGL_KERNEL_EXPORT void topk_transform_512_v2_interface(
+SGL_KERNEL_EXPORT void topk_transform_paged(
     const at::Tensor& scores,
     const at::Tensor& seq_lens,
-    const at::Tensor& page_tables,
+    std::optional<at::Tensor> page_tables_opt,
     at::Tensor& out_page_indices,
     int64_t page_size,
-    const at::Tensor& metadata,
-    std::optional<at::Tensor> out_raw_indices_opt) {
+    const at::Tensor& metadata) {
   (void)metadata;
-  topk_transform_512_launch(scores, seq_lens, page_tables, out_page_indices, page_size, out_raw_indices_opt);
+  topk_transform_paged_launch(scores, seq_lens, page_tables_opt, out_page_indices, page_size, std::nullopt);
+}
+
+SGL_KERNEL_EXPORT void topk_transform_ragged(
+    const at::Tensor& scores,
+    const at::Tensor& seq_lens,
+    at::Tensor& out_indices,
+    const at::Tensor& out_offsets,
+    std::optional<at::Tensor> row_starts_opt) {
+  CHECK_INPUT(scores);
+  CHECK_DEVICE(seq_lens);
+  CHECK_DEVICE(out_indices);
+  CHECK_DEVICE(out_offsets);
+  if (row_starts_opt.has_value()) {
+    CHECK_DEVICE(row_starts_opt.value());
+  }
+
+  TORCH_CHECK(scores.dim() == 2, "scores must be 2D");
+  TORCH_CHECK(scores.stride(1) == 1, "scores must have unit last-dim stride");
+  TORCH_CHECK(scores.scalar_type() == at::kFloat, "scores must be float32");
+
+  const int64_t B = scores.size(0);
+
+  TORCH_CHECK(seq_lens.dim() == 1 && seq_lens.is_contiguous() && seq_lens.size(0) == B);
+  TORCH_CHECK(seq_lens.scalar_type() == at::kInt, "seq_lens must be int32");
+
+  TORCH_CHECK(out_offsets.dim() == 1 && out_offsets.is_contiguous() && out_offsets.size(0) == B);
+  TORCH_CHECK(out_offsets.scalar_type() == at::kInt, "out_offsets must be int32");
+
+  if (row_starts_opt.has_value()) {
+    const auto& row_starts = row_starts_opt.value();
+    TORCH_CHECK(row_starts.dim() == 1 && row_starts.is_contiguous() && row_starts.size(0) == B);
+    TORCH_CHECK(row_starts.scalar_type() == at::kInt, "row_starts must be int32");
+  }
+
+  TORCH_CHECK(out_indices.dim() == 2, "out_indices must be 2D");
+  TORCH_CHECK(out_indices.is_contiguous(), "out_indices must be contiguous");
+  TORCH_CHECK(out_indices.size(0) == B, "out_indices.size(0) must equal scores.size(0)");
+  TORCH_CHECK(out_indices.scalar_type() == at::kInt, "out_indices must be int32");
+  const int64_t topk = out_indices.size(1);
+  TORCH_CHECK(0 < topk && topk <= kMaxTopK, "topk (out_indices.size(1)) must be in (0, ", kMaxTopK, "]");
+
+  auto stream = at::xpu::getCurrentXPUStream();
+  auto& queue = stream.queue();
+
+  TopKTransformRaggedKernel kernel(
+      scores.data_ptr<float>(),
+      seq_lens.data_ptr<int32_t>(),
+      row_starts_opt.has_value() ? row_starts_opt->data_ptr<int32_t>() : nullptr,
+      out_offsets.data_ptr<int32_t>(),
+      out_indices.data_ptr<int32_t>(),
+      scores.stride(0),
+      static_cast<int>(topk));
+  sycl_kernel_submit(
+      sycl::range<1>(static_cast<size_t>(B) * kThreadsPerBlock), sycl::range<1>(kThreadsPerBlock), queue, kernel);
 }

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -82,28 +82,33 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   /*
    * Fast radix top-k (DeepSeek V3.2 indexer)
    */
-  m.def("fast_topk(Tensor score, Tensor! indices, Tensor lengths, Tensor? row_starts) -> ()");
-  m.impl("fast_topk", torch::kXPU, &fast_topk_interface);
+  m.def("fast_topk(Tensor score, Tensor lengths, int topk, Tensor? row_starts) -> Tensor");
+  m.impl("fast_topk", torch::kXPU, &fast_topk);
 
   m.def(
-      "fast_topk_transform_fused(Tensor score, Tensor lengths, Tensor! dst_page_table, Tensor src_page_table, "
-      "Tensor cu_seqlens_q, Tensor? row_starts) -> ()");
-  m.impl("fast_topk_transform_fused", torch::kXPU, &fast_topk_transform_interface);
+      "fast_topk_transform_fused(Tensor score, Tensor lengths, Tensor src_page_table, "
+      "Tensor cu_seqlens_q, int topk, Tensor? row_starts) -> Tensor");
+  m.impl("fast_topk_transform_fused", torch::kXPU, &fast_topk_transform_fused);
 
   m.def(
-      "fast_topk_transform_ragged_fused(Tensor score, Tensor lengths, Tensor! topk_indices_ragged, "
-      "Tensor topk_indices_offset, Tensor? row_starts) -> ()");
-  m.impl("fast_topk_transform_ragged_fused", torch::kXPU, &fast_topk_transform_ragged_interface);
+      "fast_topk_transform_ragged_fused(Tensor score, Tensor lengths, "
+      "Tensor topk_indices_offset, int topk, Tensor? row_starts) -> Tensor");
+  m.impl("fast_topk_transform_ragged_fused", torch::kXPU, &fast_topk_transform_ragged_fused);
 
   m.def(
-      "topk_transform_512(Tensor scores, Tensor seq_lens, Tensor page_tables, Tensor! out_page_indices, "
+      "topk_transform(Tensor scores, Tensor seq_lens, Tensor page_tables, Tensor! out_page_indices, "
       "int page_size, Tensor? out_raw_indices) -> ()");
-  m.impl("topk_transform_512", torch::kXPU, &topk_transform_512_interface);
+  m.impl("topk_transform", torch::kXPU, &topk_transform);
 
   m.def(
-      "topk_transform_512_v2(Tensor scores, Tensor seq_lens, Tensor page_tables, "
-      "Tensor! out_page_indices, int page_size, Tensor metadata, Tensor? out_raw_indices) -> ()");
-  m.impl("topk_transform_512_v2", torch::kXPU, &topk_transform_512_v2_interface);
+      "topk_transform_paged(Tensor scores, Tensor seq_lens, Tensor? page_tables, "
+      "Tensor! out_page_indices, int page_size, Tensor metadata) -> ()");
+  m.impl("topk_transform_paged", torch::kXPU, &topk_transform_paged);
+
+  m.def(
+      "topk_transform_ragged(Tensor scores, Tensor seq_lens, Tensor! out_indices, "
+      "Tensor out_offsets, Tensor? row_starts) -> ()");
+  m.impl("topk_transform_ragged", torch::kXPU, &topk_transform_ragged);
 
   m.def("swiglu_gpt_oss_sigmoid_alpha(Tensor x, float alpha, float limit) -> Tensor");
   m.impl("swiglu_gpt_oss_sigmoid_alpha", torch::kXPU, &swiglu_gpt_oss_sigmoid_alpha);

--- a/tests/test_topk_transform.py
+++ b/tests/test_topk_transform.py
@@ -8,8 +8,9 @@ from sgl_kernel import (
     fast_topk_transform_fused,
     fast_topk_transform_ragged_fused,
     fast_topk_v2,
-    topk_transform_512,
-    topk_transform_512_v2,
+    topk_transform,
+    topk_transform_paged,
+    topk_transform_ragged,
 )
 
 
@@ -302,10 +303,10 @@ def test_fast_topk_transform_ragged(
 _arange_cache: Dict[str, torch.Tensor] = {}
 
 
-def _topk_transform_512_vectorized(
+def _topk_transform_vectorized(
     scores: torch.Tensor,
     seq_lens: torch.Tensor,
-    page_tables: torch.Tensor,
+    page_tables: Optional[torch.Tensor],
     out_page_indices: torch.Tensor,
     page_size: int,
     out_raw_indices: Optional[torch.Tensor] = None,
@@ -375,6 +376,14 @@ def _topk_transform_512_vectorized(
     raw_indices = torch.where(needs_seq_mask, seq_indices_or_neg1, raw_indices)
     valid_topk = torch.where(needs_seq_mask, sequential_valid, valid_topk)
 
+    if page_tables is None:
+        raw_indices = raw_indices.clone()
+        raw_indices.masked_fill_(~valid_topk, -1)
+        out_page_indices.copy_(raw_indices)
+        if out_raw_indices is not None:
+            out_raw_indices.copy_(raw_indices)
+        return
+
     page_idx = raw_indices >> page_bits
     offset_in_page = raw_indices & page_mask
 
@@ -393,16 +402,16 @@ def _topk_transform_512_vectorized(
         out_raw_indices.copy_(raw_indices)
 
 
-def _ref_torch_topk_transform_512_impl(
+def _ref_torch_topk_transform_impl(
     scores: torch.Tensor,
     seq_lens: torch.Tensor,
-    page_tables: torch.Tensor,
+    page_tables: Optional[torch.Tensor],
     out_page_indices: torch.Tensor,
     page_size: int,
     out_raw_indices: Optional[torch.Tensor] = None,
 ) -> None:
     """Verbatim copy of sglang's vectorised PyTorch fallback."""
-    _topk_transform_512_vectorized(
+    _topk_transform_vectorized(
         scores,
         seq_lens,
         page_tables,
@@ -414,7 +423,7 @@ def _ref_torch_topk_transform_512_impl(
     )
 
 
-def _setup_topk_transform_512(
+def _setup_topk_transform(
     bs: int,
     seq_len: int,
     page_size: int,
@@ -439,10 +448,35 @@ def _setup_topk_transform_512(
     return score, lengths, page_table
 
 
-def _ref_topk_transform_512(
+def _setup_topk_transform_paged(
+    bs: int,
+    seq_len: int,
+    page_size: int,
+    length_override: Optional[int] = None,
+):
+    torch.manual_seed(42)
+    stream = torch.xpu.Stream()
+    torch.xpu.set_stream(stream)
+
+    score = torch.randn(bs, seq_len, dtype=torch.float32, device="xpu")
+
+    length_val = seq_len if length_override is None else length_override
+    lengths = torch.full((bs,), length_val, dtype=torch.int32, device="xpu")
+
+    num_pages = (seq_len + page_size - 1) // page_size
+    page_table = (
+        torch.arange(0, num_pages, dtype=torch.int32, device="xpu")
+        .unsqueeze(0)
+        .expand(bs, -1)
+        .contiguous()
+    )
+    return score, lengths, page_table
+
+
+def _ref_topk_transform(
     score: torch.Tensor,
     lengths: torch.Tensor,
-    page_table: torch.Tensor,
+    page_table: Optional[torch.Tensor],
     page_size: int,
     topk: int,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -453,14 +487,69 @@ def _ref_topk_transform_512(
     # The upstream ref reads ``seq_lens`` as an int32 tensor sized like the
     # batch; our callers already pass such a tensor for ``lengths`` so no
     # reshape/dtype coercion is needed.
-    _ref_torch_topk_transform_512_impl(
+    _ref_torch_topk_transform_impl(
         score, lengths, page_table, out_pi, page_size, out_ri
     )
     return out_pi, out_ri
 
 
-def _empty_v2_metadata(bs: int) -> torch.Tensor:
-    return torch.empty((bs + 1, 2), dtype=torch.int32, device="xpu")
+def _setup_topk_transform_ragged(
+    bs: int,
+    seq_len: int,
+    has_row_starts: bool,
+    length_override: Optional[int] = None,
+):
+    torch.manual_seed(42)
+    stream = torch.xpu.Stream()
+    torch.xpu.set_stream(stream)
+
+    score = torch.randn(
+        bs,
+        seq_len + (2048 if has_row_starts else 0),
+        dtype=torch.float32,
+        device="xpu",
+    )
+    if has_row_starts:
+        row_starts = torch.randint(0, 2048, (bs,), dtype=torch.int32, device="xpu")
+    else:
+        row_starts = None
+    length_val = seq_len if length_override is None else length_override
+    lengths = torch.full((bs,), length_val, dtype=torch.int32, device="xpu")
+    out_offsets = torch.randint(0, 1024, (bs,), dtype=torch.int32, device="xpu")
+
+    return score, lengths, row_starts, out_offsets
+
+
+def _ref_topk_transform_ragged(
+    score: torch.Tensor,
+    lengths: torch.Tensor,
+    out_offsets: torch.Tensor,
+    topk: int,
+    row_starts: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Per-row window top-k, ``-1`` padded, rebased by ``out_offsets``.
+
+    Row ``i`` selects (up to) ``topk`` indices from
+    ``score[i, start : start + lengths[i]]`` (``start = row_starts[i]``, 0 when
+    omitted). When ``lengths[i] <= topk`` every window position is selected
+    (order doesn't matter -- callers compare as sets).
+    """
+    bs = score.shape[0]
+    device = score.device
+    out = torch.full((bs, topk), -1, dtype=torch.int32, device=device)
+    lengths_cpu = lengths.cpu().tolist()
+    starts_cpu = row_starts.cpu().tolist() if row_starts is not None else [0] * bs
+    offsets_cpu = out_offsets.cpu().tolist()
+    for i in range(bs):
+        length = lengths_cpu[i]
+        start = starts_cpu[i]
+        offset = offsets_cpu[i]
+        k = min(topk, length)
+        if k > 0:
+            window = score[i, start : start + length]
+            idx = torch.topk(window, k, dim=-1, sorted=False).indices.to(torch.int32)
+            out[i, :k] = idx + offset
+    return out
 
 
 @pytest.mark.parametrize("bs", [1, 132, 256, 4096])
@@ -469,10 +558,10 @@ def _empty_v2_metadata(bs: int) -> torch.Tensor:
 @pytest.mark.parametrize("page_size", [1, 64, 256])
 @pytest.mark.parametrize("with_raw", [False, True])
 @torch.inference_mode()
-def test_topk_transform_512(
+def test_topk_transform(
     bs: int, topk: int, seq_len: int, page_size: int, with_raw: bool
 ) -> None:
-    score, lengths, page_table = _setup_topk_transform_512(bs, seq_len, page_size)
+    score, lengths, page_table = _setup_topk_transform(bs, seq_len, page_size)
 
     out_page = torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
     out_raw = (
@@ -480,11 +569,9 @@ def test_topk_transform_512(
         if with_raw
         else None
     )
-    topk_transform_512(score, lengths, page_table, out_page, page_size, out_raw)
+    topk_transform(score, lengths, page_table, out_page, page_size, out_raw)
 
-    ref_page, ref_raw = _ref_topk_transform_512(
-        score, lengths, page_table, page_size, topk
-    )
+    ref_page, ref_raw = _ref_topk_transform(score, lengths, page_table, page_size, topk)
 
     assert_equal(
         score,
@@ -541,12 +628,12 @@ def _ragged_lengths(bs: int, topk: int, max_len: int) -> torch.Tensor:
 @pytest.mark.parametrize("page_size", [1, 64, 256])
 @pytest.mark.parametrize("with_raw", [False, True])
 @torch.inference_mode()
-def test_topk_transform_512_trivial(
+def test_topk_transform_length_trivial(
     bs: int, length: int, topk: int, page_size: int, with_raw: bool
 ) -> None:
     """All rows have ``length <= topk`` -- exercises the naive page-map path."""
     seq_len = 4096
-    score, lengths, page_table = _setup_topk_transform_512(
+    score, lengths, page_table = _setup_topk_transform(
         bs, seq_len, page_size, length_override=length
     )
 
@@ -556,11 +643,9 @@ def test_topk_transform_512_trivial(
         if with_raw
         else None
     )
-    topk_transform_512(score, lengths, page_table, out_page, page_size, out_raw)
+    topk_transform(score, lengths, page_table, out_page, page_size, out_raw)
 
-    ref_page, ref_raw = _ref_topk_transform_512(
-        score, lengths, page_table, page_size, topk
-    )
+    ref_page, ref_raw = _ref_topk_transform(score, lengths, page_table, page_size, topk)
 
     assert_equal(
         score,
@@ -589,12 +674,12 @@ def test_topk_transform_512_trivial(
 @pytest.mark.parametrize("page_size", [1, 64, 256])
 @pytest.mark.parametrize("with_raw", [False, True])
 @torch.inference_mode()
-def test_topk_transform_512_ragged(
+def test_topk_transform_length_ragged(
     bs: int, topk: int, page_size: int, with_raw: bool
 ) -> None:
     """Ragged mix of ``length <= topk`` and ``length > topk`` rows in one launch."""
     seq_len = _RAGGED_ALLOC_SEQ_LEN
-    score, _, page_table = _setup_topk_transform_512(bs, seq_len, page_size)
+    score, _, page_table = _setup_topk_transform(bs, seq_len, page_size)
     lengths = _ragged_lengths(bs, topk, max_len=seq_len)
 
     out_page = torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
@@ -603,11 +688,9 @@ def test_topk_transform_512_ragged(
         if with_raw
         else None
     )
-    topk_transform_512(score, lengths, page_table, out_page, page_size, out_raw)
+    topk_transform(score, lengths, page_table, out_page, page_size, out_raw)
 
-    ref_page, ref_raw = _ref_topk_transform_512(
-        score, lengths, page_table, page_size, topk
-    )
+    ref_page, ref_raw = _ref_topk_transform(score, lengths, page_table, page_size, topk)
 
     assert_equal(
         score,
@@ -635,27 +718,15 @@ def test_topk_transform_512_ragged(
 @pytest.mark.parametrize("topk", [512, 1024, 2048])
 @pytest.mark.parametrize("seq_len", [4096, 16384, 65536])
 @pytest.mark.parametrize("page_size", [1, 64, 256])
-@pytest.mark.parametrize("with_raw", [False, True])
 @torch.inference_mode()
-def test_topk_transform_512_v2(
-    bs: int, topk: int, seq_len: int, page_size: int, with_raw: bool
-) -> None:
-    score, lengths, page_table = _setup_topk_transform_512(bs, seq_len, page_size)
-    metadata = _empty_v2_metadata(bs)
+def test_topk_transform_paged(bs: int, topk: int, seq_len: int, page_size: int) -> None:
+    score, lengths, page_table = _setup_topk_transform_paged(bs, seq_len, page_size)
 
     out_page = torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
-    out_raw = (
-        torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
-        if with_raw
-        else None
-    )
-    topk_transform_512_v2(
-        score, lengths, page_table, out_page, page_size, metadata, out_raw
-    )
+    metadata = torch.empty((0,), dtype=torch.int32, device="cpu")
+    topk_transform_paged(score, lengths, page_table, out_page, page_size, metadata)
 
-    ref_page, ref_raw = _ref_topk_transform_512(
-        score, lengths, page_table, page_size, topk
-    )
+    ref_page, ref_raw = _ref_topk_transform(score, lengths, page_table, page_size, topk)
 
     assert_equal(
         score,
@@ -666,47 +737,26 @@ def test_topk_transform_512_v2(
         seq_len,
         max_permit_error=5,
     )
-
-    if with_raw:
-        assert_equal(
-            score,
-            torch.sort(ref_raw, dim=-1).values,
-            torch.sort(out_raw, dim=-1).values,
-            bs,
-            topk,
-            seq_len,
-            max_permit_error=5,
-        )
 
 
 @pytest.mark.parametrize("bs,length", _TRIVIAL_CONFIGS)
 @pytest.mark.parametrize("topk", [512, 1024, 2048])
 @pytest.mark.parametrize("page_size", [1, 64, 256])
-@pytest.mark.parametrize("with_raw", [False, True])
 @torch.inference_mode()
-def test_topk_transform_512_v2_trivial(
-    bs: int, length: int, topk: int, page_size: int, with_raw: bool
+def test_topk_transform_paged_length_trivial(
+    bs: int, length: int, topk: int, page_size: int
 ) -> None:
     """All rows have ``length <= topk`` -- exercises the naive page-map path."""
     seq_len = 4096
-    score, lengths, page_table = _setup_topk_transform_512(
+    score, lengths, page_table = _setup_topk_transform_paged(
         bs, seq_len, page_size, length_override=length
     )
-    metadata = _empty_v2_metadata(bs)
 
     out_page = torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
-    out_raw = (
-        torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
-        if with_raw
-        else None
-    )
-    topk_transform_512_v2(
-        score, lengths, page_table, out_page, page_size, metadata, out_raw
-    )
+    metadata = torch.empty((0,), dtype=torch.int32, device="cpu")
+    topk_transform_paged(score, lengths, page_table, out_page, page_size, metadata)
 
-    ref_page, ref_raw = _ref_topk_transform_512(
-        score, lengths, page_table, page_size, topk
-    )
+    ref_page, ref_raw = _ref_topk_transform(score, lengths, page_table, page_size, topk)
 
     assert_equal(
         score,
@@ -717,46 +767,23 @@ def test_topk_transform_512_v2_trivial(
         seq_len,
         max_permit_error=5,
     )
-
-    if with_raw:
-        assert_equal(
-            score,
-            torch.sort(ref_raw, dim=-1).values,
-            torch.sort(out_raw, dim=-1).values,
-            bs,
-            topk,
-            seq_len,
-            max_permit_error=5,
-        )
 
 
 @pytest.mark.parametrize("bs", [8, 132])
 @pytest.mark.parametrize("topk", [512, 1024, 2048])
 @pytest.mark.parametrize("page_size", [1, 64, 256])
-@pytest.mark.parametrize("with_raw", [False, True])
 @torch.inference_mode()
-def test_topk_transform_512_v2_ragged(
-    bs: int, topk: int, page_size: int, with_raw: bool
-) -> None:
+def test_topk_transform_paged_length_ragged(bs: int, topk: int, page_size: int) -> None:
     """Ragged mix of ``length <= topk`` and ``length > topk`` rows in one launch."""
     seq_len = _RAGGED_ALLOC_SEQ_LEN
-    score, _, page_table = _setup_topk_transform_512(bs, seq_len, page_size)
+    score, _, page_table = _setup_topk_transform_paged(bs, seq_len, page_size)
     lengths = _ragged_lengths(bs, topk, max_len=seq_len)
-    metadata = _empty_v2_metadata(bs)
 
     out_page = torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
-    out_raw = (
-        torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
-        if with_raw
-        else None
-    )
-    topk_transform_512_v2(
-        score, lengths, page_table, out_page, page_size, metadata, out_raw
-    )
+    metadata = torch.empty((0,), dtype=torch.int32, device="cpu")
+    topk_transform_paged(score, lengths, page_table, out_page, page_size, metadata)
 
-    ref_page, ref_raw = _ref_topk_transform_512(
-        score, lengths, page_table, page_size, topk
-    )
+    ref_page, ref_raw = _ref_topk_transform(score, lengths, page_table, page_size, topk)
 
     assert_equal(
         score,
@@ -768,16 +795,132 @@ def test_topk_transform_512_v2_ragged(
         max_permit_error=5,
     )
 
-    if with_raw:
-        assert_equal(
-            score,
-            torch.sort(ref_raw, dim=-1).values,
-            torch.sort(out_raw, dim=-1).values,
-            bs,
-            topk,
-            seq_len,
-            max_permit_error=5,
-        )
+
+@pytest.mark.parametrize("bs", [1, 132, 256, 4096])
+@pytest.mark.parametrize("topk", [512, 1024, 2048])
+@pytest.mark.parametrize("seq_len", [4096, 16384, 65536])
+@pytest.mark.parametrize("page_size", [1, 64, 256])
+@torch.inference_mode()
+def test_topk_transform_paged_page_table_none(
+    bs: int, topk: int, seq_len: int, page_size: int
+) -> None:
+    """page_tables=None -- out_page_indices should hold raw indices directly."""
+    score, lengths, _ = _setup_topk_transform_paged(bs, seq_len, page_size)
+
+    out_page = torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
+    metadata = torch.empty((0,), dtype=torch.int32, device="cpu")
+    topk_transform_paged(score, lengths, None, out_page, page_size, metadata)
+
+    ref_page, ref_raw = _ref_topk_transform(score, lengths, None, page_size, topk)
+
+    assert_equal(
+        score,
+        torch.sort(ref_page, dim=-1).values,
+        torch.sort(out_page, dim=-1).values,
+        bs,
+        topk,
+        seq_len,
+        max_permit_error=5,
+    )
+
+
+@pytest.mark.parametrize("bs", [1, 132, 256, 4096])
+@pytest.mark.parametrize("topk", [512, 1024, 2048])
+@pytest.mark.parametrize("seq_len", [2048, 4096, 16384, 65536])
+@pytest.mark.parametrize("has_row_starts", [True, False])
+@torch.inference_mode()
+def test_topk_transform_ragged(
+    bs: int, topk: int, seq_len: int, has_row_starts: bool
+) -> None:
+    score, lengths, row_starts, out_offsets = _setup_topk_transform_ragged(
+        bs, seq_len, has_row_starts
+    )
+
+    out_indices = torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
+    topk_transform_ragged(score, lengths, out_indices, out_offsets, row_starts)
+
+    ref_indices = _ref_topk_transform_ragged(
+        score, lengths, out_offsets, topk, row_starts=row_starts
+    )
+
+    assert_equal(
+        score,
+        torch.sort(ref_indices, dim=-1).values,
+        torch.sort(out_indices, dim=-1).values,
+        bs,
+        topk,
+        seq_len,
+        out_offsets,
+        row_starts=row_starts,
+        max_permit_error=5,
+    )
+
+
+@pytest.mark.parametrize("bs,length", _TRIVIAL_CONFIGS)
+@pytest.mark.parametrize("topk", [512, 1024, 2048])
+@pytest.mark.parametrize("has_row_starts", [True, False])
+@torch.inference_mode()
+def test_topk_transform_ragged_length_trivial(
+    bs: int, length: int, topk: int, has_row_starts: bool
+) -> None:
+    """All rows have ``length <= topk`` -- exercises the naive path."""
+    seq_len = 4096
+    score, lengths, row_starts, out_offsets = _setup_topk_transform_ragged(
+        bs, seq_len, has_row_starts, length_override=length
+    )
+
+    out_indices = torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
+    topk_transform_ragged(score, lengths, out_indices, out_offsets, row_starts)
+
+    ref_indices = _ref_topk_transform_ragged(
+        score, lengths, out_offsets, topk, row_starts=row_starts
+    )
+
+    assert_equal(
+        score,
+        torch.sort(ref_indices, dim=-1).values,
+        torch.sort(out_indices, dim=-1).values,
+        bs,
+        topk,
+        seq_len,
+        out_offsets,
+        row_starts=row_starts,
+        max_permit_error=5,
+    )
+
+
+@pytest.mark.parametrize("bs", [8, 132])
+@pytest.mark.parametrize("topk", [512, 1024, 2048])
+@pytest.mark.parametrize("has_row_starts", [True, False])
+@torch.inference_mode()
+def test_topk_transform_ragged_length_ragged(
+    bs: int, topk: int, has_row_starts: bool
+) -> None:
+    """Ragged mix of ``length <= topk`` and ``length > topk`` rows in one launch."""
+    seq_len = _RAGGED_ALLOC_SEQ_LEN
+    score, _, row_starts, out_offsets = _setup_topk_transform_ragged(
+        bs, seq_len, has_row_starts
+    )
+    lengths = _ragged_lengths(bs, topk, max_len=seq_len)
+
+    out_indices = torch.full((bs, topk), -1, dtype=torch.int32, device="xpu")
+    topk_transform_ragged(score, lengths, out_indices, out_offsets, row_starts)
+
+    ref_indices = _ref_topk_transform_ragged(
+        score, lengths, out_offsets, topk, row_starts=row_starts
+    )
+
+    assert_equal(
+        score,
+        torch.sort(ref_indices, dim=-1).values,
+        torch.sort(out_indices, dim=-1).values,
+        bs,
+        topk,
+        seq_len,
+        out_offsets,
+        row_starts=row_starts,
+        max_permit_error=5,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Add SYCL implementations of `topk_transform_ragged` on XPU.
This op is required by
`sglang.kernels.ops.attention.dsv4.topk.topk_transform_ragged_v2`(https://github.com/sgl-project/sglang/blob/main/python/sglang/kernels/ops/attention/dsv4/topk.py#L90), which is the
prefill-path entry point used by the DSA top-k backend.
Based on the CUDA implementation: https://github.com/sgl-project/sglang/blob/main/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh

## Modifications

- **New op: `topk_transform_ragged`**
  - Added `TopKTransformRaggedKernel` (SYCL) and its host launcher in
    `src/sycl/TopKTransform.cpp`, reusing the existing `radix_topk` /
    `trivial_topk_transform_ragged` helpers with a *runtime* `topk` (inferred
    from `out_indices.size(1)`), unlike the topk=2048-fixed
    `fast_topk_transform_ragged_fused`.
  - Selects the top-k within each row's `[row_start, row_start + seq_len)`
    window and rebases the selected positions onto the flattened KV via
    `out_offsets`, `-1`-padding the rest — matching the semantics of the CUDA
    `TopKKernel::transform_ragged` reference.
  - Declared in `include/sgl_kernel_ops.h` and registered as
    `topk_transform_ragged(Tensor scores, Tensor seq_lens, Tensor! out_indices,
    Tensor out_offsets, Tensor? row_starts) -> ()` in
    `src/torch_extension_sycl.cc`.
  - Added the Python wrapper in `python/sgl_kernel/top_k.py` and exported it
    from `python/sgl_kernel/__init__.py`.

- **Tests** (`tests/test_topk_transform.py`)
  - Added `test_topk_transform_ragged`, `test_topk_transform_ragged_length_trivial`,
    and `test_topk_transform_ragged_length_ragged`, covering fixed-length,
    trivial (`length <= topk`), and mixed trivial/radix-path rows, with and
    without `row_starts`.
  - Added `test_topk_transform_paged_page_table_none` to cover the
    `page_tables=None` (raw-index output) mode of `topk_transform_paged`,
    which previously had no test coverage.

- **Benchmark** (`benchmark/bench_topk_transform.py`)
  - Added `benchmark_topk_transform_ragged` and its config sweep, wired into
    the script's `__main__` run/report block.

- **Naming cleanup**
  - Renamed `topk_transform_512` → `topk_transform` and `topk_transform_512_v2` →
    `topk_transform_paged` to align with the CUDA op names.

## Accuracy Tests

Tested topk_transform_ragged (SYCL) vs PyTorch reference on Intel XPU.
All unit tests passed.

Command: pytest tests/test_topk_transform.py -k topk_transform_ragged
Results: 
========================================================================== test session starts ==========================================================================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/lily/PR/topk_transform_ragged/sgl-kernel-xpu
configfile: pyproject.toml
plugins: anyio-4.14.2
collected 766 items / 602 deselected / 164 selected

tests/test_topk_transform.py .................................................................................................................................... [ 80%]
................................                                                                                                                                  [100%]

============================================================ 164 passed, 602 deselected in 66.36s (0:01:06) =============================================================

## Performance

Hardware: Intel BMG. Median of 20 iterations, 5 warmup, torch.xpu.Event
timing.
SYCL is faster than the Torch reference across all reported configurations.

topk_transform_ragged: sycl vs torch
|   bs |   topk |   seq_len | row_starts |   sycl_ms |   torch_ms |   speedup |
|-----:|-------:|----------:|-----------:|----------:|-----------:|----------:|
|  132 |    512 |      4096 |      False |  0.155469 |   0.454115 |     2.921 |
|  132 |   1024 |      4096 |      False |  0.152187 |   0.450000 |     2.957 |
|  132 |   2048 |      4096 |      False |  0.111667 |   0.448385 |     4.015 |
|  132 |    512 |     16384 |       True |  0.384323 |   2.169218 |     5.644 |
|  132 |   1024 |     16384 |       True |  0.391875 |   2.197500 |     5.608 |
|  132 |   2048 |     16384 |       True |  0.407292 |   2.197708 |     5.396 |
|  132 |    512 |     65536 |      False |  1.360416 |   7.459115 |     5.483 |
|  132 |   1024 |     65536 |      False |  1.364323 |   7.489948 |     5.490 |
|  132 |   2048 |     65536 |      False |  1.364687 |   7.514740 |     5.507 |
|  256 |    512 |     16384 |      False |  0.664792 |   3.768073 |     5.668 |
|  256 |   1024 |     16384 |      False |  0.673281 |   3.803750 |     5.650 |
|  256 |   2048 |     16384 |      False |  0.704531 |   3.880000 |     5.507 |
| 4096 |    512 |      4096 |      False |  3.703594 |   7.167604 |     1.935 |
| 4096 |   1024 |      4096 |      False |  3.627291 |   8.113802 |     2.237 |
| 4096 |   2048 |      4096 |      False |  2.575313 |   9.850260 |     3.825 |
| 4096 |    512 |     16384 |       True |  9.760521 |  64.557708 |     6.614 |
| 4096 |   1024 |     16384 |       True |  9.888177 |  65.601979 |     6.634 |
| 4096 |   2048 |     16384 |       True | 10.285886 |  67.226042 |     6.536 |