### PR TITLE
changes related to permissions and license

### DIFF
--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -12,7 +12,10 @@ concurrency:
 jobs:
   build-and-test:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
-    permissions: write-all
+    # Least privilege: every write op below (git push, gh pr create/comment)
+    # authenticates with secrets.PAT, not the workflow GITHUB_TOKEN.
+    permissions:
+      contents: read
     runs-on: sglang-bmg
     steps:
       - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,5 +35,5 @@ build-dir = "build"
 minimum-version = "build-system.requires"
 
 wheel.py-api = "cp39"
-wheel.license-files = []
+wheel.license-files = ["LICENSE", "THIRDPARTYNOTICES.txt"]
 wheel.packages = ["python/sgl_kernel"]

--- a/python/sgl_kernel/jit/compiler.py
+++ b/python/sgl_kernel/jit/compiler.py
@@ -160,7 +160,9 @@ def _compute_cache_key(cache_inputs: List[Any]) -> str:
 def _get_cache_dir() -> pathlib.Path:
     """Get or create cache directory for compiled SYCL kernels."""
     cache_dir = pathlib.Path.home() / ".cache" / "sgl_kernel" / "jit_sycl"
-    cache_dir.mkdir(parents=True, exist_ok=True)
+    # 0o700: the cache holds .so files that are dlopen'd, so a group/world
+    # writable dir would let another local user swap in arbitrary code.
+    cache_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     return cache_dir
 
 


### PR DESCRIPTION
This PR tightens workflow and local cache permissions, and updates wheel packaging to include the project’s license notices. It reduces privilege in the XPU test workflow, secures the JIT cache directory, and ensures the built wheel carries the required license files.