### PR TITLE
[Attention] Route uniform length paged prefill batches to the single launch path

### DIFF
--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -1497,18 +1497,17 @@ SGL_KERNEL_EXPORT void mha_fwd(
   if (max_seqlen_q == 1) {
     // Pure decode path
     dispatch(decode::mha_fwd, std::nullopt);
-  } else if (!page_table.has_value() || batch_size == 1 || is_uniform_qlen) {
+  } else if (!page_table.has_value() || is_uniform_qlen) {
     // Pure prefill path
-    // Non-paged attn: assumption of all seqlen_q > 1;
-    // Paged attn: Proving "all prefill" for batch_size > 1 would require
-    // is_prefill.all() — a device reduction + D2H sync that costs more than it saves.
-    // Two cases are provable from host scalars alone:
-    //   batch_size == 1: a single sequence with max_seqlen_q > 1 is prefill;
-    //   sum(seqlen_q) == batch_size * max_seqlen_q: since every seqlen_q <= max_seqlen_q,
-    //     the sum reaches batch_size * max_seqlen_q only when all of them equal
-    //     max_seqlen_q, which is > 1 on this branch, so no row is a decode row.
-    // Sufficient, not necessary: a non-uniform all-prefill batch falls through to
-    // chunkprefill, which is still correct.
+    //
+    // For ragged Q, q.size(0) == sum(seqlen_q). Since every
+    // seqlen_q <= max_seqlen_q, equality with
+    // batch_size * max_seqlen_q implies that every query length
+    // equals max_seqlen_q. Since max_seqlen_q > 1 on this branch,
+    // every row is prefill.
+    //
+    // This condition is sufficient but not necessary: a non-uniform
+    // all-prefill batch falls through to chunkprefill, which is still correct.
     dispatch(prefill::mha_fwd, std::nullopt);
   } else {
     // Chunk prefill path

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -1510,8 +1510,7 @@ SGL_KERNEL_EXPORT void mha_fwd(
     // all-prefill batch falls through to chunkprefill, which is still correct.
     dispatch(prefill::mha_fwd, std::nullopt);
   } else {
-    // Chunk prefill path
-    // Paged attn with max_seqlen_q > 1 and batch_size > 1
+    // Non-uniform paged batches fall back to chunkprefill.
     dispatch(chunkprefill::mha_fwd);
   }
 }

--- a/src/sycl/flash_attention.cpp
+++ b/src/sycl/flash_attention.cpp
@@ -1492,16 +1492,23 @@ SGL_KERNEL_EXPORT void mha_fwd(
        std::forward<decltype(tail)>(tail)...);
   };
 
+  bool const is_uniform_qlen = batch_size > 0 && q.size(0) == batch_size * static_cast<int64_t>(max_seqlen_q);
+
   if (max_seqlen_q == 1) {
     // Pure decode path
     dispatch(decode::mha_fwd, std::nullopt);
-  } else if (!page_table.has_value() || batch_size == 1) {
+  } else if (!page_table.has_value() || batch_size == 1 || is_uniform_qlen) {
     // Pure prefill path
     // Non-paged attn: assumption of all seqlen_q > 1;
     // Paged attn: Proving "all prefill" for batch_size > 1 would require
     // is_prefill.all() — a device reduction + D2H sync that costs more than it saves.
-    // But batch_size == 1 makes it provable from host scalars:
-    // a single sequence with max_seqlen_q > 1 is prefill
+    // Two cases are provable from host scalars alone:
+    //   batch_size == 1: a single sequence with max_seqlen_q > 1 is prefill;
+    //   sum(seqlen_q) == batch_size * max_seqlen_q: since every seqlen_q <= max_seqlen_q,
+    //     the sum reaches batch_size * max_seqlen_q only when all of them equal
+    //     max_seqlen_q, which is > 1 on this branch, so no row is a decode row.
+    // Sufficient, not necessary: a non-uniform all-prefill batch falls through to
+    // chunkprefill, which is still correct.
     dispatch(prefill::mha_fwd, std::nullopt);
   } else {
     // Chunk prefill path


### PR DESCRIPTION
## Motivation

`mha_fwd` only proved "all rows are prefill" when `batch_size == 1`. Every other paged batch with `max_seqlen_q > 1` went through `chunkprefill`, paying a decode launch that matches no row when all query lengths are equal.

`sum(seqlen_q) == batch_size * max_seqlen_q` proves the batch is uniform, and therefore all prefill, from host scalars alone — no device work, no sync. Non-uniform batches still fall through to `chunkprefill`.

## Performance

B60, bf16, Gemma-4 SWA `head_dim=256`, extend phase. `q/kv` = per-rank heads.
Median of 5 x 200 iterations.

| shape | before (us) | after (us) | speedup |
|---|---:|---:|---:|
| 2/1 sw512 bs1 8192+512 *(unchanged path)* | 83.73 | 83.82 | 0.999x |
| 2/1 sw512 bs2 8192+512 | 207.01 | 84.14 | 2.460x |
| 2/1 sw512 bs4 8192+512 | 287.62 | 84.52 | 3.403x |
| 2/1 sw512 bs16 8192+512 | 1043.87 | 348.46 | 2.996x |
| 8/4 sw1024 bs2 8192+512 | 671.08 | 292.32 | 2.296x |
| 2/1 sw512 bs2 0+1024 | 112.14 | 84.11 | 1.333x |
| 8/4 sw1024 bs16 0+1024 | 1870.32 | 1697.38 | 1.102x |

Over 20 configurations: **geomean 1.438x, best 3.403x, no regressions.**
`batch_size == 1` is unchanged, as expected.

## Correctness

Verified against the PyTorch reference (`atol=rtol=0.01`): uniform batches take the new path, non-uniform all-prefill and mixed prefill+decode batches still route to `chunkprefill`. All pass.