### PR TITLE
Relax relative attention zero-bias tolerance

### DIFF
--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -2807,7 +2807,7 @@ def test_relative_attention_zero_bias_matches_prefill():
         **common,
     )
     torch.xpu.synchronize()
-    torch.testing.assert_close(relative.float(), baseline.float(), rtol=0, atol=5e-4)
+    torch.testing.assert_close(relative.float(), baseline.float(), rtol=0, atol=1e-3)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

- relax the zero-bias relative-attention equivalence tolerance from `5e-4` to `1e-3`
- keep `rtol=0` so the test continues to enforce a strict absolute-error bound
- leave the other relative-attention tolerances unchanged after review

## Rationale

The test compares two BF16 FMHA kernel paths after casting their outputs to float. PR #390 CI observed one mismatched element out of 264,192 with an absolute difference of `0.0009765625`, which is one BF16 ULP at that value. The existing `5e-4` bound is therefore stricter than the output precision. A `1e-3` absolute tolerance accepts that single-ULP rounding difference without introducing a relative tolerance.

## CUDA SM120 reference

The CUDA SM120 relative-bias tests use the shared [`_assert_attention_close`](https://github.com/sgl-project/sglang/blob/9ed2721c6d98b99f12bf7067883e4a137a0cd62c/test/registered/kernels/ops/attention/test_flash_attention_4_sm120.py#L268-L280) helper:

```python
error = (output.float() - reference.float()).abs()
assert error.max().item() < 1e-2
assert error.mean().item() < 5e-4
```

The dense relative-bias correctness test calls this helper after comparing the CUDA result with its FP32 reference. CUDA path-equivalence checks elsewhere in the same test use `atol=2e-3, rtol=0`. The proposed XPU threshold (`atol=1e-3, rtol=0`) remains stricter than that CUDA path-equivalence tolerance while covering the observed one-ULP BF16 difference.

## Validation

- `pre-commit run --files tests/test_flash_attention.py`
- clean default-feature build and wheel installation
- `pytest -q tests/test_flash_attention.py::test_relative_attention_zero_bias_matches_prefill` (`1 passed`)
