### PR TITLE
[Attn] Workaround for page size 1

### DIFF
--- a/benchmark/bench_flash_attn.py
+++ b/benchmark/bench_flash_attn.py
@@ -151,6 +151,7 @@ configs = list(
             and (
                 cfg[10] == "bf16"
                 or (cfg[9] not in (0, 1) and not cfg[2] and not cfg[1])
+            )
             and (
                 cfg[11] == "standard"
                 or (

--- a/benchmark/bench_flash_attn.py
+++ b/benchmark/bench_flash_attn.py
@@ -117,7 +117,10 @@ head_dim_paged = [64, 128, 256, 512]
 num_heads_q = [16]
 num_heads_kv = [4, 8]
 kv_seq_length_range = [4096]
-page_size_range = [0, 128]
+# page_size=0 -> non-paged varlen path; page_size=1 -> paged kernel has no
+# page_size==1 variant, so this exercises the gather-and-varlen workaround;
+# page_size=128 -> native paged kernel path.
+page_size_range = [0, 1, 128]
 # KV cache element type: "bf16" (default) or fp8. FP8 has two formats,
 # e5m2 and e4m3; both are exercised ("fp8_e4m3" / "fp8_e5m2"), dequantized
 # in-kernel via per-tensor k_descale / v_descale. fp8 only runs on the paged
@@ -135,14 +138,19 @@ configs = list(
             and (cfg[6] % cfg[7] == 0)
             # Condition 4: kv_seq_length >= page_size
             and (cfg[8] >= cfg[9])
-            # Condition 5: no_page mode (page_size=0) does not support sink logits
-            and (cfg[9] != 0 or not cfg[2])
+            # Condition 5: no_page mode (page_size=0) and the page_size=1
+            # workaround both dispatch to the non-paged kernel, which does
+            # not support sink logits
+            and (cfg[9] not in (0, 1) or not cfg[2])
             # Condition 6: sink is only supported for head_size == 64
             and (not cfg[2] or cfg[5] == 64)
-            # Condition 7: fp8 KV cache requires the paged path and is exercised
-            # without sinks / local masking (matches the supported fp8 path)
-            and (cfg[10] == "bf16" or (cfg[9] != 0 and not cfg[2] and not cfg[1]))
-            # Condition 8: relative attention is paged BF16 prefill at head_dim 128.
+            # Condition 7: fp8 KV cache requires the native paged kernel and is
+            # exercised without sinks / local masking (matches the supported
+            # fp8 path); page_size=1 falls back to the non-paged kernel so it
+            # is excluded like page_size=0
+            and (
+                cfg[10] == "bf16"
+                or (cfg[9] not in (0, 1) and not cfg[2] and not cfg[1])
             and (
                 cfg[11] == "standard"
                 or (

--- a/python/sgl_kernel/flash_attn.py
+++ b/python/sgl_kernel/flash_attn.py
@@ -419,8 +419,8 @@ def _flash_attn_with_kvcache_page_size_1(
 
     num_blocks, _, nheads_k, head_dim = k_cache.shape
     head_dim_v = v_cache.shape[-1]
-    k_flat = k_cache.view(num_blocks, nheads_k, head_dim)
-    v_flat = v_cache.view(num_blocks, nheads_k, head_dim_v)
+    k_flat = k_cache.reshape(num_blocks, nheads_k, head_dim)
+    v_flat = v_cache.reshape(num_blocks, nheads_k, head_dim_v)
 
     if cu_seqlens_q is None:  # !is_varlen_q
         cu_seqlens_q = torch.arange(

--- a/python/sgl_kernel/flash_attn.py
+++ b/python/sgl_kernel/flash_attn.py
@@ -252,6 +252,41 @@ def flash_attn_with_kvcache(
         )
         cache_seqlens = maybe_contiguous(cache_seqlens)
 
+    # The paged decode kernel has no page_size == 1 variant (only 64/128), so
+    # gather the scattered per-token cache slots into a dense ragged buffer and
+    # dispatch to the non-paged varlen kernel instead.
+    if page_table is not None and k_cache.shape[1] == 1:
+        return _flash_attn_with_kvcache_page_size_1(
+            q=q,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            k=k,
+            v=v,
+            qv=qv,
+            rotary_cos=rotary_cos,
+            rotary_sin=rotary_sin,
+            cache_seqlens=cache_seqlens,
+            cache_batch_idx=cache_batch_idx,
+            cache_leftpad=cache_leftpad,
+            page_table=page_table,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k_new=cu_seqlens_k_new,
+            max_seqlen_q=max_seqlen_q,
+            q_descale=q_descale,
+            k_descale=k_descale,
+            v_descale=v_descale,
+            softmax_scale=softmax_scale,
+            sinks=sinks,
+            causal=causal,
+            window_size=window_size,
+            softcap=softcap,
+            num_splits=num_splits,
+            pack_gqa=pack_gqa,
+            sm_margin=sm_margin,
+            return_softmax_lse=return_softmax_lse,
+            out=out,
+        )
+
     q, k_cache, k, v = [maybe_contiguous(x) for x in (q, k_cache, k, v)]
     v_cache = (
         v_cache.contiguous()
@@ -326,6 +361,117 @@ def flash_attn_with_kvcache(
         rel_bias_is_sheared,
     )
     return (out, softmax_lse) if return_softmax_lse else out
+
+
+def _flash_attn_with_kvcache_page_size_1(
+    q,
+    k_cache,
+    v_cache,
+    k,
+    v,
+    qv,
+    rotary_cos,
+    rotary_sin,
+    cache_seqlens,
+    cache_batch_idx,
+    cache_leftpad,
+    page_table,
+    cu_seqlens_q,
+    cu_seqlens_k_new,
+    max_seqlen_q,
+    q_descale,
+    k_descale,
+    v_descale,
+    softmax_scale,
+    sinks,
+    causal,
+    window_size,
+    softcap,
+    num_splits,
+    pack_gqa,
+    sm_margin,
+    return_softmax_lse,
+    out,
+):
+    """page_size == 1 workaround: gather per-token cache slots into a dense
+    ragged buffer (in ``cu_seqlens_k`` order) and run the non-paged varlen
+    kernel, since the paged kernel only supports page_size in {64, 128}.
+    """
+    assert k is None and v is None, (
+        "flash_attn_with_kvcache page_size=1 workaround does not support "
+        "appending new k/v to the cache"
+    )
+    assert (
+        rotary_cos is None and rotary_sin is None
+    ), "flash_attn_with_kvcache page_size=1 workaround does not support rotary embedding"
+    assert (
+        cache_leftpad is None
+    ), "flash_attn_with_kvcache page_size=1 workaround does not support cache_leftpad"
+    assert (
+        cu_seqlens_k_new is None
+    ), "flash_attn_with_kvcache page_size=1 workaround does not support cu_seqlens_k_new"
+    assert (
+        cache_seqlens is not None
+    ), "cache_seqlens is required for page_size=1 workaround"
+
+    if cache_batch_idx is not None:
+        page_table = page_table.index_select(0, cache_batch_idx.long())
+
+    num_blocks, _, nheads_k, head_dim = k_cache.shape
+    head_dim_v = v_cache.shape[-1]
+    k_flat = k_cache.view(num_blocks, nheads_k, head_dim)
+    v_flat = v_cache.view(num_blocks, nheads_k, head_dim_v)
+
+    if cu_seqlens_q is None:  # !is_varlen_q
+        cu_seqlens_q = torch.arange(
+            0, q.size(0) + 1, dtype=torch.int32, device=q.device
+        ) * q.size(1)
+        max_seqlen_q = q.size(1)
+        q = q.reshape(-1, q.size(-2), q.size(-1)).contiguous()
+
+    seqlens = cache_seqlens.long()
+    num_slots = page_table.shape[1]
+    # page_table packs the valid (occupied) slots first per row, so masking
+    # by cache_seqlens and flattening yields slots in cu_seqlens_k order.
+    valid = torch.arange(num_slots, device=page_table.device).unsqueeze(
+        0
+    ) < seqlens.unsqueeze(1)
+    flat_slots = page_table.long()[valid]
+    k_ragged = k_flat.index_select(0, flat_slots).contiguous()
+    v_ragged = v_flat.index_select(0, flat_slots).contiguous()
+
+    cu_seqlens_k = torch.nn.functional.pad(
+        torch.cumsum(cache_seqlens, dim=0, dtype=torch.int32), (1, 0)
+    )
+    max_seqlen_k = int(seqlens.max().item()) if seqlens.numel() > 0 else 0
+
+    result = flash_attn_varlen_func(
+        q,
+        k_ragged,
+        v_ragged,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        softmax_scale=softmax_scale,
+        sinks=sinks,
+        causal=causal,
+        qv=qv,
+        q_descale=q_descale,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        window_size=window_size,
+        softcap=softcap,
+        num_splits=num_splits,
+        pack_gqa=pack_gqa,
+        sm_margin=sm_margin,
+        return_softmax_lse=return_softmax_lse,
+    )
+    result_out, softmax_lse = result if return_softmax_lse else (result, None)
+    if out is not None:
+        out.copy_(result_out)
+        result_out = out
+    return (result_out, softmax_lse) if return_softmax_lse else result_out
 
 
 def flash_attn_varlen_func(

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -2,6 +2,7 @@
 import itertools
 import math
 import os
+import re
 import sys
 
 import pytest
@@ -2333,6 +2334,228 @@ if EXTENDED_KVCACHE_TESTS:
             nheads_kv=nheads_kv,
             dtype=dtype,
         )
+
+    @pytest.mark.skipif(
+        device.type != "xpu" or not is_fa3_supported(),
+        reason="large ScoreBlock2D workspace coverage is only supported on BMG XPU",
+    )
+    @pytest.mark.parametrize(
+        "batch_size,nheads_q,nheads_kv,seqlen_q,seqlen_k",
+        [
+            (1, 16, 2, 32768, 32768),
+            # These all require the 1 GiB score workspace cap to slice a
+            # 32K x 32K HD512 problem.
+            (4, 16, 2, 32768, 32768),
+            (1, 32, 4, 32768, 32768),
+            (8, 8, 1, 32768, 32768),
+            (32, 4, 1, 32768, 32768),
+            (4, 8, 2, 32768, 32768),
+            # Non-paged HD512 uses 32 Q tiles per head. Q-tile chunking keeps
+            # one query head sufficient to cover BMG (20 Xe-cores) without a
+            # 4 GiB score buffer.
+            (1, 16, 2, 4096, 32768),
+            # A low-head, high-batch case must accumulate Q tiles across batch
+            # slices instead of allocating all eight score matrices at once.
+            (8, 1, 1, 4096, 32768),
+            # Exercises nested batch and GQA-head slicing: one unsliced batch
+            # needs 2 GiB and the complete problem needs 8 GiB.
+            (4, 8, 1, 4096, 32768),
+        ],
+    )
+    def test_flash_attn_varlen_hd512_large_score_workspace(
+        batch_size, nheads_q, nheads_kv, seqlen_q, seqlen_k, monkeypatch, capfd
+    ):
+        """Large ScoreBlock2D cases that require batch, GQA-head, and Q-tile slicing."""
+        from sgl_kernel.flash_attn import flash_attn_varlen_func
+
+        head_dim = 512
+        torch.manual_seed(0)
+        monkeypatch.setenv("FMHA_SCORE_WS_VERBOSE", "1")
+
+        total_q = batch_size * seqlen_q
+        total_k = batch_size * seqlen_k
+        q = torch.randn(
+            total_q, nheads_q, head_dim, device=device, dtype=torch.bfloat16
+        )
+        k = torch.randn(
+            total_k, nheads_kv, head_dim, device=device, dtype=torch.bfloat16
+        )
+        v = torch.randn(
+            total_k, nheads_kv, head_dim, device=device, dtype=torch.bfloat16
+        )
+        cu_seqlens_q = torch.arange(
+            0, total_q + 1, seqlen_q, device=device, dtype=torch.int32
+        )
+        cu_seqlens_k = torch.arange(
+            0, total_k + 1, seqlen_k, device=device, dtype=torch.int32
+        )
+
+        out = flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            seqlen_q,
+            seqlen_k,
+            causal=True,
+        )
+        torch.xpu.synchronize()
+        assert out.shape == (total_q, nheads_q, head_dim)
+        assert out.dtype == torch.bfloat16
+        assert torch.isfinite(out).all()
+        _, stderr = capfd.readouterr()
+        match = re.search(
+            r"query_tile_slice=(\d+) q_tile_rows=(\d+) bytes=(\d+)", stderr
+        )
+        assert match, f"missing ScoreBlock2D workspace report: {stderr}"
+        q_tile_slice, q_tile_rows, workspace_bytes = map(int, match.groups())
+        total_q_tiles = math.ceil(seqlen_q / q_tile_rows)
+        assert 1 <= q_tile_slice <= total_q_tiles
+        assert workspace_bytes <= 1024 * 1024 * 1024
+
+    @pytest.mark.skipif(
+        device.type != "xpu" or not is_fa3_supported(),
+        reason="ScoreBlock2D LSE coverage is only supported on BMG XPU",
+    )
+    def test_flash_attn_varlen_hd512_score_workspace_lse_head_slicing(
+        monkeypatch, capfd
+    ):
+        """LSE rows remain globally indexed when ScoreBlock2D slices Q heads."""
+        from sgl_kernel.flash_attn import flash_attn_varlen_func
+
+        batch_size = 1
+        nheads_q = 4
+        nheads_kv = 1
+        seqlen_q = 256
+        seqlen_k = 4096
+        head_dim = 512
+        torch.manual_seed(0)
+        # A Q tile stores 128 * 4096 fp16 scores (1 MiB) per Q head. The
+        # 2 MiB cap forces the four Q heads to launch as two head slices.
+        monkeypatch.setenv("FMHA_SCORE_WS_CAP_MB", "2")
+        monkeypatch.setenv("FMHA_SCORE_WS_VERBOSE", "1")
+
+        q = torch.randn(
+            batch_size * seqlen_q,
+            nheads_q,
+            head_dim,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        k = torch.randn(
+            batch_size * seqlen_k,
+            nheads_kv,
+            head_dim,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        v = torch.randn(
+            batch_size * seqlen_k,
+            nheads_kv,
+            head_dim,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        cu_seqlens_q = torch.tensor([0, seqlen_q], device=device, dtype=torch.int32)
+        cu_seqlens_k = torch.tensor([0, seqlen_k], device=device, dtype=torch.int32)
+
+        out, lse = flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            seqlen_q,
+            seqlen_k,
+            return_softmax_lse=True,
+        )
+        torch.xpu.synchronize()
+
+        _, _, lse_ref = attention_ref(
+            q.unsqueeze(0),
+            k.unsqueeze(0),
+            v.unsqueeze(0),
+            softmax_scale=head_dim**-0.5,
+            return_lse=True,
+        )
+        _check_softmax_lse(
+            lse,
+            nheads_q,
+            batch_size * seqlen_q,
+            lse_ref.squeeze(0),
+        )
+        assert out.shape == (batch_size * seqlen_q, nheads_q, head_dim)
+        _, stderr = capfd.readouterr()
+        match = re.search(r"query_head_slice=(\d+)", stderr)
+        assert match, f"missing ScoreBlock2D workspace report: {stderr}"
+        assert int(match.group(1)) < nheads_q
+
+    @pytest.mark.parametrize(
+        "batch_size,nheads_q,nheads_kv",
+        [
+            (1, 16, 2),
+            (8, 1, 1),
+        ],
+    )
+    def test_flash_attn_paged_hd512_large_score_workspace(
+        batch_size, nheads_q, nheads_kv
+    ):
+        """Paged ScoreBlock2D cases that previously required a 4 GiB workspace."""
+        from sgl_kernel.flash_attn import flash_attn_with_kvcache
+
+        seqlen_q = 4096
+        seqlen_k = 32768
+        page_size = 128
+        head_dim = 512
+        pages_per_seq = seqlen_k // page_size
+        num_pages = batch_size * pages_per_seq
+        torch.manual_seed(0)
+
+        q = torch.randn(
+            batch_size * seqlen_q,
+            nheads_q,
+            head_dim,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        k_cache = torch.randn(
+            num_pages,
+            page_size,
+            nheads_kv,
+            head_dim,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        v_cache = torch.randn_like(k_cache)
+        page_table = torch.arange(num_pages, device=device, dtype=torch.int32).reshape(
+            batch_size, pages_per_seq
+        )
+        cache_seqlens = torch.full(
+            (batch_size,), seqlen_k, device=device, dtype=torch.int32
+        )
+        cu_seqlens_q = torch.arange(
+            0,
+            batch_size * seqlen_q + 1,
+            seqlen_q,
+            device=device,
+            dtype=torch.int32,
+        )
+
+        out = flash_attn_with_kvcache(
+            q,
+            k_cache,
+            v_cache,
+            cache_seqlens=cache_seqlens,
+            page_table=page_table,
+            cu_seqlens_q=cu_seqlens_q,
+            max_seqlen_q=seqlen_q,
+            causal=True,
+        )
+        torch.xpu.synchronize()
+        assert out.shape == (batch_size * seqlen_q, nheads_q, head_dim)
+        assert out.dtype == torch.bfloat16
+        assert torch.isfinite(out).all()
 
 
 @pytest.mark.skipif(device.type != "xpu", reason="XPU not available")

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -2,7 +2,6 @@
 import itertools
 import math
 import os
-import re
 import sys
 
 import pytest
@@ -2335,228 +2334,6 @@ if EXTENDED_KVCACHE_TESTS:
             dtype=dtype,
         )
 
-    @pytest.mark.skipif(
-        device.type != "xpu" or not is_fa3_supported(),
-        reason="large ScoreBlock2D workspace coverage is only supported on BMG XPU",
-    )
-    @pytest.mark.parametrize(
-        "batch_size,nheads_q,nheads_kv,seqlen_q,seqlen_k",
-        [
-            (1, 16, 2, 32768, 32768),
-            # These all require the 1 GiB score workspace cap to slice a
-            # 32K x 32K HD512 problem.
-            (4, 16, 2, 32768, 32768),
-            (1, 32, 4, 32768, 32768),
-            (8, 8, 1, 32768, 32768),
-            (32, 4, 1, 32768, 32768),
-            (4, 8, 2, 32768, 32768),
-            # Non-paged HD512 uses 32 Q tiles per head. Q-tile chunking keeps
-            # one query head sufficient to cover BMG (20 Xe-cores) without a
-            # 4 GiB score buffer.
-            (1, 16, 2, 4096, 32768),
-            # A low-head, high-batch case must accumulate Q tiles across batch
-            # slices instead of allocating all eight score matrices at once.
-            (8, 1, 1, 4096, 32768),
-            # Exercises nested batch and GQA-head slicing: one unsliced batch
-            # needs 2 GiB and the complete problem needs 8 GiB.
-            (4, 8, 1, 4096, 32768),
-        ],
-    )
-    def test_flash_attn_varlen_hd512_large_score_workspace(
-        batch_size, nheads_q, nheads_kv, seqlen_q, seqlen_k, monkeypatch, capfd
-    ):
-        """Large ScoreBlock2D cases that require batch, GQA-head, and Q-tile slicing."""
-        from sgl_kernel.flash_attn import flash_attn_varlen_func
-
-        head_dim = 512
-        torch.manual_seed(0)
-        monkeypatch.setenv("FMHA_SCORE_WS_VERBOSE", "1")
-
-        total_q = batch_size * seqlen_q
-        total_k = batch_size * seqlen_k
-        q = torch.randn(
-            total_q, nheads_q, head_dim, device=device, dtype=torch.bfloat16
-        )
-        k = torch.randn(
-            total_k, nheads_kv, head_dim, device=device, dtype=torch.bfloat16
-        )
-        v = torch.randn(
-            total_k, nheads_kv, head_dim, device=device, dtype=torch.bfloat16
-        )
-        cu_seqlens_q = torch.arange(
-            0, total_q + 1, seqlen_q, device=device, dtype=torch.int32
-        )
-        cu_seqlens_k = torch.arange(
-            0, total_k + 1, seqlen_k, device=device, dtype=torch.int32
-        )
-
-        out = flash_attn_varlen_func(
-            q,
-            k,
-            v,
-            cu_seqlens_q,
-            cu_seqlens_k,
-            seqlen_q,
-            seqlen_k,
-            causal=True,
-        )
-        torch.xpu.synchronize()
-        assert out.shape == (total_q, nheads_q, head_dim)
-        assert out.dtype == torch.bfloat16
-        assert torch.isfinite(out).all()
-        _, stderr = capfd.readouterr()
-        match = re.search(
-            r"query_tile_slice=(\d+) q_tile_rows=(\d+) bytes=(\d+)", stderr
-        )
-        assert match, f"missing ScoreBlock2D workspace report: {stderr}"
-        q_tile_slice, q_tile_rows, workspace_bytes = map(int, match.groups())
-        total_q_tiles = math.ceil(seqlen_q / q_tile_rows)
-        assert 1 <= q_tile_slice <= total_q_tiles
-        assert workspace_bytes <= 1024 * 1024 * 1024
-
-    @pytest.mark.skipif(
-        device.type != "xpu" or not is_fa3_supported(),
-        reason="ScoreBlock2D LSE coverage is only supported on BMG XPU",
-    )
-    def test_flash_attn_varlen_hd512_score_workspace_lse_head_slicing(
-        monkeypatch, capfd
-    ):
-        """LSE rows remain globally indexed when ScoreBlock2D slices Q heads."""
-        from sgl_kernel.flash_attn import flash_attn_varlen_func
-
-        batch_size = 1
-        nheads_q = 4
-        nheads_kv = 1
-        seqlen_q = 256
-        seqlen_k = 4096
-        head_dim = 512
-        torch.manual_seed(0)
-        # A Q tile stores 128 * 4096 fp16 scores (1 MiB) per Q head. The
-        # 2 MiB cap forces the four Q heads to launch as two head slices.
-        monkeypatch.setenv("FMHA_SCORE_WS_CAP_MB", "2")
-        monkeypatch.setenv("FMHA_SCORE_WS_VERBOSE", "1")
-
-        q = torch.randn(
-            batch_size * seqlen_q,
-            nheads_q,
-            head_dim,
-            device=device,
-            dtype=torch.bfloat16,
-        )
-        k = torch.randn(
-            batch_size * seqlen_k,
-            nheads_kv,
-            head_dim,
-            device=device,
-            dtype=torch.bfloat16,
-        )
-        v = torch.randn(
-            batch_size * seqlen_k,
-            nheads_kv,
-            head_dim,
-            device=device,
-            dtype=torch.bfloat16,
-        )
-        cu_seqlens_q = torch.tensor([0, seqlen_q], device=device, dtype=torch.int32)
-        cu_seqlens_k = torch.tensor([0, seqlen_k], device=device, dtype=torch.int32)
-
-        out, lse = flash_attn_varlen_func(
-            q,
-            k,
-            v,
-            cu_seqlens_q,
-            cu_seqlens_k,
-            seqlen_q,
-            seqlen_k,
-            return_softmax_lse=True,
-        )
-        torch.xpu.synchronize()
-
-        _, _, lse_ref = attention_ref(
-            q.unsqueeze(0),
-            k.unsqueeze(0),
-            v.unsqueeze(0),
-            softmax_scale=head_dim**-0.5,
-            return_lse=True,
-        )
-        _check_softmax_lse(
-            lse,
-            nheads_q,
-            batch_size * seqlen_q,
-            lse_ref.squeeze(0),
-        )
-        assert out.shape == (batch_size * seqlen_q, nheads_q, head_dim)
-        _, stderr = capfd.readouterr()
-        match = re.search(r"query_head_slice=(\d+)", stderr)
-        assert match, f"missing ScoreBlock2D workspace report: {stderr}"
-        assert int(match.group(1)) < nheads_q
-
-    @pytest.mark.parametrize(
-        "batch_size,nheads_q,nheads_kv",
-        [
-            (1, 16, 2),
-            (8, 1, 1),
-        ],
-    )
-    def test_flash_attn_paged_hd512_large_score_workspace(
-        batch_size, nheads_q, nheads_kv
-    ):
-        """Paged ScoreBlock2D cases that previously required a 4 GiB workspace."""
-        from sgl_kernel.flash_attn import flash_attn_with_kvcache
-
-        seqlen_q = 4096
-        seqlen_k = 32768
-        page_size = 128
-        head_dim = 512
-        pages_per_seq = seqlen_k // page_size
-        num_pages = batch_size * pages_per_seq
-        torch.manual_seed(0)
-
-        q = torch.randn(
-            batch_size * seqlen_q,
-            nheads_q,
-            head_dim,
-            device=device,
-            dtype=torch.bfloat16,
-        )
-        k_cache = torch.randn(
-            num_pages,
-            page_size,
-            nheads_kv,
-            head_dim,
-            device=device,
-            dtype=torch.bfloat16,
-        )
-        v_cache = torch.randn_like(k_cache)
-        page_table = torch.arange(num_pages, device=device, dtype=torch.int32).reshape(
-            batch_size, pages_per_seq
-        )
-        cache_seqlens = torch.full(
-            (batch_size,), seqlen_k, device=device, dtype=torch.int32
-        )
-        cu_seqlens_q = torch.arange(
-            0,
-            batch_size * seqlen_q + 1,
-            seqlen_q,
-            device=device,
-            dtype=torch.int32,
-        )
-
-        out = flash_attn_with_kvcache(
-            q,
-            k_cache,
-            v_cache,
-            cache_seqlens=cache_seqlens,
-            page_table=page_table,
-            cu_seqlens_q=cu_seqlens_q,
-            max_seqlen_q=seqlen_q,
-            causal=True,
-        )
-        torch.xpu.synchronize()
-        assert out.shape == (batch_size * seqlen_q, nheads_q, head_dim)
-        assert out.dtype == torch.bfloat16
-        assert torch.isfinite(out).all()
-
 
 @pytest.mark.skipif(device.type != "xpu", reason="XPU not available")
 def test_flash_attn_with_kvcache_out_buffer():
@@ -2958,6 +2735,53 @@ def test_relative_attention_decode_d512_bias_only_matches_reference_and_pre_shea
         raw.cpu().float()[0], reference.float(), rtol=0, atol=2e-2
     )
     torch.testing.assert_close(sheared.float(), raw.float(), rtol=0, atol=2e-2)
+
+
+@pytest.mark.skipif(device.type != "xpu", reason="XPU not available")
+def test_flash_attn_with_kvcache_page_size_1():
+    from sgl_kernel.flash_attn import flash_attn_with_kvcache
+
+    torch.random.manual_seed(42)
+    batch_size, nheads_q, nheads_kv, d = 2, 4, 2, 64
+    dtype = torch.bfloat16
+    cache_seqlens = torch.tensor([3, 5], dtype=torch.int32, device=device)
+    page_table = torch.tensor(
+        [[7, 2, 9, 0, 0], [4, 1, 8, 3, 6]],
+        dtype=torch.int32,
+        device=device,
+    )
+    q = torch.randn(batch_size, 1, nheads_q, d, device=device, dtype=dtype)
+    k_cache = torch.randn(10, 1, nheads_kv, d, device=device, dtype=dtype)
+    v_cache = torch.randn(10, 1, nheads_kv, d, device=device, dtype=dtype)
+    out_buf = torch.empty(batch_size, nheads_q, d, device=device, dtype=dtype)
+
+    out, lse = flash_attn_with_kvcache(
+        q,
+        k_cache,
+        v_cache,
+        cache_seqlens=cache_seqlens,
+        page_table=page_table,
+        out=out_buf,
+        return_softmax_lse=True,
+    )
+
+    scale = d**-0.5
+    out_ref = torch.empty_like(out)
+    lse_ref = torch.empty(nheads_q, batch_size, device=device, dtype=torch.float32)
+    for batch_idx, seqlen_k in enumerate(cache_seqlens.tolist()):
+        slots = page_table[batch_idx, :seqlen_k].long()
+        k = k_cache[slots, 0].repeat_interleave(nheads_q // nheads_kv, dim=1)
+        v = v_cache[slots, 0].repeat_interleave(nheads_q // nheads_kv, dim=1)
+        scores = torch.einsum("hd,shd->hs", q[batch_idx, 0].float(), k.float()) * scale
+        out_ref[batch_idx] = torch.einsum(
+            "hs,shd->hd", torch.softmax(scores, dim=-1), v.float()
+        ).to(dtype)
+        lse_ref[:, batch_idx] = torch.logsumexp(scores, dim=-1)
+
+    torch.xpu.synchronize()
+    assert out.data_ptr() == out_buf.data_ptr()
+    torch.testing.assert_close(out, out_ref, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(lse, lse_ref, atol=3e-2, rtol=3e-2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, `flash_attn_with_kvcache` does not support `page_size=1`.
This PR provides a workaround to route the above case to `flash_attn_varlen_func` which does not need page table.