### PR TITLE
Optimize W4A16 MoE GEMM across GPT-OSS workloads

### DIFF
--- a/benchmark/bench_moe_w4a16_grouped_gemm.py
+++ b/benchmark/bench_moe_w4a16_grouped_gemm.py
@@ -27,6 +27,9 @@
 # includes GPT-OSS geometry (4 local experts, hidden=2880, intermediate=2880).
 # Set SGL_MOE_BENCH_FULL_SHAPES=1 to also include DeepSeek-V4 geometry (32 local
 # experts, hidden=4096, intermediate=2048) and higher-load model points.
+# Set SGL_MOE_BENCH_MODEL=gpt-oss-120b to run the dedicated GPT-OSS-120B
+# profile: all 16 TP4/TP8 prefill/decode production workloads and no generic
+# shape sweep.
 #
 # Run:
 #   python benchmark/bench_moe_w4a16_grouped_gemm.py
@@ -99,16 +102,197 @@ FULL_BENCH_SHAPES = QUICK_BENCH_SHAPES + [
 ]
 
 RUN_FULL_SHAPES = os.environ.get("SGL_MOE_BENCH_FULL_SHAPES") == "1"
+BENCH_MODEL = os.environ.get("SGL_MOE_BENCH_MODEL", "").lower()
+RUN_GPT_OSS_120B = BENCH_MODEL == "gpt-oss-120b" or (
+    os.environ.get("SGL_MOE_BENCH_GPT_OSS_TP4_L0") == "1"
+)
 BENCH_SHAPES = FULL_BENCH_SHAPES if RUN_FULL_SHAPES else QUICK_BENCH_SHAPES
 print(
-    f"[config] grouped-GEMM shape set: "
-    f"{'full' if RUN_FULL_SHAPES else 'quick'} ({len(BENCH_SHAPES)} shapes)",
+    "[config] grouped-GEMM shape set: "
+    + (
+        "gpt-oss-120b (16 production workloads)"
+        if RUN_GPT_OSS_120B
+        else f"{'full' if RUN_FULL_SHAPES else 'quick'} ({len(BENCH_SHAPES)} shapes)"
+    ),
     flush=True,
 )
 
 
 ALL_RESULTS = []
 _MXFP4_CPU_WEIGHT_CACHE = {}
+
+# GPT-OSS-120B TP=4, layer 0. This is the real 128-expert routing vector from
+# fmha-cri's examples/16_bmg_moe_gemm/gpt_oss_120b_workloads.hpp. The total is
+# 16,384 routed rows; its long tails are why the 64-row production tile matters.
+GPT_OSS_120B_TP4_L0_ROWS = (
+    50,
+    32,
+    48,
+    37,
+    60,
+    54,
+    32,
+    267,
+    100,
+    33,
+    72,
+    12,
+    1422,
+    47,
+    70,
+    176,
+    474,
+    21,
+    76,
+    35,
+    47,
+    72,
+    45,
+    37,
+    41,
+    101,
+    27,
+    102,
+    699,
+    48,
+    65,
+    80,
+    43,
+    46,
+    62,
+    59,
+    114,
+    12,
+    33,
+    4,
+    56,
+    74,
+    86,
+    56,
+    74,
+    78,
+    199,
+    3,
+    138,
+    36,
+    98,
+    81,
+    42,
+    228,
+    58,
+    205,
+    117,
+    82,
+    88,
+    47,
+    107,
+    58,
+    56,
+    78,
+    69,
+    128,
+    51,
+    88,
+    110,
+    55,
+    83,
+    349,
+    51,
+    67,
+    67,
+    30,
+    1028,
+    58,
+    46,
+    55,
+    39,
+    39,
+    52,
+    538,
+    398,
+    112,
+    72,
+    190,
+    196,
+    21,
+    61,
+    33,
+    35,
+    23,
+    208,
+    43,
+    39,
+    18,
+    46,
+    137,
+    53,
+    42,
+    57,
+    682,
+    48,
+    124,
+    32,
+    32,
+    151,
+    29,
+    56,
+    82,
+    53,
+    59,
+    98,
+    88,
+    39,
+    151,
+    51,
+    124,
+    39,
+    45,
+    49,
+    80,
+    85,
+    40,
+    20,
+    2340,
+)
+
+
+# Remaining production vectors, copied verbatim from gpt_oss_120b_workloads.hpp.
+def _rows(csv):
+    values = tuple(map(int, csv.split(",")))
+    assert len(values) == 128
+    return values
+
+
+GPT_OSS_120B_TP4_L14_ROWS = _rows(
+    "283,2509,0,1,0,0,210,0,0,0,6,30,6,2,13,0,0,0,0,5,0,1,79,0,0,0,0,70,0,0,3487,0,"
+    "3,0,0,131,32,1229,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,177,0,43,0,0,0,0,17,0,0,0,"
+    "0,237,4,48,0,0,98,0,2,0,0,3,0,123,11,0,208,0,0,9,0,0,0,0,155,139,1,0,0,3,"
+    "0,0,4,0,0,2,156,1,0,0,1617,404,0,13,0,69,0,1,4096,0,0,51,0,0,581,10,0,0,0,0,0,0,0"
+)
+GPT_OSS_120B_TP4_L35_ROWS = _rows(
+    "0,0,0,76,22,32,0,1,0,0,0,3573,0,0,0,1,0,0,0,0,0,0,0,0,2,0,396,0,0,0,1,0,"
+    "0,0,64,0,478,0,0,0,0,0,3,0,49,0,22,0,0,0,0,0,92,0,0,0,0,0,0,0,0,100,2,0,"
+    "0,0,75,1,0,0,0,199,0,0,0,0,0,0,7,0,4,35,0,0,0,0,2,0,298,4,0,0,0,0,0,2736,"
+    "0,0,5,0,12,0,541,12,23,40,0,0,0,0,0,26,0,398,0,0,4080,0,0,0,48,0,16,0,2,0,0,2906"
+)
+GPT_OSS_120B_TP8_L0_ROWS = _rows(
+    "73,29,29,45,53,43,27,208,122,29,72,16,1461,53,47,173,502,18,60,41,48,54,39,24,42,113,28,104,733,64,104,60,"
+    "45,53,80,57,120,9,32,4,46,61,94,59,72,75,245,5,172,38,75,72,48,223,45,177,126,78,90,43,68,44,65,59,"
+    "64,145,70,84,85,60,68,322,55,65,64,28,1101,55,46,63,35,45,43,542,350,122,75,186,176,16,64,35,17,25,"
+    "186,57,26,18,52,134,52,51,38,651,52,156,49,30,148,19,46,91,52,67,115,86,39,146,54,136,35,49,37,49,81,39,25,2418"
+)
+GPT_OSS_120B_TP8_L14_ROWS = _rows(
+    "329,2489,0,1,0,0,213,0,0,0,4,30,7,0,8,0,0,0,0,10,0,0,97,0,0,0,0,68,0,0,3510,0,"
+    "6,0,0,98,27,1461,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,139,0,49,0,0,0,0,39,0,0,0,"
+    "0,265,3,45,0,0,107,0,5,0,0,1,0,115,12,0,164,0,0,13,0,0,0,0,112,138,3,0,0,5,"
+    "0,1,2,0,0,0,120,0,0,0,1549,336,0,7,0,74,0,4,4094,0,0,52,0,0,557,11,0,0,0,0,0,0,0"
+)
+GPT_OSS_120B_TP8_L35_ROWS = _rows(
+    "0,0,0,107,13,34,0,1,0,0,0,3501,0,0,1,2,0,0,0,1,0,0,0,0,0,0,368,0,0,0,2,0,"
+    "0,0,57,0,650,0,0,0,0,0,2,0,90,0,14,0,0,0,0,0,83,1,0,0,0,0,0,0,0,133,3,0,"
+    "0,0,40,3,0,0,0,179,0,0,0,0,1,0,4,0,4,66,0,0,0,0,2,0,299,4,0,0,0,0,0,2713,"
+    "2,0,11,0,14,0,585,12,29,24,0,0,0,0,0,15,0,377,0,0,4076,0,0,0,33,0,29,0,1,0,0,2798"
+)
 
 
 def _quantize_bf16_weights_mxfp4(num_experts: int, N: int, K: int):
@@ -255,6 +439,7 @@ def _prepare_inputs(
     gemm_k: int,
     recipe: str = "mxfp4",
     backend: str = "sgl",
+    rows_per_expert=None,
 ):
     """Build the XPU tensors for one provider.
 
@@ -278,8 +463,14 @@ def _prepare_inputs(
     torch.manual_seed(0)
     torch.xpu.manual_seed_all(0)
 
-    total_m = num_experts * avg_m
-    total_rows = torch.full((num_experts,), avg_m, dtype=torch.int32, device="xpu")
+    if rows_per_expert is None:
+        total_m = num_experts * avg_m
+        total_rows = torch.full((num_experts,), avg_m, dtype=torch.int32, device="xpu")
+    else:
+        if len(rows_per_expert) != num_experts:
+            raise ValueError("rows_per_expert must have one value per expert")
+        total_m = sum(rows_per_expert)
+        total_rows = torch.tensor(rows_per_expert, dtype=torch.int32, device="xpu")
 
     a = torch.empty((total_m, gemm_k), dtype=torch.bfloat16, device="xpu").normal_(
         0, 0.01
@@ -511,6 +702,77 @@ def benchmark(num_experts, avg_m, gemm_n, gemm_k, provider):
     return ms
 
 
+def _run_gpt_oss_120b_benchmark():
+    """Time all 16 real ragged GPT-OSS-120B production calls.
+
+    This uses the same registered op as the model path.  The warmup is expressed
+    in device-time iterations rather than host time, so it reaches the stable
+    GPU clock before the median is collected.
+    """
+    decode_tp4 = tuple(int(i in (14, 49, 79, 118)) for i in range(128))
+    decode_tp8 = tuple(int(i in (22, 36, 73, 115)) for i in range(128))
+    workloads = (
+        ("gpt-oss-120b-prefill-l0", GPT_OSS_120B_TP4_L0_ROWS, 1472, 2880, 2880, 736),
+        ("gpt-oss-120b-prefill-l14", GPT_OSS_120B_TP4_L14_ROWS, 1472, 2880, 2880, 736),
+        ("gpt-oss-120b-prefill-l35", GPT_OSS_120B_TP4_L35_ROWS, 1472, 2880, 2880, 736),
+        ("gpt-oss-120b-decode", decode_tp4, 1472, 2880, 2880, 736),
+        ("gpt-oss-120b-tp8-prefill-l0", GPT_OSS_120B_TP8_L0_ROWS, 768, 2880, 2880, 384),
+        (
+            "gpt-oss-120b-tp8-prefill-l14",
+            GPT_OSS_120B_TP8_L14_ROWS,
+            768,
+            2880,
+            2880,
+            384,
+        ),
+        (
+            "gpt-oss-120b-tp8-prefill-l35",
+            GPT_OSS_120B_TP8_L35_ROWS,
+            768,
+            2880,
+            2880,
+            384,
+        ),
+        ("gpt-oss-120b-tp8-decode", decode_tp8, 768, 2880, 2880, 384),
+    )
+    shapes = tuple(
+        (f"{name}-gemm{gemm}", rows, n, k)
+        for name, rows, n1, k1, n2, k2 in workloads
+        for gemm, n, k in ((1, n1, k1), (2, n2, k2))
+    )
+    print("\n[GPT-OSS-120B production routing: 16 workloads]", flush=True)
+    for name, rows, gemm_n, gemm_k in shapes:
+        inputs = _prepare_inputs(
+            len(rows),
+            sum(rows) // len(rows),
+            gemm_n,
+            gemm_k,
+            recipe="mxfp4",
+            backend="sgl",
+            rows_per_expert=rows,
+        )
+        for _ in range(20):
+            _run_mxfp4_fused(inputs)
+        torch.xpu.synchronize()
+        ms, ms_min, ms_max = triton.testing.do_bench(
+            lambda: _run_mxfp4_fused(inputs),
+            warmup=6000,
+            rep=1000,
+            quantiles=[0.5, 0.2, 0.8],
+        )
+        total_m = inputs["total_m"]
+        tflops = 2 * total_m * gemm_n * gemm_k / (ms / 1e3) / 1e12
+        print(
+            f"{name}: rows={total_m}, N={gemm_n}, K={gemm_k}, "
+            f"median={ms:.4f} ms, p20={ms_min:.4f} ms, p80={ms_max:.4f} ms, "
+            f"{tflops:.2f} TFLOP/s",
+            flush=True,
+        )
+        del inputs
+        gc.collect()
+        torch.xpu.empty_cache()
+
+
 def _correctness_check(rel_tol=CORRECTNESS_REL_TOL):
     """Cross-check sgl_kernel vs vLLM outputs on the same logical weights.
 
@@ -571,6 +833,11 @@ def _correctness_check(rel_tol=CORRECTNESS_REL_TOL):
 
 
 if __name__ == "__main__":
+    if RUN_GPT_OSS_120B:
+        _run_gpt_oss_120b_benchmark()
+        print("\nGPT-OSS-120B benchmark finished!\n")
+        raise SystemExit(0)
+
     _correctness_check()
     benchmark.run(print_data=False)
     print("\nBenchmark finished!\n")

--- a/src/GroupGemmW4A16Xe20.cmake
+++ b/src/GroupGemmW4A16Xe20.cmake
@@ -18,8 +18,8 @@ endfunction()
 # layouts and have separate N-tail-skip instantiations, because that bit changes
 # device code. select_w4a16_policy_id() chooses from this table per call.
 # group_size (32/64/128/256) is compiled into every unit as a runtime branch,
-# so it does not multiply the instance count. Total: 8 policies x 2
-# (int4/mxfp4) x 2 (bf16/fp16 activation) = 32 units.
+# so it does not multiply the instance count. Total: 7 policies x 2
+# (int4/mxfp4) x 2 (bf16/fp16 activation) = 28 units.
 foreach(policy
         w4a16_launch_policy_m_8_n_64
         w4a16_launch_policy_m_16_n_64
@@ -27,8 +27,7 @@ foreach(policy
         w4a16_launch_policy_m_64_n_128
         w4a16_launch_policy_m_64_n_128_skip
         w4a16_launch_policy_m_64_n_256
-        w4a16_launch_policy_m_64_n_256_skip
-        w4a16_launch_policy_m_128_n_128)
+        w4a16_launch_policy_m_64_n_256_skip)
     foreach(act_tag bf16 fp16)
         if(act_tag STREQUAL "bf16")
             set(element_a "cutlass::bfloat16_t")

--- a/src/GroupGemmW4A16Xe20.cmake
+++ b/src/GroupGemmW4A16Xe20.cmake
@@ -14,18 +14,21 @@ function(add_group_gemm_w4a16_xe20_inst POLICY ELEMENT_S ELEMENT_A SANITIZED)
     set(GROUP_GEMM_W4A16_XE20_INST_SRCS ${GROUP_GEMM_W4A16_XE20_INST_SRCS} PARENT_SCOPE)
 endfunction()
 
-# Policy menu. select_w4a16_tile_m() in GroupGemmW4A16Xe20.cpp picks one per
-# call from the average rows-per-expert:
-#   w4a16_policy_m_8_n_64    <_8,  _64,  _32>  — avg_m <= 4
-#   w4a16_policy_m_16_n_64   <_16, _64,  _32>  — avg_m <= 8
-#   w4a16_policy_m_32_n_64   <_32, _64,  _32>  — small avg_m
-#   w4a16_policy_m_64_n_128  <_64, _128, _32>  — mid avg_m
-#   w4a16_policy_m_128_n_128 <_128,_128, _32>  — large avg_m
+# fmha-cri production registry. The 64-row policies use single-M-subgroup
+# layouts and have separate N-tail-skip instantiations, because that bit changes
+# device code. select_w4a16_policy_id() chooses from this table per call.
 # group_size (32/64/128/256) is compiled into every unit as a runtime branch,
-# so it does not multiply the instance count. Total: 5 policies x 2 (int4/mxfp4)
-# x 2 (bf16/fp16 activation) = 20 units.
-foreach(policy w4a16_policy_m_8_n_64 w4a16_policy_m_16_n_64 w4a16_policy_m_32_n_64
-               w4a16_policy_m_64_n_128 w4a16_policy_m_128_n_128)
+# so it does not multiply the instance count. Total: 8 policies x 2
+# (int4/mxfp4) x 2 (bf16/fp16 activation) = 32 units.
+foreach(policy
+        w4a16_launch_policy_m_8_n_64
+        w4a16_launch_policy_m_16_n_64
+        w4a16_launch_policy_m_32_n_64
+        w4a16_launch_policy_m_64_n_128
+        w4a16_launch_policy_m_64_n_128_skip
+        w4a16_launch_policy_m_64_n_256
+        w4a16_launch_policy_m_64_n_256_skip
+        w4a16_launch_policy_m_128_n_128)
     foreach(act_tag bf16 fp16)
         if(act_tag STREQUAL "bf16")
             set(element_a "cutlass::bfloat16_t")

--- a/src/jit/moe_jit.cpp
+++ b/src/jit/moe_jit.cpp
@@ -176,8 +176,6 @@ const char* w4a16_policy(int policy_id) {
       return "w4a16_launch_policy_m_64_n_256";
     case 6:
       return "w4a16_launch_policy_m_64_n_256_skip";
-    case 7:
-      return "w4a16_launch_policy_m_128_n_128";
     default:
       return nullptr;
   }

--- a/src/jit/moe_jit.cpp
+++ b/src/jit/moe_jit.cpp
@@ -22,6 +22,7 @@ using KernelFn = void (*)(
     int,
     const int*,
     int,
+    int,
     int*,
     float,
     float,
@@ -154,22 +155,29 @@ using W4A16Fn = void (*)(
     const int*,
     int,
     int,
+    int,
     int*);
 
 // Policy id is selected by GroupGemmW4A16Xe20.cpp so AOT and JIT dispatch use
-// the same avg_m- and gemm_n-dependent decision.
+// the same production-tile decision.
 const char* w4a16_policy(int policy_id) {
   switch (policy_id) {
     case 0:
-      return "w4a16_policy_m_8_n_64";
+      return "w4a16_launch_policy_m_8_n_64";
     case 1:
-      return "w4a16_policy_m_16_n_64";
+      return "w4a16_launch_policy_m_16_n_64";
     case 2:
-      return "w4a16_policy_m_32_n_64";
+      return "w4a16_launch_policy_m_32_n_64";
     case 3:
-      return "w4a16_policy_m_64_n_128";
+      return "w4a16_launch_policy_m_64_n_128";
     case 4:
-      return "w4a16_policy_m_128_n_128";
+      return "w4a16_launch_policy_m_64_n_128_skip";
+    case 5:
+      return "w4a16_launch_policy_m_64_n_256";
+    case 6:
+      return "w4a16_launch_policy_m_64_n_256_skip";
+    case 7:
+      return "w4a16_launch_policy_m_128_n_128";
     default:
       return nullptr;
   }
@@ -239,6 +247,7 @@ bool w4a16_grouped_gemm_launch(
     int gemm_n,
     int gemm_k,
     const int* rows_per_expert,
+    int total_rows,
     int num_experts,
     int group_size,
     int* atomic_buffer,
@@ -256,6 +265,7 @@ bool w4a16_grouped_gemm_launch(
      gemm_n,
      gemm_k,
      rows_per_expert,
+     total_rows,
      num_experts,
      group_size,
      atomic_buffer);

--- a/src/jit/moe_jit.h
+++ b/src/jit/moe_jit.h
@@ -39,7 +39,7 @@ bool grouped_gemm_launch(
     std::string* err = nullptr);
 
 // Launch the W4A16 (int4 / mxfp4) grouped GEMM. policy_id is selected by
-// GroupGemmW4A16Xe20.cpp so JIT uses the exact same avg_m- and gemm_n-dependent
+// GroupGemmW4A16Xe20.cpp so JIT uses the exact same avg_m-, gemm_n-, and gemm_k-dependent
 // policy as AOT. (ElementS, ElementA) comes from (is_int4, is_fp16), and
 // group_size is a runtime arg (not a template param).
 bool w4a16_grouped_gemm_launch(
@@ -56,6 +56,7 @@ bool w4a16_grouped_gemm_launch(
     int gemm_n,
     int gemm_k,
     const int* rows_per_expert,
+    int total_rows,
     int num_experts,
     int group_size,
     int* atomic_buffer,

--- a/src/sycl/GroupGemmW4A16Xe20.cpp
+++ b/src/sycl/GroupGemmW4A16Xe20.cpp
@@ -35,11 +35,13 @@
 #include <c10/xpu/XPUStream.h>
 #include <torch/all.h>
 
+#include <cstdint>
 #include <sycl/sycl.hpp>
+#include <unordered_map>
 
 #include "sgl_kernel_export.h"
 #include "sycl/Utils.h"
-#include "sycl/kernels/moe/xe20/w4a16/gemm_xe2_policy.hpp"
+#include "sycl/kernels/moe/xe20/w4a16_launch_policy.hpp"
 #ifdef USE_MOE_JIT
 #include "jit/moe_jit.h"
 #endif
@@ -57,6 +59,7 @@ void w4a16_launch(
     const int gemm_n,
     const int gemm_k,
     const int* rows_per_expert,
+    const int total_rows,
     const int num_experts,
     const int group_size,
     int32_t* atomic_buffer);
@@ -76,6 +79,7 @@ void w4a16_launch(
       const int*,                                                                      \
       const int,                                                                       \
       const int,                                                                       \
+      const int,                                                                       \
       int32_t*);
 
 #define DECLARE_W4A16_POLICY(Policy)                                     \
@@ -84,64 +88,68 @@ void w4a16_launch(
   DECLARE_W4A16_EXTERN(Policy, uint8_t, cutlass::bfloat16_t)             \
   DECLARE_W4A16_EXTERN(Policy, uint8_t, cutlass::half_t)
 
-DECLARE_W4A16_POLICY(w4a16_policy_m_8_n_64)
-DECLARE_W4A16_POLICY(w4a16_policy_m_16_n_64)
-DECLARE_W4A16_POLICY(w4a16_policy_m_32_n_64)
-DECLARE_W4A16_POLICY(w4a16_policy_m_64_n_128)
-DECLARE_W4A16_POLICY(w4a16_policy_m_128_n_128)
+DECLARE_W4A16_POLICY(w4a16_launch_policy_m_8_n_64)
+DECLARE_W4A16_POLICY(w4a16_launch_policy_m_16_n_64)
+DECLARE_W4A16_POLICY(w4a16_launch_policy_m_32_n_64)
+DECLARE_W4A16_POLICY(w4a16_launch_policy_m_64_n_128)
+DECLARE_W4A16_POLICY(w4a16_launch_policy_m_64_n_128_skip)
+DECLARE_W4A16_POLICY(w4a16_launch_policy_m_64_n_256)
+DECLARE_W4A16_POLICY(w4a16_launch_policy_m_64_n_256_skip)
+DECLARE_W4A16_POLICY(w4a16_launch_policy_m_128_n_128)
 
 #undef DECLARE_W4A16_POLICY
 #undef DECLARE_W4A16_EXTERN
 
 namespace {
 
-// GEMM shape -> tile policy, weighted by how much of each tile the GEMM fills.
-//
-// The grouped GEMM tiles every expert's rows independently, so a policy with an
-// M tile of T computes ceil(avg_m / T) * T rows per expert whatever avg_m is.
-// Picking the widest tile unconditionally therefore falls off a cliff just past
-// a multiple of T: at avg_m = 129 an M=128 tile does 256 rows of work for 129
-// rows of data and loses half the machine. N tails have the same effect: a
-// policy computes ceil(gemm_n / tile_n) * tile_n columns. Scoring each candidate
-// by its peak throughput times both fill factors estimates which policy finishes
-// first.
-//
-// The peaks below are measured on Xe2 (Arc Pro B60, bf16 activations) at
-// avg_m values that fill each tile exactly, in TFLOP/s. They are only ever
-// compared against each other, so the absolute scale does not matter -- what
-// matters is that a wider tile is worth more per row but wastes more of a
-// partial tile. GPT-OSS gemm1 (N=5760, K=2880) and DeepSeek-V4 gemm1
-// (N=4096, K=4096) agree on this ordering.
-constexpr int kW4A16TileM[] = {32, 64, 128};
-constexpr int kW4A16TileN[] = {64, 128, 128};
-constexpr float kW4A16TilePeakTflops[] = {49.0f, 64.0f, 68.0f};
+// fmha-cri's production registry keeps one M subgroup in the large-M tiles, so
+// an irregular expert tail never leaves an entire subgroup doing masked work.
+// The 256-wide variant wins long-K GEMM1 except where N padding outweighs its
+// measured peak advantage; short-K GEMM2 uses the 128-wide variant.
+constexpr float kW4A16PeakN256 = 82.9f;
+constexpr float kW4A16PeakN128 = 75.6f;
+constexpr int kW4A16ShortK = 1024;
 
-int select_w4a16_tile_m(int avg_m, int gemm_n) {
-  int best_tile_m = kW4A16TileM[0];
-  float best_score = 0.0f;
-  for (size_t i = 0; i < sizeof(kW4A16TileM) / sizeof(kW4A16TileM[0]); ++i) {
-    const int tile_m = kW4A16TileM[i];
-    const int tile_n = kW4A16TileN[i];
-    const int rows_computed = ((avg_m + tile_m - 1) / tile_m) * tile_m;
-    const int columns_computed = ((gemm_n + tile_n - 1) / tile_n) * tile_n;
-    const float score = kW4A16TilePeakTflops[i] * static_cast<float>(avg_m) / static_cast<float>(rows_computed) *
-                        static_cast<float>(gemm_n) / static_cast<float>(columns_computed);
-    if (score > best_score) {
-      best_score = score;
-      best_tile_m = tile_m;
-    }
-  }
-  return best_tile_m;
+int round_up(int value, int multiple) {
+  return (value + multiple - 1) / multiple * multiple;
 }
 
-int select_w4a16_policy_id(int avg_m, int gemm_n) {
-  if (avg_m <= 4) return 0;
-  if (avg_m <= 8) return 1;
+bool want_nskip(int gemm_n, int tile_n) {
+  const int tail = gemm_n % tile_n;
+  return tail != 0 && tail <= tile_n / 2;
+}
 
-  const int tile_m = select_w4a16_tile_m(avg_m, gemm_n);
-  if (tile_m <= 32) return 2;
-  if (tile_m <= 64) return 3;
-  return 4;
+at::Tensor& w4a16_atomic_counter(const torch::TensorOptions& options, c10::xpu::XPUStream stream) {
+  // This counter is private to one host thread, XPU device, and PyTorch stream.
+  // Keeping it alive avoids an allocator round trip between the benchmark's
+  // device timing events on every launch, while distinct streams never race on
+  // the work-stealing state.
+  thread_local std::unordered_map<uint64_t, at::Tensor> counters;
+  const uint64_t device_key = static_cast<uint32_t>(stream.device_index());
+  const uint64_t stream_key = static_cast<uint32_t>(stream.id());
+  const uint64_t key = (device_key << 32) | stream_key;
+  auto [it, inserted] = counters.try_emplace(key);
+  if (inserted) {
+    it->second = at::empty({1}, options.dtype(at::kInt));
+  }
+  return it->second;
+}
+
+int select_w4a16_policy_id(int avg_m, int gemm_n, int gemm_k) {
+  if (avg_m <= 8) return 0;
+  if (avg_m <= 16) return 1;
+  if (avg_m <= 32) return 2;
+
+  if (gemm_k <= kW4A16ShortK) {
+    return want_nskip(gemm_n, 128) ? 4 : 3;
+  }
+
+  const float fill_n256 = static_cast<float>(gemm_n) / round_up(gemm_n, 256);
+  const float fill_n128 = static_cast<float>(gemm_n) / round_up(gemm_n, 128);
+  if (kW4A16PeakN256 * fill_n256 >= kW4A16PeakN128 * fill_n128) {
+    return want_nskip(gemm_n, 256) ? 6 : 5;
+  }
+  return want_nskip(gemm_n, 128) ? 4 : 3;
 }
 
 }  // namespace
@@ -247,10 +255,12 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
   c10::DeviceGuard device_guard(activations.device());
   auto stream = at::xpu::getCurrentXPUStream();
   auto queue = stream.queue();
-  at::Tensor atomic_buffer = at::empty({static_cast<long>(1)}, activations.options().dtype(at::kInt));
+  at::Tensor& atomic_buffer = w4a16_atomic_counter(activations.options(), stream);
+  // The imported kernel resets this persistent work-stealing counter itself.
+  // Avoid a separate four-byte memset launch, which is material for decode.
 
   const int avg_m = total_m / static_cast<int>(n_experts);
-  const int policy_id = select_w4a16_policy_id(avg_m, gemm_n);
+  const int policy_id = select_w4a16_policy_id(avg_m, gemm_n, gemm_k);
   const bool is_fp16_act = activations.scalar_type() == at::ScalarType::Half;
 #define LAUNCH_W4A16(Policy)                                                                  \
   do {                                                                                        \
@@ -267,6 +277,7 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
             gemm_n,                                                                           \
             gemm_k,                                                                           \
             rows_per_expert.data_ptr<int>(),                                                  \
+            total_m,                                                                          \
             static_cast<int>(n_experts),                                                      \
             static_cast<int>(group_size),                                                     \
             atomic_buffer.data_ptr<int>());                                                   \
@@ -282,6 +293,7 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
             gemm_n,                                                                           \
             gemm_k,                                                                           \
             rows_per_expert.data_ptr<int>(),                                                  \
+            total_m,                                                                          \
             static_cast<int>(n_experts),                                                      \
             static_cast<int>(group_size),                                                     \
             atomic_buffer.data_ptr<int>());                                                   \
@@ -299,6 +311,7 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
             gemm_n,                                                                           \
             gemm_k,                                                                           \
             rows_per_expert.data_ptr<int>(),                                                  \
+            total_m,                                                                          \
             static_cast<int>(n_experts),                                                      \
             static_cast<int>(group_size),                                                     \
             atomic_buffer.data_ptr<int>());                                                   \
@@ -314,6 +327,7 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
             gemm_n,                                                                           \
             gemm_k,                                                                           \
             rows_per_expert.data_ptr<int>(),                                                  \
+            total_m,                                                                          \
             static_cast<int>(n_experts),                                                      \
             static_cast<int>(group_size),                                                     \
             atomic_buffer.data_ptr<int>());                                                   \
@@ -321,25 +335,34 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
     }                                                                                         \
   } while (0)
 
-#define DISPATCH_W4A16_POLICY()                 \
-  do {                                          \
-    switch (policy_id) {                        \
-      case 0:                                   \
-        LAUNCH_W4A16(w4a16_policy_m_8_n_64);    \
-        break;                                  \
-      case 1:                                   \
-        LAUNCH_W4A16(w4a16_policy_m_16_n_64);   \
-        break;                                  \
-      case 2:                                   \
-        LAUNCH_W4A16(w4a16_policy_m_32_n_64);   \
-        break;                                  \
-      case 3:                                   \
-        LAUNCH_W4A16(w4a16_policy_m_64_n_128);  \
-        break;                                  \
-      case 4:                                   \
-        LAUNCH_W4A16(w4a16_policy_m_128_n_128); \
-        break;                                  \
-    }                                           \
+#define DISPATCH_W4A16_POLICY()                            \
+  do {                                                     \
+    switch (policy_id) {                                   \
+      case 0:                                              \
+        LAUNCH_W4A16(w4a16_launch_policy_m_8_n_64);        \
+        break;                                             \
+      case 1:                                              \
+        LAUNCH_W4A16(w4a16_launch_policy_m_16_n_64);       \
+        break;                                             \
+      case 2:                                              \
+        LAUNCH_W4A16(w4a16_launch_policy_m_32_n_64);       \
+        break;                                             \
+      case 3:                                              \
+        LAUNCH_W4A16(w4a16_launch_policy_m_64_n_128);      \
+        break;                                             \
+      case 4:                                              \
+        LAUNCH_W4A16(w4a16_launch_policy_m_64_n_128_skip); \
+        break;                                             \
+      case 5:                                              \
+        LAUNCH_W4A16(w4a16_launch_policy_m_64_n_256);      \
+        break;                                             \
+      case 6:                                              \
+        LAUNCH_W4A16(w4a16_launch_policy_m_64_n_256_skip); \
+        break;                                             \
+      case 7:                                              \
+        LAUNCH_W4A16(w4a16_launch_policy_m_128_n_128);     \
+        break;                                             \
+    }                                                      \
   } while (0)
 
 #ifdef USE_MOE_JIT
@@ -360,6 +383,7 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
             gemm_n,
             gemm_k,
             rows_per_expert.data_ptr<int>(),
+            total_m,
             static_cast<int>(n_experts),
             static_cast<int>(group_size),
             atomic_buffer.data_ptr<int>(),

--- a/src/sycl/GroupGemmW4A16Xe20.cpp
+++ b/src/sycl/GroupGemmW4A16Xe20.cpp
@@ -95,7 +95,6 @@ DECLARE_W4A16_POLICY(w4a16_launch_policy_m_64_n_128)
 DECLARE_W4A16_POLICY(w4a16_launch_policy_m_64_n_128_skip)
 DECLARE_W4A16_POLICY(w4a16_launch_policy_m_64_n_256)
 DECLARE_W4A16_POLICY(w4a16_launch_policy_m_64_n_256_skip)
-DECLARE_W4A16_POLICY(w4a16_launch_policy_m_128_n_128)
 
 #undef DECLARE_W4A16_POLICY
 #undef DECLARE_W4A16_EXTERN
@@ -358,9 +357,6 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_w4a16(
         break;                                             \
       case 6:                                              \
         LAUNCH_W4A16(w4a16_launch_policy_m_64_n_256_skip); \
-        break;                                             \
-      case 7:                                              \
-        LAUNCH_W4A16(w4a16_launch_policy_m_128_n_128);     \
         break;                                             \
     }                                                      \
   } while (0)

--- a/src/sycl/GroupGemmW4A16Xe20LauncherInstance.cpp.in
+++ b/src/sycl/GroupGemmW4A16Xe20LauncherInstance.cpp.in
@@ -5,7 +5,15 @@
 #include <sycl/sycl.hpp>
 #include <sycl/ext/intel/experimental/grf_size_properties.hpp>
 
-#include "sycl/kernels/moe/xe20/w4a16/gemm_xe2_policy.hpp"
+#include "sycl/kernels/moe/xe20/w4a16_launch_policy.hpp"
+
+// Keep the imported fmha-cri kernel source byte-identical while making its
+// unqualified detail:: lookup robust in translation units that include
+// PyTorch's global ::detail namespace.
+namespace moe_w4a16 {
+namespace detail = cute::detail;
+}
+
 #include "sycl/kernels/moe/xe20/w4a16/grouped_gemm_xe2.hpp"
 
 namespace moe_w4a16 {
@@ -35,6 +43,7 @@ void MoEGEMMLauncher(
         const int gemm_n,
         const int gemm_k,
         const int* rows_per_expert,
+        const int total_rows,
         const int num_experts,
         const int group_size,
         int32_t* atomic_buffer) {
@@ -69,7 +78,19 @@ void MoEGEMMLauncher(
         sycl::local_accessor<int32_t, 1> local_mem(sycl::range<1>(1), cgh);
         cgh.parallel_for<GemmCuteName<ElementA, ElementB, ElementS, ElementD, HasZero, layoutA, layoutB, policy>>(
                 sycl::nd_range<3>{global * local, local}, kernel_props, [=](auto) {
-            moe_w4a16::MoEGEMM<GmemTiledCopyA, GmemTiledCopyB, GmemTiledCopyD, layoutA, layoutB, 'R', HasZero>(
+            moe_w4a16::MoEGEMM<
+                    GmemTiledCopyA,
+                    GmemTiledCopyB,
+                    GmemTiledCopyD,
+                    layoutA,
+                    layoutB,
+                    'R',
+                    HasZero,
+                    policy::StealChunk,
+                    policy::PrefetchDist,
+                    policy::MainloopBarrier,
+                    policy::RowExtend,
+                    policy::SkipPaddedN>(
                     activations,
                     weights,
                     scales,
@@ -78,6 +99,7 @@ void MoEGEMMLauncher(
                     outputs,
                     mma,
                     rows_per_expert,
+                    total_rows,
                     num_experts,
                     group_size,
                     gemm_n,
@@ -100,6 +122,7 @@ void w4a16_launch(
         const int gemm_n,
         const int gemm_k,
         const int* rows_per_expert,
+        const int total_rows,
         const int num_experts,
         const int group_size,
         int32_t* atomic_buffer) {
@@ -116,6 +139,7 @@ void w4a16_launch(
                 gemm_n,
                 gemm_k,
                 rows_per_expert,
+                total_rows,
                 num_experts,
                 group_size,
                 atomic_buffer);
@@ -146,6 +170,7 @@ void moe_w4a16::w4a16_launch<moe_w4a16::@POLICY@, @ELEMENT_S@, @ELEMENT_A@>(
     const int*,
     const int,
     const int,
+    const int,
     int32_t*);
 
 #ifdef SGL_W4A16_JIT_ENTRY
@@ -162,6 +187,7 @@ extern "C" __attribute__((visibility("default"))) void sgl_moe_w4a16_entry(
     int gemm_n,
     int gemm_k,
     const int* rows_per_expert,
+    int total_rows,
     int num_experts,
     int group_size,
     int* atomic_buffer) {
@@ -176,6 +202,7 @@ extern "C" __attribute__((visibility("default"))) void sgl_moe_w4a16_entry(
       gemm_n,
       gemm_k,
       rows_per_expert,
+      total_rows,
       num_experts,
       group_size,
       atomic_buffer);

--- a/src/sycl/kernels/moe/xe20/w4a16/gemm_xe2.hpp
+++ b/src/sycl/kernels/moe/xe20/w4a16/gemm_xe2.hpp
@@ -41,6 +41,7 @@
 #include "cutlass/kernel_hardware_info.h"
 #include "cutlass/platform/platform.h"
 #include "cutlass/tensor_ref.h"
+#include "mxfp4_dequant.hpp"
 
 #pragma clang diagnostic ignored "-Wpass-failed"
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -223,12 +224,28 @@ CUTE_DEVICE void xe_gemm(
   copy(copy_c, tCrC_out, tCgC);
 }
 
+// A view of `Blocks` M-blocks of a (V, M, ...) register fragment, starting at
+// M-block `First`. The M mode of an A or C fragment is the dpas atom's 8-row
+// block, so a view is what lets one gemm() cover a row range that is a whole
+// number of blocks -- there is no way to give dpas a partial block.
+// Non-const on purpose: a view built from a `Tensor const&` carries a const
+// element type, and dpas writes its accumulator.
+template <int First, int Blocks, class Engine, class Layout>
+CUTE_DEVICE auto m_block_view(Tensor<Engine, Layout>& t) {
+  static_assert(rank(Layout{}) == 3, "an A/C subgroup fragment is (V, M, K|N)");
+  auto layout = make_layout(get<0>(t.layout()), make_layout(Int<Blocks>{}, stride<1>(t.layout())), get<2>(t.layout()));
+  return make_tensor(t.data() + First * stride<1>(t.layout()), layout);
+}
+
 template <
     class GmemTiledCopyA,
     class GmemTiledCopyB,
     class GmemTiledCopyC,
     int GroupSize,
     bool HasZero,
+    int PrefetchDist,
+    bool MainloopBarrier,
+    bool SkipPaddedN,
     class ATensor,
     class BTensor,
     class DTensor,
@@ -296,7 +313,11 @@ CUTE_DEVICE void xe_gemm_4bits(
   auto pAgA = thr_prefetch_A.partition_S(gA);
   auto pBgB = thr_prefetch_B.partition_S(gB);
 
-  const int prefetch_dist = 6;
+  // Keep this a plain const int, in this position: the mainloop's IGC schedule is
+  // sensitive to the shape of the prologue, and reordering even one declaration in
+  // it costs 1.4-8.3% (worst on the short-M tiles).
+  static_assert(PrefetchDist > 0, "prefetch distance must be positive");
+  const int prefetch_dist = PrefetchDist;
 
   constexpr SPIRVScope barrier_scope = ScopeWorkgroup;
 
@@ -329,18 +350,149 @@ CUTE_DEVICE void xe_gemm_4bits(
   scaleStoreType scales[thr_N * channel_num];
   conditional_t<HasZero, TA, uint8_t> zeros[thr_N * channel_num];
 
+  // Where each (n, channel) slot gathers its group scales from, i.e. the start of
+  // its B column inside this expert's scale matrix. The N direction is tiled to a
+  // BLK_N multiple, so the last tile of an expert whose N is not a multiple can
+  // hold columns that do not exist; their scales are clamped to the last real
+  // column, because past the last expert they would be past the whole array.
+  // (The clamped columns are not stored: the D copy is bounds-checked.)
+  // Carried as pointers, not as (base, index) pairs: consecutive gathers always
+  // advance by one group, so the loop pays one 64-bit add per slot instead of the
+  // int add + widen + 64-bit add IGC needs to rebuild `Scales[offset + group_idx]`
+  // from scratch every k-tile.
+  const int scale_col_bound = size<0>(B.shape()) - 1;
+  const ElementS* scale_ptr[thr_N * channel_num];
+  const ElementS* zero_ptr[HasZero ? thr_N * channel_num : 1];
+  CUTLASS_PRAGMA_UNROLL
+  for (int n = 0; n < thr_N; ++n) {
+    CUTLASS_PRAGMA_UNROLL
+    for (int c = 0; c < channel_num; ++c) {
+      const int col = n_tile_start + n_sg_start + n * sg_local_range + x_idx + c * (sg_local_range / channel_num);
+      const int offset = cute::min(col, scale_col_bound) * group_num;
+      scale_ptr[n * channel_num + c] = Scales + offset;
+      if constexpr (HasZero) {
+        zero_ptr[n * channel_num + c] = Zeros + offset;
+      }
+    }
+  }
+
+  // Whether to prefetch the next group's scales. They are one E8M0 byte per B
+  // column per group, so a whole subgroup's worth is 16-32 B: the 2D-block
+  // prefetch below costs a message and a k-loop test to fetch what the gather
+  // will pull into L1 anyway one k-tile later. Off is worth ~3%.
+  //
+  // It is also not safe as written. The prefetch covers SG_N columns starting at
+  // this subgroup's first one, so on the last tile of the last expert it reads
+  // past the end of the scale array -- with a 2D-block message, past what the
+  // clamp above can fix. That is a device fault, not a wrong answer, and it only
+  // shows up when the allocation ends exactly at the array (E=128, N=768,
+  // K=2880). The bound test below is the fix if this is ever turned back on.
+  static constexpr bool kScalePrefetch = false;
+  static constexpr int kScalePrefetchSlop = 64;
+  const int scale_prefetch_bound = (scale_col_bound + 1) * group_num - kScalePrefetchSlop;
+
+  // MXFP4 without zero points is dequantized inside the E2M1 -> BF16 reorder,
+  // which ends in a multiply anyway; see mxfp4_dequant.hpp. Everything else needs
+  // the separate pass over the B fragment further down.
+  static constexpr bool kFuseDequant = std::is_same_v<TB, float_e2m1_t> && std::is_same_v<TA, bfloat16_t> && !HasZero;
+
+  // The multipliers a reorder chunk needs, from the chunk's first value index:
+  // the fragment's innermost mode alternates between the two columns a work-item
+  // covers (channels), and so between their two group scales, while a whole
+  // 8-value chunk stays inside one n-block.
+  using BFragLayout = decltype(tCrB.layout());
+  static constexpr int frag_mode0 = size<0>(tCrB.shape());
+  intel::vector_t<float, 2> mul_pairs[kFuseDequant ? thr_N : 1];
+  auto mul_of = [&](auto dv) -> intel::vector_t<float, 2> const& {
+    constexpr int n = (decltype(dv)::value / frag_mode0) % thr_N;
+    return mul_pairs[n];
+  };
+  if constexpr (kFuseDequant) {
+    static_assert(channel_num == 2, "the folded multiply covers exactly two channels");
+    static_assert(std::is_same_v<scaleStoreType, float>, "the folded multiply takes f32 multipliers");
+    // ((channel, x), n, k):((1, channel), mode0, ...) -- the n mode carries a zero
+    // stride when it is degenerate, which the index above handles.
+    static_assert(
+        stride<0, 0>(BFragLayout{}) == 1 && stride<0, 1>(BFragLayout{}) == channel_num &&
+            (thr_N == 1 || stride<1>(BFragLayout{}) == frag_mode0),
+        "the folded dequant needs a channel-innermost B fragment with n above mode 0");
+    static_assert(frag_mode0 % 8 == 0, "an 8-value reorder chunk must stay inside one n-block");
+  }
+
   clear(tCrC);
 
   using ElementB = typename BTensor::element_type;
   static constexpr bool is_B_fp8_type =
       std::is_same_v<ElementB, cutlass::float_e5m2_t> || std::is_same_v<ElementB, cutlass::float_e4m3_t>;
 
+  // How many of this subgroup's 8-row dpas blocks hold rows that exist.
+  //
+  // A tile spans tile_m rows of the expert's A/D slice, but an expert's last tile
+  // is partial, and that is where nearly all of this kernel's lost throughput
+  // lives: on the gpt-oss-120b l0 histogram (128 experts, 16384 rows) 23% of the
+  // dpas work at BLK_M = 64 is on rows past the end of an expert.
+  //
+  // Skipping the padded blocks costs nothing else: the tile keeps its shape, so B
+  // is loaded and dequantized exactly once per k-tile as it is for a full tile
+  // (which is why a narrower tile loses instead -- see the tile registry), and the
+  // D store was already bounds-checked and never wrote those rows.
+  //
+  // Only for a tile whose work-group is one M subgroup wide (ATOM_M == 1, which is
+  // every tile the production dispatch selects), and only for a subgroup tile that
+  // holds more than one dpas M block: at SG_M = 8 (the decode tile) a live tile
+  // always has its one block live, so the predicate can never fire and all that is
+  // left of it is a branch the compiler cannot fold.
+  static constexpr int kMBlocks = size<1>(tCrA.shape());
+  static constexpr int kMBlockRows = SG_M / kMBlocks;
+  static_assert(kMBlocks * kMBlockRows == SG_M, "the M mode of the A fragment must tile SG_M");
+  static constexpr bool kSkipPaddedM = ATOM_M == 1 && kMBlocks > 1;
+  const int sg_m_row0 = (cutlass::get_sub_group_id() / ATOM_N) * SG_M;
+  const int sg_m_blocks = cute::max(
+      0, cute::min(kMBlocks, ceil_div(int(size<0>(C.shape())) - int(wg_m) * int(tile_m) - sg_m_row0, kMBlockRows)));
+
+  // The other side of the padding: a work-group tile is a whole BLK_N wide, so an
+  // expert whose N is not a multiple of it -- gpt-oss GEMM2 is N = 2880 against
+  // BLK_N = 128 -- ends with subgroups whose columns are all past the end of D.
+  // Those subgroups have nothing to store (the D copy is bounds-checked and never
+  // wrote those columns), so they skip the mainloop's loads, dequant, dpas and
+  // epilogue, and leave their issue slots, their share of the L1 and their share of
+  // the XMX array to the subgroups that do have work. The work-stealing loop is
+  // outside this function and every subgroup still reaches it, so this cannot
+  // deadlock.
+  //
+  // The skip is not free, and whether it pays is a property of the shape: a skipped
+  // subgroup drops its share of the prefetch with it (make_block_2d_prefetch is
+  // sliced by the work-item id, so the WG's A and B tile prefetches are partitioned
+  // across all of its subgroups and the live ones then miss on the lines the dead
+  // one would have fetched), and the `sg_alive` branch itself costs codegen even
+  // where nothing is ever skipped. Hence the shape rule in want_nskip().
+  //
+  // The M skip above cannot leave a subgroup dead -- it needs ATOM_M == 1, and then
+  // the subgroup owning row 0 is the only one there is and always has a live block
+  // -- so only the N skip appears here.
+  static constexpr bool kSkipPaddedN = SkipPaddedN;
+  const bool sg_alive = !kSkipPaddedN || n_tile_start + n_sg_start < int(size<1>(C.shape()));
+
+  // Whether the policy's per-k-tile split barrier request (MainloopBarrier, see
+  // gemm_xe2_policy.hpp) can actually be honoured. A split barrier is only legal if
+  // *every* subgroup of the work-group reaches it, and a subgroup that finds
+  // `sg_alive` false runs no k-loop, so the ones that do would wait on an arrive
+  // that never comes and the work-group hangs. Whether the N skip fires is a
+  // run-time property, so the compile-time test has to be the template bit itself.
+  static constexpr bool kMainloopBarrier = MainloopBarrier && !kSkipPaddedN;
+
   auto prefetch_scale_group = [&](int scale_k_tile) {
+    if constexpr (!kScalePrefetch) {
+      return;
+    }
     if (scale_k_tile >= k_tile_count || scale_k_tile * tile_k % group_size != 0) {
       return;
     }
 
     int scale_group_idx = scale_k_tile * tile_k / group_size;
+    if ((n_tile_start + n_sg_start + SG_N - 1) * group_num + scale_group_idx > scale_prefetch_bound) {
+      return;
+    }
     auto next_scales_tensor = make_tensor(
         make_gmem_ptr(
             reinterpret_cast<const ElementS*>(Scales + (n_tile_start + n_sg_start) * group_num + scale_group_idx)),
@@ -351,6 +503,13 @@ CUTE_DEVICE void xe_gemm_4bits(
     prefetch(prefetch_scales, pSgS(_, 0, 0));
   };
 
+  // No columns: no mainloop at all -- not even the prefetch -- and no epilogue
+  // either. Hoisted out of the k-loop rather than tested in it, so the loop the
+  // compiler schedules is the one a live subgroup runs.
+  if (!sg_alive) {
+    return;
+  }
+
   CUTE_UNROLL
   for (; k_tile_prefetch < prefetch_dist; k_tile_prefetch++) {
     prefetch(prefetch_a, pAgA(_, _, _, k_tile_prefetch));
@@ -359,35 +518,50 @@ CUTE_DEVICE void xe_gemm_4bits(
   }
 
   for (int k_tile = 0; k_tile < k_tile_count; k_tile++, k_tile_prefetch++) {
-    barrier_arrive(barrier_scope);
+    if constexpr (kMainloopBarrier) {
+      barrier_arrive(barrier_scope);
+    }
 
     copy(copy_a, tAgA(_, _, _, k_tile), tArA);
     copy(copy_b, tBgB(_, _, _, k_tile), tBrB);
 
     if (k_tile * tile_k % group_size == 0) {
-      int group_idx = (k_tile * tile_k) / group_size;
-
       CUTLASS_PRAGMA_UNROLL
       for (int n = 0; n < thr_N; ++n) {
         CUTLASS_PRAGMA_UNROLL
         for (int c = 0; c < channel_num; ++c) {
-          int real_idx = x_idx + c * (sg_local_range / channel_num);
-          int sg_local_n = n * sg_local_range + real_idx;
+          const int slot = n * channel_num + c;
+          const ElementS* sp = scale_ptr[slot];
+          scale_ptr[slot] = sp + 1;
+          const ElementS* zp = nullptr;
+          if constexpr (HasZero) {
+            zp = zero_ptr[slot];
+            zero_ptr[slot] = zp + 1;
+          }
           scaleStoreType scale;
           if constexpr (std::is_same_v<TB, int4_t>) {
-            scale = Scales[(n_tile_start + n_sg_start + sg_local_n) * group_num + group_idx];
+            scale = sp[0];
           } else if constexpr (std::is_same_v<TB, uint4_t>) {
-            int idx = (n_tile_start + n_sg_start + sg_local_n) * group_num + group_idx;
-            scale = static_cast<scaleStoreType>(Scales[idx]);
+            scale = static_cast<scaleStoreType>(sp[0]);
             if constexpr (HasZero) {
-              zeros[n * channel_num + c] = static_cast<TA>(Zeros[idx]);
+              zeros[slot] = static_cast<TA>(zp[0]);
             }
           } else if constexpr (std::is_same_v<TB, float_e2m1_t>) {
-            uint32_t scale_u32 = Scales[(n_tile_start + n_sg_start + sg_local_n) * group_num + group_idx] << 23;
-            scale = static_cast<scaleStoreType>(reinterpret_cast<float&>(scale_u32));
+            const uint32_t e8m0 = static_cast<uint32_t>(sp[0]);
+            if constexpr (kFuseDequant) {
+              // Folded into the reorder's own multiply, so it carries the
+              // conversion constant and the 2^-kFoldShift bias with it.
+              scale = mxfp4_fold_multiplier(e8m0);
+            } else {
+              uint32_t scale_u32 = e8m0 << 23;
+              scale = static_cast<scaleStoreType>(reinterpret_cast<float&>(scale_u32));
+            }
           }
 
-          scales[n * channel_num + c] = scale;
+          scales[slot] = scale;
+          if constexpr (kFuseDequant) {
+            mul_pairs[n][c] = scale;
+          }
         }
       }
     }
@@ -399,10 +573,14 @@ CUTE_DEVICE void xe_gemm_4bits(
     prefetch_scale_group(k_tile_prefetch);
 
     reorder(tArA, tCrA);
-    reorder(tBrB, tCrB);
+    if constexpr (kFuseDequant) {
+      mxfp4_reorder_dequant(tBrB, tCrB, mul_of);
+    } else {
+      reorder(tBrB, tCrB);
+    }
 
     CUTLASS_PRAGMA_UNROLL
-    for (int n = 0; n < thr_N; ++n) {
+    for (int n = 0; n < thr_N && !kFuseDequant; ++n) {
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < channel_num; ++c) {
         CUTLASS_PRAGMA_UNROLL
@@ -426,9 +604,47 @@ CUTE_DEVICE void xe_gemm_4bits(
       }
     }
 
-    cute::gemm(mma, tCrA, tCrB, tCrC);
+    if constexpr (kSkipPaddedM) {
+      if (sg_m_blocks == kMBlocks) {
+        cute::gemm(mma, tCrA, tCrB, tCrC);
+      } else {
+        // One gemm over the whole valid block range, picked by an equality test on
+        // a subgroup-uniform, loop-invariant count. Predicating each block
+        // separately instead costs far more than the dpas it saves: the branch
+        // between two blocks is a basic-block boundary, so what should be one run
+        // of independent dpas becomes a chain of dependent pairs, and the penalty
+        // grows with the block count. Measured cost of one partial tile, in units
+        // of a full tile of the same shape (l0 GEMM1, 90 k-tiles, three full tiles
+        // alongside it so the launch is not bandwidth-bound):
+        //
+        //   valid blocks   1     2     4     6     7     8
+        //   per block    0.803 0.830 0.915 1.220 1.292 1.000
+        //   one range    0.79 (a single range at 6 blocks measures 0.808)
+        //
+        // A 6-of-8 tile was *slower* than computing all eight. The floor near 0.79
+        // is the per-k-tile stream that does not depend on the block count (the A
+        // and B loads, the scale gather, the prefetches, the two reorders); no
+        // predication can go below it, which is why the histogram of tail blocks --
+        // 59 of 128 l0 experts land on 5, 6 or 7 -- decides whether the skip pays.
+        for_each(make_int_sequence<kMBlocks - 1>{}, [&](auto mb) {
+          constexpr int blocks = decltype(mb)::value + 1;
+          if (sg_m_blocks == blocks) {
+            cute::gemm(mma, m_block_view<0, blocks>(tCrA), tCrB, m_block_view<0, blocks>(tCrC));
+          }
+        });
+      }
+    } else {
+      cute::gemm(mma, tCrA, tCrB, tCrC);
+    }
 
-    barrier_wait(barrier_scope);
+    if constexpr (kMainloopBarrier) {
+      barrier_wait(barrier_scope);
+    }
+  }
+
+  // Every product carried a 2^-kFoldShift from the folded multiplier.
+  if constexpr (kFuseDequant) {
+    mxfp4_unfold(tCrC);
   }
 
   if (Bias != nullptr) {

--- a/src/sycl/kernels/moe/xe20/w4a16/gemm_xe2_policy.hpp
+++ b/src/sycl/kernels/moe/xe20/w4a16/gemm_xe2_policy.hpp
@@ -45,6 +45,48 @@ class xe_gemm_policy_base {
   using GmemTiledCopyA = void;
   using GmemTiledCopyB = void;
   using GmemTiledCopyD = void;
+
+  // Whether the mainloop takes a split barrier per k-tile. The mainloop shares
+  // nothing through SLM, so the barrier is not a correctness requirement: it is a
+  // scheduling device, holding the work-group's subgroups together so their loads
+  // stay in the same k window and hit in L1 instead of drifting apart. Upstream
+  // takes it unconditionally; whether it pays is per tile
+  // (w4a16_tile_wants_barrier).
+  static constexpr bool MainloopBarrier = true;
+};
+
+// Which tiles want the mainloop barrier. A tile whose work-group spans several M
+// subgroups needs it -- its subgroups sit on different rows and drift apart without
+// it. A one-subgroup-deep tile does not, except at 32x64.
+constexpr bool w4a16_tile_wants_barrier(int BlkM, int BlkN, int SgCountM) {
+  if (SgCountM > 1) return true;
+  return BlkM == 32 && BlkN == 64;
+}
+
+// Generic (work-group tile, subgroup layout) pair, so a caller can pick the tile
+// that fits an expert's row count instead of padding up to the nearest policy in
+// the hand-written menu below. Every policy in that menu is expressible as one of
+// these; the tile registry in 16_bmg_moe_gemm.cpp instantiates them by name.
+//
+// BlkK is a parameter because it is the only knob that trades the A fragment's
+// register footprint against loop overhead. A subgroup holds SG_M*BlkK bf16 of A
+// (SG_M*BlkK/32 registers) and SG_M*SG_N/16 floats of C. It cannot go below 16,
+// the bf16 DPAS K, and it cannot go above the quantization group, because the
+// mainloop gathers one scale per B column per k-tile.
+template <
+    int BlkM,
+    int BlkN,
+    int SgCountM,
+    int SgCountN,
+    int BlkK = 32,
+    bool Barrier = w4a16_tile_wants_barrier(BlkM, BlkN, SgCountM)>
+class w4a16_tile : public xe_gemm_policy_base {
+ public:
+  static_assert(BlkK == 32 || BlkK == 16, "BLK_K must be one MXFP4 group (32) or one bf16 DPAS K (16)");
+  using WGTile = Shape<Int<BlkM>, Int<BlkN>, Int<BlkK>>;
+  using SGLayout = Layout<Shape<Int<SgCountM>, Int<SgCountN>, _1>, Stride<Int<SgCountN>, _1, _0>>;
+
+  static constexpr bool MainloopBarrier = Barrier;
 };
 
 // Policy menu. Every policy keeps the *per-subgroup* tile at 32x32: the 4-bit

--- a/src/sycl/kernels/moe/xe20/w4a16/grouped_gemm_xe2.hpp
+++ b/src/sycl/kernels/moe/xe20/w4a16/grouped_gemm_xe2.hpp
@@ -64,6 +64,11 @@ template <
     char LayoutKindB,
     char LayoutKindD,
     bool HasZero,
+    int StealChunk,
+    int PrefetchDist,
+    bool MainloopBarrier,
+    bool RowExtend,
+    bool SkipPaddedN,
     class TiledMMA,
     typename ElementA,
     typename ElementB,
@@ -79,6 +84,9 @@ CUTE_DEVICE void MoEGEMM(
     ElementD* Outputs,
     TiledMMA const& mma,
     const int* rows_per_expert,
+    // Total rows in Activations/Outputs, i.e. the bound past which the A surface
+    // must not be extended. Pass 0 to disable the extension entirely.
+    const int32_t total_rows,
     const int32_t num_experts,
     const int32_t group_size,
     const int32_t gemm_n,
@@ -86,6 +94,9 @@ CUTE_DEVICE void MoEGEMM(
     int32_t* atomic_buffer,
     const sycl::local_accessor<int32_t, 1>& slm_mem_const) {
   constexpr char actual_layout_of_B = LayoutKindB ^ ('R' ^ 'C');
+  // The surface extensions below only keep the addressing intact for row-major
+  // slices, whose stride does not carry the row count.
+  static_assert(LayoutKindA == 'R' && actual_layout_of_B == 'R', "surface extension needs row-major A and B");
   static constexpr bool is_B_int4 = (std::is_same_v<ElementB, uint8_t>) && (!std::is_same_v<ElementS, uint8_t>);
   static constexpr bool is_B_mxfp4 = (std::is_same_v<ElementB, uint8_t>) && (std::is_same_v<ElementS, uint8_t>);
   static constexpr bool is_B_4bits = std::is_same_v<ElementB, uint8_t>;
@@ -112,6 +123,10 @@ CUTE_DEVICE void MoEGEMM(
 
   int pre_rows = 0;
   int pre_tiles = 0;
+  // Tiles of the current steal still to run before the next atomic. StealChunk == 1
+  // is upstream: one atomic per tile, and this counter folds away.
+  static_assert(StealChunk >= 1, "work-stealing chunk must be positive");
+  int steal_tiles_left = 0;
 
   int32_t* slm_mem = static_cast<int32_t*>(slm_mem_const.template get_multi_ptr<sycl::access::decorated::no>().get());
 
@@ -147,21 +162,41 @@ CUTE_DEVICE void MoEGEMM(
       ptr_Bias_curr_batch = const_cast<ElementBI*>(Bias) + expert_id * gemm_n;
     }
 
-    auto A_tensor = make_moe_tensor<ElementA, LayoutKindA>(ptr_A_curr_batch, gemm_m, gemm_k);
+    // A 2D-block load whose block crosses the surface's last row costs far more
+    // than the rows it discards, so a tile whose block is not filled by the
+    // surface pays that on every k-tile. Both surfaces are slices of a larger
+    // buffer -- the rows past an expert's A are the next expert's rows, the rows
+    // past its B are the next expert's weights -- so the rows are real memory:
+    // give each surface a tile-aligned height and let the edge tiles read them.
+    // Nothing extra is computed (the tile spans those rows either way) and no
+    // extra result is written, because D keeps the true row and column counts.
+    // The last expert has nothing after it, so it keeps its true height.
+    int a_rows = gemm_m;
+    int b_rows = gemm_n;
+    if constexpr (RowExtend)
+      if (total_rows > 0) {
+        const int padded_m = (gemm_m + wg_tile_m - 1) / wg_tile_m * wg_tile_m;
+        a_rows = cute::max(gemm_m, cute::min(padded_m, total_rows - pre_rows));
+        if (expert_id + 1 < num_experts) {
+          b_rows = (gemm_n + wg_tile_n - 1) / wg_tile_n * wg_tile_n;
+        }
+      }
+
+    auto A_tensor = make_moe_tensor<ElementA, LayoutKindA>(ptr_A_curr_batch, a_rows, gemm_k);
     auto B_tensor = [&]() {
       if constexpr (is_B_int4) {
         if constexpr (HasZero) {
           return make_moe_tensor<uint4_t, actual_layout_of_B>(
-              reinterpret_cast<uint4_t*>(ptr_B_curr_batch), gemm_n, gemm_k);
+              reinterpret_cast<uint4_t*>(ptr_B_curr_batch), b_rows, gemm_k);
         } else {
           return make_moe_tensor<int4_t, actual_layout_of_B>(
-              reinterpret_cast<int4_t*>(ptr_B_curr_batch), gemm_n, gemm_k);
+              reinterpret_cast<int4_t*>(ptr_B_curr_batch), b_rows, gemm_k);
         }
       } else if constexpr (is_B_mxfp4) {
         return make_moe_tensor<float_e2m1_t, actual_layout_of_B>(
-            reinterpret_cast<float_e2m1_t*>(ptr_B_curr_batch), gemm_n, gemm_k);
+            reinterpret_cast<float_e2m1_t*>(ptr_B_curr_batch), b_rows, gemm_k);
       } else {
-        return make_moe_tensor<ElementB, actual_layout_of_B>(ptr_B_curr_batch, gemm_n, gemm_k);
+        return make_moe_tensor<ElementB, actual_layout_of_B>(ptr_B_curr_batch, b_rows, gemm_k);
       }
     }();
     auto D_tensor = make_moe_tensor<ElementD, LayoutKindD>(ptr_D_curr_batch, gemm_m, gemm_n);
@@ -172,15 +207,23 @@ CUTE_DEVICE void MoEGEMM(
       auto tile_coord = make_coord(m_coord, n_coord, _, 0);
 
       if constexpr (is_B_4bits) {
-#define XE_GEMM_4BITS_CALLER(GroupSize)                                              \
-  xe_gemm_4bits<GmemTiledCopyA, GmemTiledCopyB, GmemTiledCopyD, GroupSize, HasZero>( \
-      A_tensor,                                                                      \
-      B_tensor,                                                                      \
-      ptr_Scales_curr_batch,                                                         \
-      ptr_Zeros_curr_batch,                                                          \
-      ptr_Bias_curr_batch,                                                           \
-      D_tensor,                                                                      \
-      tile_coord,                                                                    \
+#define XE_GEMM_4BITS_CALLER(GroupSize) \
+  xe_gemm_4bits<                        \
+      GmemTiledCopyA,                   \
+      GmemTiledCopyB,                   \
+      GmemTiledCopyD,                   \
+      GroupSize,                        \
+      HasZero,                          \
+      PrefetchDist,                     \
+      MainloopBarrier,                  \
+      SkipPaddedN>(                     \
+      A_tensor,                         \
+      B_tensor,                         \
+      ptr_Scales_curr_batch,            \
+      ptr_Zeros_curr_batch,             \
+      ptr_Bias_curr_batch,              \
+      D_tensor,                         \
+      tile_coord,                       \
       mma);
         if (group_size == 32) {
           XE_GEMM_4BITS_CALLER(32)
@@ -197,11 +240,20 @@ CUTE_DEVICE void MoEGEMM(
             A_tensor, B_tensor, ptr_Scales_curr_batch, ptr_Bias_curr_batch, D_tensor, tile_coord, mma);
       }
 
-      if (local_id == 0) {
-        slm_mem[0] = cutlass::atomicAdd(atomic_buffer, 1);
+      // Work stealing in chunks of StealChunk tiles: one atomic per chunk instead
+      // of one per tile, and a chunk's tiles are consecutive in the tile order, so
+      // they share their A rows. At StealChunk == 1 this is upstream's loop.
+      if (steal_tiles_left > 0) {
+        ++group_id;
+        --steal_tiles_left;
+      } else {
+        if (local_id == 0) {
+          slm_mem[0] = cutlass::atomicAdd(atomic_buffer, StealChunk);
+        }
+        item.barrier(sycl::access::fence_space::local_space);
+        group_id = group_range + slm_mem[0];
+        steal_tiles_left = StealChunk - 1;
       }
-      item.barrier(sycl::access::fence_space::local_space);
-      group_id = group_range + slm_mem[0];
       group_m_id = (group_id * wg_tile_n) / gemm_n_pad;
     }
     pre_rows = cumsum_rows_for_experts;

--- a/src/sycl/kernels/moe/xe20/w4a16/mxfp4_dequant.hpp
+++ b/src/sycl/kernels/moe/xe20/w4a16/mxfp4_dequant.hpp
@@ -1,0 +1,198 @@
+/***************************************************************************************************
+ * Copyright (C) 2025 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#pragma once
+
+// MXFP4 dequantization fused into the E2M1 -> BF16 subgroup reorder.
+//
+// cute's E2M1 -> BF16 reorder ends in one multiply per output register, by the
+// constant 2^126 that compensates where the 4-bit exponent lands after the bit
+// shuffling. Applying the E8M0 group scale afterwards costs much more than that
+// multiply: the scale of a value depends on which of two columns it belongs to,
+// which alternates between neighbouring values inside a work-item, so the scaling
+// pass walks the fragment one *element* at a time -- and because each element is
+// a separate variable, each one is a copy out of the fragment, a 16-wide
+// multiply, and a copy back.
+//
+// Folding the scale into the conversion's own multiply removes all of it. The
+// alternating columns cost execution size (8 sixteen-wide multiplies per chunk
+// instead of 4 thirty-two-wide ones) but nothing else: no extra instructions
+// beyond the conversion's own, and no copies, since the multiplies address the
+// fragment in place with a stride of two.
+//
+// The folded multiplier is 2^(126 - kFoldShift) * scale, so that it stays inside
+// the f32 range for E8M0 exponents up to 192 instead of only 128; the resulting
+// 2^-kFoldShift on every product is undone once on the accumulator after the
+// k-loop.
+
+#include <cute/algorithm/reorder.hpp>
+#include <cute/tensor.hpp>
+#include <cute/util/compat.hpp>
+#include <sycl/sycl.hpp>
+
+#include "cutlass/cutlass.h"
+
+namespace moe_w4a16 {
+
+using namespace cute;
+
+// Exponent headroom kept out of the folded multiplier, and undone on the
+// accumulator. Covers E8M0 exponents in [0, 192], i.e. scales up to 2^65.
+static constexpr int kFoldShift = 64;
+
+// f32 multiplier that converts *and* scales in one step, from an E8M0 byte.
+//
+// The parameter is uint32_t on purpose. The gather that feeds it is a
+// `load.ugm.d8u32`, which already zero-extends every byte into a dword, so a
+// uint8_t parameter makes IGC narrow the loaded dword back to a packed byte
+// register and re-widen it -- two exec-16 movs per gather that buy nothing, in a
+// loop where 19 slots is the whole margin between ALU-bound and DPAS-bound.
+CUTE_DEVICE float mxfp4_fold_multiplier(uint32_t e8m0) {
+  return sycl::bit_cast<float>((e8m0 + (126u - kFoldShift)) << 23);
+}
+
+// Undo kFoldShift on an accumulator fragment.
+template <class CTensor>
+CUTE_DEVICE void mxfp4_unfold(CTensor& tCrC) {
+  constexpr float unfold = kFoldShift == 64 ? 0x1p64f : 0x1p0f;
+  static_assert(kFoldShift == 64, "unfold constant must match kFoldShift");
+  CUTLASS_PRAGMA_UNROLL
+  for (int i = 0; i < tCrC.size(); ++i) {
+    tCrC(i) *= unfold;
+  }
+}
+
+// Tail of the E2M1 -> BF16 sequence with the group scale folded in: identical to
+// CUTE_XE_REORDER_E2M1_BF16_SEQ except that the conversion's constant multiplier
+// becomes the pair of per-lane multipliers in %3.
+//
+// A fragment register holds one value index of every work-item before it holds
+// the next (element = 16 * value + work_item), and a work-item's neighbouring
+// values alternate between the two columns it covers. So the two columns' group
+// scales split a register into its two contiguous halves -- which is exactly the
+// register layout of a per-lane float pair, and one multiply per register still
+// covers everything.
+#define MOE_E2M1_BF16_FOLDED_TAIL                                          \
+  ".decl OUT_W v_type=G type=W num_elts=128 alias=<%0,0>\n"                \
+  ".decl OUT_UD v_type=G type=UD num_elts=64 alias=<%0,0>\n"               \
+  ".decl OUT_BF v_type=G type=BF num_elts=128 alias=<%0,0>\n"              \
+  ".decl MULS_F v_type=G type=F num_elts=32 alias=<%3,0>\n"                \
+  "asr (M1_NM, 32) OUT_W(0,0)<1> OUT_W(0,0)<1;1,0> 6:uw\n"                 \
+  "asr (M1_NM, 32) OUT_W(1,0)<1> OUT_W(1,0)<1;1,0> 6:uw\n"                 \
+  "asr (M1_NM, 32) OUT_W(2,0)<1> OUT_W(2,0)<1;1,0> 6:uw\n"                 \
+  "asr (M1_NM, 32) OUT_W(3,0)<1> OUT_W(3,0)<1;1,0> 6:uw\n"                 \
+  "and (M1_NM, 32) OUT_UD(0,0)<1> OUT_UD(0,0)<1;1,0> 0x81C081C0:ud\n"      \
+  "and (M1_NM, 32) OUT_UD(2,0)<1> OUT_UD(2,0)<1;1,0> 0x81C081C0:ud\n"      \
+  "mul (M1_NM, 32) OUT_BF(0,0)<1> OUT_BF(0,0)<1;1,0> MULS_F(0,0)<1;1,0>\n" \
+  "mul (M1_NM, 32) OUT_BF(1,0)<1> OUT_BF(1,0)<1;1,0> MULS_F(0,0)<1;1,0>\n" \
+  "mul (M1_NM, 32) OUT_BF(2,0)<1> OUT_BF(2,0)<1;1,0> MULS_F(0,0)<1;1,0>\n" \
+  "mul (M1_NM, 32) OUT_BF(3,0)<1> OUT_BF(3,0)<1;1,0> MULS_F(0,0)<1;1,0>\n"
+
+// E2M1 -> BF16 reorder with the group scale folded into the conversion.
+template <ReorderKind Kind>
+CUTE_DEVICE void
+mxfp4_reorder_folded(intel::uchar4 const& src0, intel::ushort8& dst0, intel::vector_t<float, 2> const& muls) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(SYCL_INTEL_TARGET)
+  const uint32_t shifts = 0x0008000C;
+  if constexpr (Kind == ReorderKind::UU) {
+    asm("{\n"
+        ".decl IN_UB v_type=G type=UB num_elts=64 alias=<%1,0>\n"
+        ".decl OUT_UW v_type=G type=UW num_elts=128 alias=<%0,0>\n"
+        ".decl SHIFTS v_type=G type=UW num_elts=2 alias=<%2,0>\n"
+        "shl (M1_NM, 32) OUT_UW(0,0)<1> IN_UB(0,0)<1;2,0>  SHIFTS(0,0)<0;2,1>\n"
+        "shl (M1_NM, 32) OUT_UW(1,0)<1> IN_UB(0,16)<1;2,0> SHIFTS(0,0)<0;2,1>\n"
+        "shl (M1_NM, 32) OUT_UW(2,0)<1> IN_UB(0,32)<1;2,0> SHIFTS(0,0)<0;2,1>\n"
+        "shl (M1_NM, 32) OUT_UW(3,0)<1> IN_UB(0,48)<1;2,0> SHIFTS(0,0)<0;2,1>\n" MOE_E2M1_BF16_FOLDED_TAIL "}\n"
+        : "=rw"(dst0)
+        : "rw"(src0), "rw.u"(shifts), "rw"(muls));
+  } else {
+    static_assert(Kind == ReorderKind::VV, "unsupported E2M1 -> BF16 reorder kind for the folded dequant");
+    asm("{\n"
+        ".decl IN_UB v_type=G type=UB num_elts=64 alias=<%1,0>\n"
+        ".decl OUT_UW v_type=G type=UW num_elts=128 alias=<%0,0>\n"
+        ".decl SHIFTS v_type=G type=UW num_elts=2 alias=<%2,0>\n"
+        "shl (M1_NM, 32) OUT_UW(0,0)<1> IN_UB(0,0)<4;2,0> SHIFTS(0,0)<0;2,1>\n"
+        "shl (M1_NM, 32) OUT_UW(1,0)<1> IN_UB(0,1)<4;2,0> SHIFTS(0,0)<0;2,1>\n"
+        "shl (M1_NM, 32) OUT_UW(2,0)<1> IN_UB(0,2)<4;2,0> SHIFTS(0,0)<0;2,1>\n"
+        "shl (M1_NM, 32) OUT_UW(3,0)<1> IN_UB(0,3)<4;2,0> SHIFTS(0,0)<0;2,1>\n" MOE_E2M1_BF16_FOLDED_TAIL "}\n"
+        : "=rw"(dst0)
+        : "rw"(src0), "rw.u"(shifts), "rw"(muls));
+  }
+#endif
+}
+
+template <class T>
+struct reorder_kind_of;
+template <ReorderKind K, class S, class D>
+struct reorder_kind_of<Xe_Reorder<K, S, D>> {
+  static constexpr ReorderKind value = K;
+};
+
+// Subgroup-cooperative E2M1 -> BF16 reorder that also applies the group scale.
+// This is cute::reorder() / reorder_impl() with a folded-scale atom;
+// mul_of(dst_offset) supplies a chunk's two per-lane multipliers.
+template <class SEngine, class SLayoutWI, class SLayout, class DEngine, class DLayoutWI, class DLayout, class MulOf>
+CUTE_DEVICE void mxfp4_reorder_dequant(
+    SubgroupTensor<SEngine, SLayoutWI, SLayout> const& src,
+    SubgroupTensor<DEngine, DLayoutWI, DLayout>& dst,
+    MulOf const& mul_of) {
+  using SType = typename SEngine::element_type;
+  using DType = typename DEngine::element_type;
+  static_assert(is_same_v<SType, float_e2m1_t> && is_same_v<DType, bfloat16_t>, "folded dequant is E2M1 -> BF16 only");
+  static_assert(size(DLayoutWI{}) == size(SLayoutWI{}), "broadcasting reorders are not folded");
+
+  using SL0 = decltype(detail::subbyte_sg_tv_swizzle<SType>(project_strides(SLayout{})));
+  using DL0 = decltype(detail::subbyte_sg_tv_swizzle<DType>(project_strides(DLayout{})));
+  using Atom = decltype(choose_xe_reorder_impl<SType, DType>(SL0{}, DL0{}));
+  using RegTypeSrc = typename remove_extent<typename Atom::SRegisters>::type;
+  using RegTypeDst = typename remove_extent<typename Atom::DRegisters>::type;
+
+  static constexpr int values = size(SL0{}) / size<0>(SL0{});
+  static constexpr int vchunk = sizeof_bits_v<typename Atom::SRegisters> / sizeof_bits_v<SType>;
+
+  // src index -> dst index, then src value -> dst value (cute::reorder_impl).
+  using RLayout = decltype(coalesce(composition(right_inverse(DL0{}), SL0{})));
+  using VRLayout = decltype(composition(
+      composition(Layout<Shape<intel::_SGSize, Int<values>>, Stride<_0, _1>>{}, RLayout{}),
+      Layout<Shape<_1, Int<values>>, Stride<_0, intel::_SGSize>>{}));
+
+  for_each(make_int_sequence<values / vchunk>{}, [&](auto ci) {
+    constexpr int sv = decltype(ci)::value * vchunk;
+    constexpr int dv = VRLayout{}(sv);
+    // The two multipliers land on the chunk's even and odd elements, so a chunk
+    // must start on an even value index for them to mean channel 0 and 1.
+    static_assert(dv % 2 == 0, "a reorder chunk must start on an even value index");
+    auto pS = recast_ptr<RegTypeSrc>(src.data() + sv);
+    auto pD = recast_ptr<RegTypeDst>(dst.data() + dv);
+    mxfp4_reorder_folded<reorder_kind_of<Atom>::value>(*pS, *pD, mul_of(Int<dv>{}));
+  });
+}
+
+}  // namespace moe_w4a16

--- a/src/sycl/kernels/moe/xe20/w4a16/mxfp4_dequant.hpp
+++ b/src/sycl/kernels/moe/xe20/w4a16/mxfp4_dequant.hpp
@@ -119,7 +119,7 @@ CUTE_DEVICE void mxfp4_unfold(CTensor& tCrC) {
 template <ReorderKind Kind>
 CUTE_DEVICE void
 mxfp4_reorder_folded(intel::uchar4 const& src0, intel::ushort8& dst0, intel::vector_t<float, 2> const& muls) {
-#if defined(__SYCL_DEVICE_ONLY__) && defined(SYCL_INTEL_TARGET)
+#if defined(__SYCL_DEVICE_ONLY__) && defined(SYCL_INTEL_TARGET) && SYCL_INTEL_TARGET == 20
   const uint32_t shifts = 0x0008000C;
   if constexpr (Kind == ReorderKind::UU) {
     asm("{\n"
@@ -145,6 +145,8 @@ mxfp4_reorder_folded(intel::uchar4 const& src0, intel::ushort8& dst0, intel::vec
         : "=rw"(dst0)
         : "rw"(src0), "rw.u"(shifts), "rw"(muls));
   }
+#elif defined(__SYCL_DEVICE_ONLY__) && defined(SYCL_INTEL_TARGET)
+#error "MXFP4 folded reorder is only supported on SYCL_INTEL_TARGET 20 (BMG/Xe20)"
 #endif
 }
 

--- a/src/sycl/kernels/moe/xe20/w4a16_launch_policy.hpp
+++ b/src/sycl/kernels/moe/xe20/w4a16_launch_policy.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+// Framework launch-policy layer for the byte-identical fmha-cri W4A16 kernel.
+//
+// The copied kernel policy header deliberately contains only the upstream policy
+// menu plus its generic w4a16_tile building block.  This file keeps production
+// tile/scheduling choices in the framework adapter, so importing a new kernel
+// revision never requires editing the authoritative kernel source.
+
+#include "sycl/kernels/moe/xe20/w4a16/gemm_xe2_policy.hpp"
+
+namespace moe_w4a16 {
+
+template <class KernelPolicy, int StealChunk_, int PrefetchDist_, bool RowExtend_, bool SkipPaddedN_>
+class w4a16_launch_policy : public KernelPolicy {
+ public:
+  static constexpr int StealChunk = StealChunk_;
+  static constexpr int PrefetchDist = PrefetchDist_;
+  static constexpr bool RowExtend = RowExtend_;
+  static constexpr bool SkipPaddedN = SkipPaddedN_;
+};
+
+// Decode-size tiles use the shallow prefetch that fmha-cri measures for the
+// small-M band.  The 32-row policy retains its imported split-barrier trait.
+using w4a16_launch_policy_m_8_n_64 = w4a16_launch_policy<w4a16_policy_m_8_n_64, 1, 3, false, false>;
+using w4a16_launch_policy_m_16_n_64 = w4a16_launch_policy<w4a16_policy_m_16_n_64, 1, 3, false, false>;
+using w4a16_launch_policy_m_32_n_64 = w4a16_launch_policy<w4a16_policy_m_32_n_64, 1, 3, false, false>;
+
+// Production prefill tiles from fmha-cri's registry.  SG_N=16 gives one DPAS
+// N block per subgroup and avoids the ragged-M cost of multiple M subgroups.
+using w4a16_launch_policy_m_64_n_128 = w4a16_launch_policy<w4a16_tile<64, 128, 1, 8>, 4, 2, true, false>;
+using w4a16_launch_policy_m_64_n_128_skip = w4a16_launch_policy<w4a16_tile<64, 128, 1, 8>, 4, 2, true, true>;
+using w4a16_launch_policy_m_64_n_256 = w4a16_launch_policy<w4a16_tile<64, 256, 1, 16>, 1, 2, true, false>;
+using w4a16_launch_policy_m_64_n_256_skip = w4a16_launch_policy<w4a16_tile<64, 256, 1, 16>, 1, 2, true, true>;
+
+// Retained only as a measurement/reference option; production dispatch routes
+// all M > 32 through one of the 64-row tiles above.
+using w4a16_launch_policy_m_128_n_128 = w4a16_launch_policy<w4a16_policy_m_128_n_128, 1, 6, true, false>;
+
+}  // namespace moe_w4a16

--- a/src/sycl/kernels/moe/xe20/w4a16_launch_policy.hpp
+++ b/src/sycl/kernels/moe/xe20/w4a16_launch_policy.hpp
@@ -33,8 +33,4 @@ using w4a16_launch_policy_m_64_n_128_skip = w4a16_launch_policy<w4a16_tile<64, 1
 using w4a16_launch_policy_m_64_n_256 = w4a16_launch_policy<w4a16_tile<64, 256, 1, 16>, 1, 2, true, false>;
 using w4a16_launch_policy_m_64_n_256_skip = w4a16_launch_policy<w4a16_tile<64, 256, 1, 16>, 1, 2, true, true>;
 
-// Retained only as a measurement/reference option; production dispatch routes
-// all M > 32 through one of the 64-row tiles above.
-using w4a16_launch_policy_m_128_n_128 = w4a16_launch_policy<w4a16_policy_m_128_n_128, 1, 6, true, false>;
-
 }  // namespace moe_w4a16

--- a/tests/test_moe_gemm.py
+++ b/tests/test_moe_gemm.py
@@ -915,5 +915,63 @@ def test_moe_grouped_mm_nt_xe20_w4a16_mxfp4_input_dtypes(weight_dtype, scale_dty
     )
 
 
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "gemm_n,gemm_k",
+    [
+        (320, 256),  # short K: 64x128 SG_N=16 with the half-tile N skip
+        (256, 1056),  # long K: 64x256 SG_N=16 without an N tail
+        (320, 1056),  # long K: 64x256 SG_N=16 with the N skip
+    ],
+)
+def test_moe_grouped_mm_nt_xe20_w4a16_mxfp4_ragged_production_tiles(
+    dtype, gemm_n, gemm_k
+):
+    """Reference-check all fmha-cri production large-M dispatch variants.
+
+    The 64-row production tiles are selected from the mean row count, while
+    each expert still has its own ragged tail.  This verifies both the
+    tile-aligned A/B surfaces and the N-tail-skip variants against the
+    dequantized MXFP4 reference without allocating full GPT-OSS weights.
+    """
+    rows_per_expert = [40, 0, 80]
+    num_experts = len(rows_per_expert)
+    total_m = sum(rows_per_expert)
+
+    torch.manual_seed(17)
+    torch.xpu.manual_seed_all(17)
+    activations = create_random_xpu_tensor((total_m, gemm_k), dtype)
+    weights_cpu = create_random_cpu_tensor((num_experts, gemm_n, gemm_k), dtype)
+    packed_cpu, scales_cpu = _quantize_weights_mxfp4(weights_cpu)
+    dequantized_cpu = _dequantize_weights_mxfp4(packed_cpu, scales_cpu, dtype=dtype)
+
+    expected = torch.empty((total_m, gemm_n), dtype=dtype)
+    row_start = 0
+    for expert, row_count in enumerate(rows_per_expert):
+        row_end = row_start + row_count
+        if row_count:
+            expected[row_start:row_end] = (
+                activations[row_start:row_end].cpu().float()
+                @ dequantized_cpu[expert].float().transpose(0, 1)
+            ).to(dtype)
+        row_start = row_end
+
+    actual = torch.empty((total_m, gemm_n), dtype=dtype, device="xpu")
+    torch.ops.sgl_kernel.moe_grouped_mm_nt_xe20_w4a16(
+        actual,
+        activations,
+        packed_cpu.to("xpu"),
+        scales_cpu.to("xpu"),
+        None,
+        None,
+        torch.tensor(rows_per_expert, dtype=torch.int32, device="xpu"),
+        num_experts,
+        False,
+        MXFP4_BLOCK_SIZE,
+    )
+
+    torch.testing.assert_close(actual.cpu(), expected, rtol=1e-1, atol=1e-2)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary

This PR integrates **10 validated W4A16 MoE GEMM optimizations** for GPT-OSS workloads:

1. Shape-specific decode, 64x128, and 64x256 tile policies.
2. MXFP4 E8M0 group-scale folding during E2M1-to-BF16 reorder.
3. Per-tile work-stealing chunk-size and prefetch-distance tuning.
4. Mainloop barriers only on beneficial tile configurations.
5. Group-scale and zero-point pointer reuse across the K loop.
6. Removal of the unprofitable group-scale prefetch path.
7. Tile-aligned A/B surfaces for ragged expert tails.
8. Row extension only where aligned surfaces help.
9. Skipping DPAS blocks covering padded M rows.
10. Skipping subgroups covering only padded N tails.

The host integration also keeps a persistent per-stream work-stealing counter, removes a redundant device-memset launch, and dispatches tuned policies without tensor copies or synchronization. The PR adds GPT-OSS-120B TP4/TP8 prefill/decode benchmark coverage and MoE GEMM test coverage.

## Performance: GPT-OSS-120B production shapes

Registered `sgl/mxfp4` grouped-GEMM path, across all 16 GPT-OSS-120B-specific TP4/TP8 prefill/decode routing workloads (not generic synthetic shapes). Values are median device times after 6000 warmup iterations and 1000 measured iterations.

| GPT-OSS-120B-specific workload | Before (ms) | After (ms) | Speedup |
| --- | ---: | ---: | ---: |
| TP4 prefill L0 GEMM1 | 4.4502 | 2.0480 | 2.17x |
| TP4 prefill L0 GEMM2 | 2.3551 | 1.1074 | 2.13x |
| TP4 prefill L14 GEMM1 | 3.6665 | 1.9601 | 1.87x |
| TP4 prefill L14 GEMM2 | 1.9095 | 1.0442 | 1.83x |
| TP4 prefill L35 GEMM1 | 3.4519 | 1.8795 | 1.84x |
| TP4 prefill L35 GEMM2 | 1.8039 | 0.9696 | 1.86x |
| TP4 decode GEMM1 | 0.0562 | 0.0470 | 1.20x |
| TP4 decode GEMM2 | 0.0411 | 0.0359 | 1.14x |
| TP8 prefill L0 GEMM1 | 2.2683 | 1.0421 | 2.18x |
| TP8 prefill L0 GEMM2 | 1.3795 | 0.7031 | 1.96x |
| TP8 prefill L14 GEMM1 | 1.8149 | 0.9923 | 1.83x |
| TP8 prefill L14 GEMM2 | 1.0683 | 0.6157 | 1.74x |
| TP8 prefill L35 GEMM1 | 1.8088 | 0.9445 | 1.92x |
| TP8 prefill L35 GEMM2 | 1.0735 | 0.5962 | 1.80x |
| TP8 decode GEMM1 | 0.0511 | 0.0422 | 1.21x |
| TP8 decode GEMM2 | 0.0326 | 0.0301 | 1.08x |

| Aggregate (geometric mean of median time) | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| 12 prefill shapes | 2.0460 ms | 1.0651 ms | **1.92x** |
| 4 decode shapes | 0.0443 ms | 0.0383 ms | **1.16x** |
| All 16 shapes | 0.7848 ms | 0.4637 ms | **1.69x** |

All 16 production shapes improve.

## Performance: generic `benchmark/` full-shape sweep

This is a separate generic sweep from `benchmark/bench_moe_w4a16_grouped_gemm.py` with `SGL_MOE_BENCH_FULL_SHAPES=1`; it is not the GPT-OSS-120B-specific routing profile above. It covers GPT-OSS-20B-like geometry, controlled small/medium-M points, and DeepSeek-V4 geometry. The table reports the `sgl/mxfp4` provider used by GPT-OSS, using Triton device-time median measurements (50 warmup, 200 repetitions). Shape format: `(E, avg_M, M, N, K)`.

| Generic benchmark shape `(E, avg_M, M, N, K)` | Before (ms) | After (ms) | Speedup |
| --- | ---: | ---: | ---: |
| (4, 4, 16, 2880, 2880) | 0.0795 | 0.0675 | 1.18x |
| (4, 4, 16, 5760, 2880) | 0.1204 | 0.1067 | 1.13x |
| (4, 256, 1024, 2880, 2880) | 0.3605 | 0.2279 | 1.58x |
| (4, 256, 1024, 5760, 2880) | 0.6459 | 0.4301 | 1.50x |
| (8, 4, 32, 1024, 1024) | 0.0291 | 0.0259 | 1.12x |
| (8, 8, 64, 1024, 1024) | 0.0320 | 0.0289 | 1.11x |
| (8, 33, 264, 1024, 1024) | 0.0419 | 0.0319 | 1.31x |
| (8, 33, 264, 1024, 2048) | 0.0726 | 0.0564 | 1.29x |
| (8, 33, 264, 2048, 1024) | 0.0770 | 0.0859 | 0.90x |
| (8, 129, 1032, 1024, 1024) | 0.0935 | 0.1233 | 0.76x |
| (8, 129, 1032, 2048, 2048) | 0.2687 | 0.2476 | 1.09x |
| (32, 1, 32, 4096, 2048) | 0.3616 | 0.3281 | 1.10x |
| (32, 1, 32, 4096, 4096) | 0.6835 | 0.6469 | 1.06x |
| (32, 48, 1536, 4096, 2048) | 0.5942 | 0.4712 | 1.26x |
| (32, 48, 1536, 4096, 4096) | 1.2081 | 0.8810 | 1.37x |

**Aggregate:** 13/15 generic shapes improve; the geometric-mean speedup is **1.16x**. The two regressions are intentionally shown above.

## Performance: GPT-OSS-120B E2E serving

Configuration: `openai/gpt-oss-120b`, TP4, C1, 4096 input / 1024 output tokens, radix cache disabled. Real SGLang server runs using `server.sh` + `benchmark.sh`; each value is a two-run average.

Main ablation A/B series:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Mean TTFT | 662.0 ms | 523.1 ms | **-21.0% (1.27x)** |
| Mean TPOT | 74.38 ms | 74.70 ms | +0.43% |
| Mean E2E latency | 76.75 s | 76.94 s | +0.25% |

## Validation

- `pre-commit` checks passed for the changed files (the host Black hook over-spawned workers; verified with the same Black version constrained to one worker).
- `clang-format` passed after formatting the affected kernel headers.
- `git diff --check` passed.
- Default-feature clean BMG build launched on GPU 0 and is still compiling behind other host builds due to the memory guard; no source failure observed.
- The original commit records a previously successful default wheel build and `tests/test_moe_gemm.py` run.



