### PR TITLE
[flash_attn] Support non-contiguous inputs in flash_attn_varlen_func kernel

### DIFF
--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
@@ -446,19 +446,19 @@ class XeFMHAFwdKernel {
       auto dcO = const_cast<ElementO*>(p.O + offset_o);
       // NHD layout for GQA
       auto layout_q = [&] {
-        if constexpr (is_var_len && !CollectiveMainloop::ScoreBlock2D) {
+        if constexpr (is_var_len && (!CollectiveMainloop::ScoreBlock2D || PackGQA_)) {
           return make_ordered_layout(shape_Q, VarLenQLayoutStep_{});
         }
         return make_layout(shape_Q, p.dQ);
       }();
       auto layout_k = [&] {
-        if constexpr (is_var_len && !CollectiveMainloop::ScoreBlock2D) {
+        if constexpr (is_var_len && (!CollectiveMainloop::ScoreBlock2D || PackGQA_)) {
           return make_ordered_layout(shape_K, VarLenKLayoutStep_{});
         }
         return make_layout(shape_K, p.dK);
       }();
       auto layout_v = [&] {
-        if constexpr (is_var_len && !CollectiveMainloop::ScoreBlock2D) {
+        if constexpr (is_var_len && (!CollectiveMainloop::ScoreBlock2D || PackGQA_)) {
           return make_ordered_layout(shape_V, VarLenVLayoutStep_{});
         }
         return make_layout(shape_V, p.dV);
@@ -466,7 +466,7 @@ class XeFMHAFwdKernel {
 
       // NHD layout for GQA
       auto layout_o = [&] {
-        if constexpr (is_var_len && !CollectiveMainloop::ScoreBlock2D) {
+        if constexpr (is_var_len && (!CollectiveMainloop::ScoreBlock2D || PackGQA_)) {
           return make_ordered_layout(shape_O, VarLenOLayoutStep_{});
         }
         return make_layout(shape_O, p.dO);

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
@@ -445,6 +445,10 @@ class XeFMHAFwdKernel {
       auto dcV_cache = const_cast<ElementV*>(p.V_cache + offset_v_cache);
       auto dcO = const_cast<ElementO*>(p.O + offset_o);
       // NHD layout for GQA
+      // Non-contiguous stride layouts are currently unappliable with PackedGQA_ = 1.
+      // When PackedGQA is enabled, the head dimension packs multiple query heads sharing the same KV group,
+      // causing standard stride calculations to mismatch the underlying memory layout.
+      // Supporting strided layouts for PackedGQA would require introducing a dedicated `head_stride`.
       auto layout_q = [&] {
         if constexpr (is_var_len && (PackGQA_)) {
           return make_ordered_layout(shape_Q, VarLenQLayoutStep_{});

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
@@ -446,19 +446,19 @@ class XeFMHAFwdKernel {
       auto dcO = const_cast<ElementO*>(p.O + offset_o);
       // NHD layout for GQA
       auto layout_q = [&] {
-        if constexpr (is_var_len && (!CollectiveMainloop::ScoreBlock2D || PackGQA_)) {
+        if constexpr (is_var_len && (PackGQA_)) {
           return make_ordered_layout(shape_Q, VarLenQLayoutStep_{});
         }
         return make_layout(shape_Q, p.dQ);
       }();
       auto layout_k = [&] {
-        if constexpr (is_var_len && (!CollectiveMainloop::ScoreBlock2D || PackGQA_)) {
+        if constexpr (is_var_len && (PackGQA_)) {
           return make_ordered_layout(shape_K, VarLenKLayoutStep_{});
         }
         return make_layout(shape_K, p.dK);
       }();
       auto layout_v = [&] {
-        if constexpr (is_var_len && (!CollectiveMainloop::ScoreBlock2D || PackGQA_)) {
+        if constexpr (is_var_len && (PackGQA_)) {
           return make_ordered_layout(shape_V, VarLenVLayoutStep_{});
         }
         return make_layout(shape_V, p.dV);
@@ -466,7 +466,7 @@ class XeFMHAFwdKernel {
 
       // NHD layout for GQA
       auto layout_o = [&] {
-        if constexpr (is_var_len && (!CollectiveMainloop::ScoreBlock2D || PackGQA_)) {
+        if constexpr (is_var_len && (PackGQA_)) {
           return make_ordered_layout(shape_O, VarLenOLayoutStep_{});
         }
         return make_layout(shape_O, p.dO);

--- a/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
+++ b/src/sycl/kernels/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
@@ -444,8 +444,7 @@ class XeFMHAFwdKernel {
       auto dcK_cache = const_cast<ElementK*>(p.K_cache + offset_k_cache);
       auto dcV_cache = const_cast<ElementV*>(p.V_cache + offset_v_cache);
       auto dcO = const_cast<ElementO*>(p.O + offset_o);
-      // NHD layout for GQA
-      // Non-contiguous stride layouts are currently unappliable with PackedGQA_ = 1.
+      // Under standard NHD layout for GQA, non-contiguous stride layouts are currently disabled for PackedGQA_ = 1.
       // When PackedGQA is enabled, the head dimension packs multiple query heads sharing the same KV group,
       // causing standard stride calculations to mismatch the underlying memory layout.
       // Supporting strided layouts for PackedGQA would require introducing a dedicated `head_stride`.

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
@@ -333,21 +333,54 @@ struct DecodeRunner {
       shape = problem_shape_in;
     }
 
-    auto [batch, num_heads_q, num_heads_kv, seq_len_qo, seq_len_kv, seq_len_kv_cache, head_size_qk, head_size_vo] =
-        problem_size;
-    // NHD format
-    stride_Q = cutlass::make_stride(
-        num_heads_q * head_size_qk, Int<1>{}, head_size_qk, head_size_qk * num_heads_q * seq_len_qo);
-    stride_K = cutlass::make_stride(
-        num_heads_kv * head_size_qk, Int<1>{}, head_size_qk, head_size_qk * num_heads_kv * seq_len_kv);
-    stride_V = cutlass::make_stride(
-        Int<1>{}, num_heads_kv * head_size_vo, head_size_vo, head_size_vo * num_heads_kv * seq_len_kv);
-    stride_K_cache = cutlass::make_stride(
-        num_heads_kv * head_size_qk, Int<1>{}, head_size_qk, head_size_qk * num_heads_kv * seq_len_kv_cache);
-    stride_V_cache = cutlass::make_stride(
-        Int<1>{}, num_heads_kv * head_size_vo, head_size_vo, head_size_vo * num_heads_kv * seq_len_kv_cache);
-    stride_O = cutlass::make_stride(
-        num_heads_q * head_size_vo, Int<1>{}, head_size_vo, head_size_vo * num_heads_q * seq_len_qo);
+    auto [batch,
+          num_heads_q,
+          num_heads_kv,
+          seq_len_qo,
+          seq_len_kv,
+          seq_len_kv_cache,
+          head_size_qk,
+          head_size_vo,
+          q_row_stride,
+          k_row_stride,
+          v_row_stride,
+          q_head_stride,
+          k_head_stride,
+          v_head_stride,
+          o_row_stride,
+          o_head_stride] = cute::tuple_cat(
+        problem_size,
+        cute::make_tuple(
+            params.q_row_stride,
+            params.k_row_stride,
+            params.v_row_stride,
+            params.q_head_stride,
+            params.k_head_stride,
+            params.v_head_stride,
+            params.o_row_stride,
+            params.o_head_stride));
+    // Row/head strides come straight from the caller's tensors so q/k/v may be
+    // non-contiguous views (e.g. sliced out of a fused qkv projection) without
+    // an extra `.contiguous()` copy; only the last (head_size) dim must be
+    // contiguous, which is enforced by CHECK_LAST_DIM_CONTIGUOUS_INPUT.
+    // StrideQ/K/V/O use plain `int` elements, but Arguments stores strides as
+    // int64_t, so narrow explicitly before handing them to make_stride.
+    int const q_row_stride_i = static_cast<int>(q_row_stride);
+    int const k_row_stride_i = static_cast<int>(k_row_stride);
+    int const v_row_stride_i = static_cast<int>(v_row_stride);
+    int const q_head_stride_i = static_cast<int>(q_head_stride);
+    int const k_head_stride_i = static_cast<int>(k_head_stride);
+    int const v_head_stride_i = static_cast<int>(v_head_stride);
+    int const o_row_stride_i = static_cast<int>(o_row_stride);
+    int const o_head_stride_i = static_cast<int>(o_head_stride);
+    stride_Q = cutlass::make_stride(q_row_stride_i, Int<1>{}, q_head_stride_i, q_row_stride_i * seq_len_qo);
+    stride_K = cutlass::make_stride(k_row_stride_i, Int<1>{}, k_head_stride_i, k_row_stride_i * seq_len_kv);
+    stride_V = cutlass::make_stride(Int<1>{}, v_row_stride_i, v_head_stride_i, v_row_stride_i * seq_len_kv);
+    stride_K_cache =
+        cutlass::make_stride(k_row_stride_i, Int<1>{}, k_head_stride_i, k_row_stride_i * seq_len_kv_cache);
+    stride_V_cache =
+        cutlass::make_stride(Int<1>{}, v_row_stride_i, v_head_stride_i, v_row_stride_i * seq_len_kv_cache);
+    stride_O = cutlass::make_stride(o_row_stride_i, Int<1>{}, o_head_stride_i, o_row_stride_i * seq_len_qo);
 
     if constexpr (isVarLen) {
       shape.seq_len_qo.cumulative_length = params.cu_seqlens_q;

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
@@ -333,54 +333,21 @@ struct DecodeRunner {
       shape = problem_shape_in;
     }
 
-    auto
-        [batch,
-         num_heads_q,
-         num_heads_kv,
-         seq_len_qo,
-         seq_len_kv,
-         seq_len_kv_cache,
-         head_size_qk,
-         head_size_vo,
-         q_row_stride,
-         k_row_stride,
-         v_row_stride,
-         q_head_stride,
-         k_head_stride,
-         v_head_stride,
-         o_row_stride,
-         o_head_stride] =
-            cute::tuple_cat(
-                problem_size,
-                cute::make_tuple(
-                    params.q_row_stride,
-                    params.k_row_stride,
-                    params.v_row_stride,
-                    params.q_head_stride,
-                    params.k_head_stride,
-                    params.v_head_stride,
-                    params.o_row_stride,
-                    params.o_head_stride));
-    // Row/head strides come straight from the caller's tensors so q/k/v may be
-    // non-contiguous views (e.g. sliced out of a fused qkv projection) without
-    // an extra `.contiguous()` copy; only the last (head_size) dim must be
-    // contiguous, which is enforced by CHECK_LAST_DIM_CONTIGUOUS_INPUT.
-    // StrideQ/K/V/O use plain `int` elements, but Arguments stores strides as
-    // int64_t, so narrow explicitly before handing them to make_stride.
-    int const q_row_stride_i = static_cast<int>(q_row_stride);
-    int const k_row_stride_i = static_cast<int>(k_row_stride);
-    int const v_row_stride_i = static_cast<int>(v_row_stride);
-    int const q_head_stride_i = static_cast<int>(q_head_stride);
-    int const k_head_stride_i = static_cast<int>(k_head_stride);
-    int const v_head_stride_i = static_cast<int>(v_head_stride);
-    int const o_row_stride_i = static_cast<int>(o_row_stride);
-    int const o_head_stride_i = static_cast<int>(o_head_stride);
-    stride_Q = cutlass::make_stride(q_row_stride_i, Int<1>{}, q_head_stride_i, q_row_stride_i * seq_len_qo);
-    stride_K = cutlass::make_stride(k_row_stride_i, Int<1>{}, k_head_stride_i, k_row_stride_i * seq_len_kv);
-    stride_V = cutlass::make_stride(Int<1>{}, v_row_stride_i, v_head_stride_i, v_row_stride_i * seq_len_kv);
-    stride_K_cache = cutlass::make_stride(k_row_stride_i, Int<1>{}, k_head_stride_i, k_row_stride_i * seq_len_kv_cache);
-    stride_V_cache = cutlass::make_stride(Int<1>{}, v_row_stride_i, v_head_stride_i, v_row_stride_i * seq_len_kv_cache);
-    stride_O = cutlass::make_stride(o_row_stride_i, Int<1>{}, o_head_stride_i, o_row_stride_i * seq_len_qo);
+    auto [batch, num_heads_q, num_heads_kv, seq_len_qo, seq_len_kv, seq_len_kv_cache, head_size_qk, head_size_vo] =
+        problem_size;
+    // NHD format
+    stride_Q = cutlass::make_stride(
+        num_heads_q * head_size_qk, Int<1>{}, head_size_qk, head_size_qk * num_heads_q * seq_len_qo);
+    stride_K = cutlass::make_stride(
+        num_heads_kv * head_size_qk, Int<1>{}, head_size_qk, head_size_qk * num_heads_kv * seq_len_kv);
+    stride_V = cutlass::make_stride(
+        Int<1>{}, num_heads_kv * head_size_vo, head_size_vo, head_size_vo * num_heads_kv * seq_len_kv);
+    stride_K_cache = cutlass::make_stride(
+        num_heads_kv * head_size_qk, Int<1>{}, head_size_qk, head_size_qk * num_heads_kv * seq_len_kv_cache);
+    stride_V_cache = cutlass::make_stride(
+        Int<1>{}, num_heads_kv * head_size_vo, head_size_vo, head_size_vo * num_heads_kv * seq_len_kv_cache);
+    stride_O = cutlass::make_stride(
+        num_heads_q * head_size_vo, Int<1>{}, head_size_vo, head_size_vo * num_heads_q * seq_len_qo);
 
     if constexpr (isVarLen) {
       shape.seq_len_qo.cumulative_length = params.cu_seqlens_q;

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
@@ -333,32 +333,34 @@ struct DecodeRunner {
       shape = problem_shape_in;
     }
 
-    auto [batch,
-          num_heads_q,
-          num_heads_kv,
-          seq_len_qo,
-          seq_len_kv,
-          seq_len_kv_cache,
-          head_size_qk,
-          head_size_vo,
-          q_row_stride,
-          k_row_stride,
-          v_row_stride,
-          q_head_stride,
-          k_head_stride,
-          v_head_stride,
-          o_row_stride,
-          o_head_stride] = cute::tuple_cat(
-        problem_size,
-        cute::make_tuple(
-            params.q_row_stride,
-            params.k_row_stride,
-            params.v_row_stride,
-            params.q_head_stride,
-            params.k_head_stride,
-            params.v_head_stride,
-            params.o_row_stride,
-            params.o_head_stride));
+    auto
+        [batch,
+         num_heads_q,
+         num_heads_kv,
+         seq_len_qo,
+         seq_len_kv,
+         seq_len_kv_cache,
+         head_size_qk,
+         head_size_vo,
+         q_row_stride,
+         k_row_stride,
+         v_row_stride,
+         q_head_stride,
+         k_head_stride,
+         v_head_stride,
+         o_row_stride,
+         o_head_stride] =
+            cute::tuple_cat(
+                problem_size,
+                cute::make_tuple(
+                    params.q_row_stride,
+                    params.k_row_stride,
+                    params.v_row_stride,
+                    params.q_head_stride,
+                    params.k_head_stride,
+                    params.v_head_stride,
+                    params.o_row_stride,
+                    params.o_head_stride));
     // Row/head strides come straight from the caller's tensors so q/k/v may be
     // non-contiguous views (e.g. sliced out of a fused qkv projection) without
     // an extra `.contiguous()` copy; only the last (head_size) dim must be
@@ -376,10 +378,8 @@ struct DecodeRunner {
     stride_Q = cutlass::make_stride(q_row_stride_i, Int<1>{}, q_head_stride_i, q_row_stride_i * seq_len_qo);
     stride_K = cutlass::make_stride(k_row_stride_i, Int<1>{}, k_head_stride_i, k_row_stride_i * seq_len_kv);
     stride_V = cutlass::make_stride(Int<1>{}, v_row_stride_i, v_head_stride_i, v_row_stride_i * seq_len_kv);
-    stride_K_cache =
-        cutlass::make_stride(k_row_stride_i, Int<1>{}, k_head_stride_i, k_row_stride_i * seq_len_kv_cache);
-    stride_V_cache =
-        cutlass::make_stride(Int<1>{}, v_row_stride_i, v_head_stride_i, v_row_stride_i * seq_len_kv_cache);
+    stride_K_cache = cutlass::make_stride(k_row_stride_i, Int<1>{}, k_head_stride_i, k_row_stride_i * seq_len_kv_cache);
+    stride_V_cache = cutlass::make_stride(Int<1>{}, v_row_stride_i, v_head_stride_i, v_row_stride_i * seq_len_kv_cache);
     stride_O = cutlass::make_stride(o_row_stride_i, Int<1>{}, o_head_stride_i, o_row_stride_i * seq_len_qo);
 
     if constexpr (isVarLen) {

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_decode_runner.hpp
@@ -333,21 +333,62 @@ struct DecodeRunner {
       shape = problem_shape_in;
     }
 
-    auto [batch, num_heads_q, num_heads_kv, seq_len_qo, seq_len_kv, seq_len_kv_cache, head_size_qk, head_size_vo] =
-        problem_size;
-    // NHD format
-    stride_Q = cutlass::make_stride(
-        num_heads_q * head_size_qk, Int<1>{}, head_size_qk, head_size_qk * num_heads_q * seq_len_qo);
-    stride_K = cutlass::make_stride(
-        num_heads_kv * head_size_qk, Int<1>{}, head_size_qk, head_size_qk * num_heads_kv * seq_len_kv);
-    stride_V = cutlass::make_stride(
-        Int<1>{}, num_heads_kv * head_size_vo, head_size_vo, head_size_vo * num_heads_kv * seq_len_kv);
-    stride_K_cache = cutlass::make_stride(
-        num_heads_kv * head_size_qk, Int<1>{}, head_size_qk, head_size_qk * num_heads_kv * seq_len_kv_cache);
-    stride_V_cache = cutlass::make_stride(
-        Int<1>{}, num_heads_kv * head_size_vo, head_size_vo, head_size_vo * num_heads_kv * seq_len_kv_cache);
-    stride_O = cutlass::make_stride(
-        num_heads_q * head_size_vo, Int<1>{}, head_size_vo, head_size_vo * num_heads_q * seq_len_qo);
+    auto
+        [batch,
+         num_heads_q,
+         num_heads_kv,
+         seq_len_qo,
+         seq_len_kv,
+         seq_len_kv_cache,
+         head_size_qk,
+         head_size_vo,
+         q_row_stride,
+         k_row_stride,
+         v_row_stride,
+         q_head_stride,
+         k_head_stride,
+         v_head_stride,
+         o_row_stride,
+         o_head_stride] =
+            cute::tuple_cat(
+                problem_size,
+                cute::make_tuple(
+                    params.q_row_stride,
+                    params.k_row_stride,
+                    params.v_row_stride,
+                    params.q_head_stride,
+                    params.k_head_stride,
+                    params.v_head_stride,
+                    params.o_row_stride,
+                    params.o_head_stride));
+    // Row/head strides come straight from the caller's tensors so q/k/v may be
+    // non-contiguous views (e.g. sliced out of a fused qkv projection) without
+    // an extra `.contiguous()` copy; only the last (head_size) dim must be
+    // contiguous, which is enforced by CHECK_LAST_DIM_CONTIGUOUS_INPUT.
+    // StrideQ/K/V/O use plain `int` elements, but Arguments stores strides as
+    // int64_t, so narrow explicitly before handing them to make_stride.
+    constexpr int64_t kIntMax = 2147483647LL;
+    TORCH_CHECK(
+        q_row_stride <= kIntMax && k_row_stride <= kIntMax && v_row_stride <= kIntMax && q_head_stride <= kIntMax &&
+            k_head_stride <= kIntMax && v_head_stride <= kIntMax && o_row_stride <= kIntMax && o_head_stride <= kIntMax,
+        "Q/K/V/O stride exceeds int32 max (",
+        kIntMax,
+        ")");
+    int const q_row_stride_i = static_cast<int>(q_row_stride);
+    int const k_row_stride_i = static_cast<int>(k_row_stride);
+    int const v_row_stride_i = static_cast<int>(v_row_stride);
+    int const q_head_stride_i = static_cast<int>(q_head_stride);
+    int const k_head_stride_i = static_cast<int>(k_head_stride);
+    int const v_head_stride_i = static_cast<int>(v_head_stride);
+    int const o_row_stride_i = static_cast<int>(o_row_stride);
+    int const o_head_stride_i = static_cast<int>(o_head_stride);
+
+    stride_Q = cutlass::make_stride(q_row_stride_i, Int<1>{}, q_head_stride_i, q_row_stride_i * seq_len_qo);
+    stride_K = cutlass::make_stride(k_row_stride_i, Int<1>{}, k_head_stride_i, k_row_stride_i * seq_len_kv);
+    stride_V = cutlass::make_stride(Int<1>{}, v_row_stride_i, v_head_stride_i, v_row_stride_i * seq_len_kv);
+    stride_K_cache = cutlass::make_stride(k_row_stride_i, Int<1>{}, k_head_stride_i, k_row_stride_i * seq_len_kv_cache);
+    stride_V_cache = cutlass::make_stride(Int<1>{}, v_row_stride_i, v_head_stride_i, v_row_stride_i * seq_len_kv_cache);
+    stride_O = cutlass::make_stride(o_row_stride_i, Int<1>{}, o_head_stride_i, o_row_stride_i * seq_len_qo);
 
     if constexpr (isVarLen) {
       shape.seq_len_qo.cumulative_length = params.cu_seqlens_q;

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -288,32 +288,34 @@ struct PrefillRunner {
       shape = problem_shape_in;
     }
 
-    auto [batch,
-          num_heads_q,
-          num_heads_kv,
-          seq_len_qo,
-          seq_len_kv,
-          seq_len_kv_cache,
-          head_size_qk,
-          head_size_vo,
-          q_row_stride,
-          k_row_stride,
-          v_row_stride,
-          q_head_stride,
-          k_head_stride,
-          v_head_stride,
-          o_row_stride,
-          o_head_stride] = cute::tuple_cat(
-        problem_size,
-        cute::make_tuple(
-            params.q_row_stride,
-            params.k_row_stride,
-            params.v_row_stride,
-            params.q_head_stride,
-            params.k_head_stride,
-            params.v_head_stride,
-            params.o_row_stride,
-            params.o_head_stride));
+    auto
+        [batch,
+         num_heads_q,
+         num_heads_kv,
+         seq_len_qo,
+         seq_len_kv,
+         seq_len_kv_cache,
+         head_size_qk,
+         head_size_vo,
+         q_row_stride,
+         k_row_stride,
+         v_row_stride,
+         q_head_stride,
+         k_head_stride,
+         v_head_stride,
+         o_row_stride,
+         o_head_stride] =
+            cute::tuple_cat(
+                problem_size,
+                cute::make_tuple(
+                    params.q_row_stride,
+                    params.k_row_stride,
+                    params.v_row_stride,
+                    params.q_head_stride,
+                    params.k_head_stride,
+                    params.v_head_stride,
+                    params.o_row_stride,
+                    params.o_head_stride));
     // Row/head strides come straight from the caller's tensors instead of
     // being derived from head_size * num_heads, so q/k/v may be
     // non-contiguous views (e.g. sliced out of a fused qkv projection)
@@ -332,10 +334,8 @@ struct PrefillRunner {
     stride_Q = cutlass::make_stride(q_row_stride_i, Int<1>{}, q_head_stride_i, q_row_stride_i * seq_len_qo);
     stride_K = cutlass::make_stride(k_row_stride_i, Int<1>{}, k_head_stride_i, k_row_stride_i * seq_len_kv);
     stride_V = cutlass::make_stride(Int<1>{}, v_row_stride_i, v_head_stride_i, v_row_stride_i * seq_len_kv);
-    stride_K_cache =
-        cutlass::make_stride(k_row_stride_i, Int<1>{}, k_head_stride_i, k_row_stride_i * seq_len_kv_cache);
-    stride_V_cache =
-        cutlass::make_stride(Int<1>{}, v_row_stride_i, v_head_stride_i, v_row_stride_i * seq_len_kv_cache);
+    stride_K_cache = cutlass::make_stride(k_row_stride_i, Int<1>{}, k_head_stride_i, k_row_stride_i * seq_len_kv_cache);
+    stride_V_cache = cutlass::make_stride(Int<1>{}, v_row_stride_i, v_head_stride_i, v_row_stride_i * seq_len_kv_cache);
     stride_O = cutlass::make_stride(o_row_stride_i, Int<1>{}, o_head_stride_i, o_row_stride_i * seq_len_qo);
 
     if constexpr (isVarLen) {

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -288,21 +288,55 @@ struct PrefillRunner {
       shape = problem_shape_in;
     }
 
-    auto [batch, num_heads_q, num_heads_kv, seq_len_qo, seq_len_kv, seq_len_kv_cache, head_size_qk, head_size_vo] =
-        problem_size;
-    // NHD format
-    stride_Q = cutlass::make_stride(
-        num_heads_q * head_size_qk, Int<1>{}, head_size_qk, head_size_qk * num_heads_q * seq_len_qo);
-    stride_K = cutlass::make_stride(
-        num_heads_kv * head_size_qk, Int<1>{}, head_size_qk, head_size_qk * num_heads_kv * seq_len_kv);
-    stride_V = cutlass::make_stride(
-        Int<1>{}, num_heads_kv * head_size_vo, head_size_vo, head_size_vo * num_heads_kv * seq_len_kv);
-    stride_K_cache = cutlass::make_stride(
-        num_heads_kv * head_size_qk, Int<1>{}, head_size_qk, head_size_qk * num_heads_kv * seq_len_kv_cache);
-    stride_V_cache = cutlass::make_stride(
-        Int<1>{}, num_heads_kv * head_size_vo, head_size_vo, head_size_vo * num_heads_kv * seq_len_kv_cache);
-    stride_O = cutlass::make_stride(
-        num_heads_q * head_size_vo, Int<1>{}, head_size_vo, head_size_vo * num_heads_q * seq_len_qo);
+    auto [batch,
+          num_heads_q,
+          num_heads_kv,
+          seq_len_qo,
+          seq_len_kv,
+          seq_len_kv_cache,
+          head_size_qk,
+          head_size_vo,
+          q_row_stride,
+          k_row_stride,
+          v_row_stride,
+          q_head_stride,
+          k_head_stride,
+          v_head_stride,
+          o_row_stride,
+          o_head_stride] = cute::tuple_cat(
+        problem_size,
+        cute::make_tuple(
+            params.q_row_stride,
+            params.k_row_stride,
+            params.v_row_stride,
+            params.q_head_stride,
+            params.k_head_stride,
+            params.v_head_stride,
+            params.o_row_stride,
+            params.o_head_stride));
+    // Row/head strides come straight from the caller's tensors instead of
+    // being derived from head_size * num_heads, so q/k/v may be
+    // non-contiguous views (e.g. sliced out of a fused qkv projection)
+    // without an extra `.contiguous()` copy; only the last (head_size) dim
+    // must be contiguous, which is enforced by CHECK_LAST_DIM_CONTIGUOUS_INPUT.
+    // StrideQ/K/V/O use plain `int` elements, but Arguments stores strides as
+    // int64_t, so narrow explicitly before handing them to make_stride.
+    int const q_row_stride_i = static_cast<int>(q_row_stride);
+    int const k_row_stride_i = static_cast<int>(k_row_stride);
+    int const v_row_stride_i = static_cast<int>(v_row_stride);
+    int const q_head_stride_i = static_cast<int>(q_head_stride);
+    int const k_head_stride_i = static_cast<int>(k_head_stride);
+    int const v_head_stride_i = static_cast<int>(v_head_stride);
+    int const o_row_stride_i = static_cast<int>(o_row_stride);
+    int const o_head_stride_i = static_cast<int>(o_head_stride);
+    stride_Q = cutlass::make_stride(q_row_stride_i, Int<1>{}, q_head_stride_i, q_row_stride_i * seq_len_qo);
+    stride_K = cutlass::make_stride(k_row_stride_i, Int<1>{}, k_head_stride_i, k_row_stride_i * seq_len_kv);
+    stride_V = cutlass::make_stride(Int<1>{}, v_row_stride_i, v_head_stride_i, v_row_stride_i * seq_len_kv);
+    stride_K_cache =
+        cutlass::make_stride(k_row_stride_i, Int<1>{}, k_head_stride_i, k_row_stride_i * seq_len_kv_cache);
+    stride_V_cache =
+        cutlass::make_stride(Int<1>{}, v_row_stride_i, v_head_stride_i, v_row_stride_i * seq_len_kv_cache);
+    stride_O = cutlass::make_stride(o_row_stride_i, Int<1>{}, o_head_stride_i, o_row_stride_i * seq_len_qo);
 
     if constexpr (isVarLen) {
       shape.seq_len_qo.cumulative_length = params.cu_seqlens_q;

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -323,6 +323,13 @@ struct PrefillRunner {
     // must be contiguous, which is enforced by CHECK_LAST_DIM_CONTIGUOUS_INPUT.
     // StrideQ/K/V/O use plain `int` elements, but Arguments stores strides as
     // int64_t, so narrow explicitly before handing them to make_stride.
+    constexpr int64_t kIntMax = 2147483647LL;
+    TORCH_CHECK(
+      q_row_stride <= kIntMax && k_row_stride <= kIntMax && v_row_stride <= kIntMax && q_head_stride <= kIntMax &&
+          k_head_stride <= kIntMax && v_head_stride <= kIntMax && o_row_stride <= kIntMax && o_head_stride <= kIntMax,
+      "Q/K/V/O stride exceeds int32 max (",
+      kIntMax,
+    ")");
     int const q_row_stride_i = static_cast<int>(q_row_stride);
     int const k_row_stride_i = static_cast<int>(k_row_stride);
     int const v_row_stride_i = static_cast<int>(v_row_stride);
@@ -337,7 +344,6 @@ struct PrefillRunner {
     stride_K_cache = cutlass::make_stride(k_row_stride_i, Int<1>{}, k_head_stride_i, k_row_stride_i * seq_len_kv_cache);
     stride_V_cache = cutlass::make_stride(Int<1>{}, v_row_stride_i, v_head_stride_i, v_row_stride_i * seq_len_kv_cache);
     stride_O = cutlass::make_stride(o_row_stride_i, Int<1>{}, o_head_stride_i, o_row_stride_i * seq_len_qo);
-
     if constexpr (isVarLen) {
       shape.seq_len_qo.cumulative_length = params.cu_seqlens_q;
       shape.seq_len_kv.cumulative_length = params.cu_seqlens_knew;

--- a/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
+++ b/src/sycl/kernels/flash_attention_v2/xe_fmha_fwd_prefill_runner.hpp
@@ -325,11 +325,11 @@ struct PrefillRunner {
     // int64_t, so narrow explicitly before handing them to make_stride.
     constexpr int64_t kIntMax = 2147483647LL;
     TORCH_CHECK(
-      q_row_stride <= kIntMax && k_row_stride <= kIntMax && v_row_stride <= kIntMax && q_head_stride <= kIntMax &&
-          k_head_stride <= kIntMax && v_head_stride <= kIntMax && o_row_stride <= kIntMax && o_head_stride <= kIntMax,
-      "Q/K/V/O stride exceeds int32 max (",
-      kIntMax,
-    ")");
+        q_row_stride <= kIntMax && k_row_stride <= kIntMax && v_row_stride <= kIntMax && q_head_stride <= kIntMax &&
+            k_head_stride <= kIntMax && v_head_stride <= kIntMax && o_row_stride <= kIntMax && o_head_stride <= kIntMax,
+        "Q/K/V/O stride exceeds int32 max (",
+        kIntMax,
+        ")");
     int const q_row_stride_i = static_cast<int>(q_row_stride);
     int const k_row_stride_i = static_cast<int>(k_row_stride);
     int const v_row_stride_i = static_cast<int>(v_row_stride);

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -3005,7 +3005,83 @@ def test_flash_attn_with_kvcache_page_size_1():
     assert out.data_ptr() == out_buf.data_ptr()
     torch.testing.assert_close(out, out_ref, atol=3e-2, rtol=3e-2)
     torch.testing.assert_close(lse, lse_ref, atol=3e-2, rtol=3e-2)
+@pytest.mark.skipif(device.type != "xpu", reason="XPU not available")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("d", [72, 128])
+def test_flash_attn_varlen_output_noncontiguous(d, causal, dtype):
+    """q/k/v sliced out of a fused qkv-projection-like buffer (last dim
+    contiguous, but row_stride > num_heads * head_size) must produce the same
+    output as the .contiguous() copy of the same data, without the caller
+    having to pay for that copy."""
+    from sgl_kernel.flash_attn import flash_attn_varlen_func
+
+    torch.random.manual_seed(d + int(causal))
+    batch_size, seqlen_q, seqlen_k, nheads = 4, 96, 128, 8
+
+    def sliced_qkv(total, nheads):
+        # Emulates a fused qkv_proj output of width 2 * nheads * d, split along
+        # the last dim into two (nheads, d) chunks: last dim stays contiguous,
+        # but row_stride == 2 * nheads * d != nheads * d.
+        fused = torch.randn(
+            total, 2 * nheads * d, device=device, dtype=dtype
+        )
+        a, b = fused.split(nheads * d, dim=-1)
+        return a.view(total, nheads, d), b.view(total, nheads, d)
+
+    q, _ = sliced_qkv(batch_size * seqlen_q, nheads)
+    k, v = sliced_qkv(batch_size * seqlen_k, nheads)
+    for t in (q, k, v):
+        assert t.stride(-1) == 1 and t.stride(-3) != nheads * d
+
+    cu_seqlens_q = torch.arange(
+        0, (batch_size + 1) * seqlen_q, step=seqlen_q, dtype=torch.int32, device=device
+    )
+    cu_seqlens_k = torch.arange(
+        0, (batch_size + 1) * seqlen_k, step=seqlen_k, dtype=torch.int32, device=device
+    )
+    softmax_scale = 1.0 / math.sqrt(d)
+
+    kwargs = dict(
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=seqlen_q,
+        max_seqlen_k=seqlen_k,
+        causal=causal,
+        softmax_scale=softmax_scale,
+    )
+
+    out = flash_attn_varlen_func(q.contiguous(), k.contiguous(), v.contiguous(), **kwargs)
+    # attention_ref expects batched (batch, seqlen, nheads, d) tensors, not the
+    # ragged (total, nheads, d) layout flash_attn_varlen_func takes. Every batch
+    # here has the same seqlen (evenly-spaced cu_seqlens), so splitting the
+    # leading "total" dim into (batch, seqlen) is a pure view (single uniform
+    # stride), which works even though q/k/v are non-contiguous.
+    out_ref, _ = attention_ref(
+        q.view(batch_size, seqlen_q, nheads, d),
+        k.view(batch_size, seqlen_k, nheads, d),
+        v.view(batch_size, seqlen_k, nheads, d),
+        softmax_scale,
+        causal=causal,
+    )
+    out_pt, _ = attention_ref(
+        q.view(batch_size, seqlen_q, nheads, d),
+        k.view(batch_size, seqlen_k, nheads, d),
+        v.view(batch_size, seqlen_k, nheads, d),
+        softmax_scale,
+        causal=causal,
+        upcast=False,
+        reorder_ops=True,
+    )
+    out_ref = out_ref.reshape(batch_size * seqlen_q, nheads, d)
+    out_pt = out_pt.reshape(batch_size * seqlen_q, nheads, d)
+    torch.xpu.synchronize()
+    # Numerical error if we just do any arithmetic on out_ref
+    fwd_atol = 2 * (out_ref + 0.3 - 0.3 - out_ref).abs().max().item()
+    assert (out - out_ref).abs().max().item() <= 2 * (
+        out_pt - out_ref
+    ).abs().max().item() + fwd_atol, "non-contiguous q/k/v must match golden result"
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))
+    sys.exit(pytest.main([f"{__file__}::test_flash_attn_varlen_output_noncontiguous"]))

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -3005,6 +3005,8 @@ def test_flash_attn_with_kvcache_page_size_1():
     assert out.data_ptr() == out_buf.data_ptr()
     torch.testing.assert_close(out, out_ref, atol=3e-2, rtol=3e-2)
     torch.testing.assert_close(lse, lse_ref, atol=3e-2, rtol=3e-2)
+
+
 @pytest.mark.skipif(device.type != "xpu", reason="XPU not available")
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("causal", [False, True])
@@ -3023,9 +3025,7 @@ def test_flash_attn_varlen_output_noncontiguous(d, causal, dtype):
         # Emulates a fused qkv_proj output of width 2 * nheads * d, split along
         # the last dim into two (nheads, d) chunks: last dim stays contiguous,
         # but row_stride == 2 * nheads * d != nheads * d.
-        fused = torch.randn(
-            total, 2 * nheads * d, device=device, dtype=dtype
-        )
+        fused = torch.randn(total, 2 * nheads * d, device=device, dtype=dtype)
         a, b = fused.split(nheads * d, dim=-1)
         return a.view(total, nheads, d), b.view(total, nheads, d)
 
@@ -3051,7 +3051,9 @@ def test_flash_attn_varlen_output_noncontiguous(d, causal, dtype):
         softmax_scale=softmax_scale,
     )
 
-    out = flash_attn_varlen_func(q.contiguous(), k.contiguous(), v.contiguous(), **kwargs)
+    out = flash_attn_varlen_func(
+        q.contiguous(), k.contiguous(), v.contiguous(), **kwargs
+    )
     # attention_ref expects batched (batch, seqlen, nheads, d) tensors, not the
     # ragged (total, nheads, d) layout flash_attn_varlen_func takes. Every batch
     # here has the same seqlen (evenly-spaced cu_seqlens), so splitting the

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -3050,9 +3050,10 @@ def test_flash_attn_varlen_output_noncontiguous(d, causal, dtype):
         causal=causal,
         softmax_scale=softmax_scale,
     )
-
+    for name, t in (("q", q), ("k", k), ("v", v)):
+        print(f"{name}: shape={tuple(t.shape)} stride={t.stride()}")
     out = flash_attn_varlen_func(
-        q.contiguous(), k.contiguous(), v.contiguous(), **kwargs
+        q, k, v, **kwargs
     )
     # attention_ref expects batched (batch, seqlen, nheads, d) tensors, not the
     # ragged (total, nheads, d) layout flash_attn_varlen_func takes. Every batch
@@ -3086,4 +3087,4 @@ def test_flash_attn_varlen_output_noncontiguous(d, causal, dtype):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([f"{__file__}::test_flash_attn_varlen_output_noncontiguous"]))
+    sys.exit(pytest.main([__file__]))

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -3052,9 +3052,7 @@ def test_flash_attn_varlen_output_noncontiguous(d, causal, dtype):
     )
     for name, t in (("q", q), ("k", k), ("v", v)):
         print(f"{name}: shape={tuple(t.shape)} stride={t.stride()}")
-    out = flash_attn_varlen_func(
-        q, k, v, **kwargs
-    )
+    out = flash_attn_varlen_func(q, k, v, **kwargs)
     # attention_ref expects batched (batch, seqlen, nheads, d) tensors, not the
     # ragged (total, nheads, d) layout flash_attn_varlen_func takes. Every batch
     # here has the same seqlen (evenly-spaced cu_seqlens), so splitting the

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -3050,9 +3050,12 @@ def test_flash_attn_varlen_output_noncontiguous(d, causal, dtype):
         causal=causal,
         softmax_scale=softmax_scale,
     )
-    for name, t in (("q", q), ("k", k), ("v", v)):
-        print(f"{name}: shape={tuple(t.shape)} stride={t.stride()}")
+
     out = flash_attn_varlen_func(q, k, v, **kwargs)
+    out_contig = flash_attn_varlen_func(
+        q.contiguous(), k.contiguous(), v.contiguous(), **kwargs
+    )
+    torch.testing.assert_close(out, out_contig, atol=3e-2, rtol=3e-2)
     # attention_ref expects batched (batch, seqlen, nheads, d) tensors, not the
     # ragged (total, nheads, d) layout flash_attn_varlen_func takes. Every batch
     # here has the same seqlen (evenly-spaced cu_seqlens), so splitting the


### PR DESCRIPTION
`flash_attn_varlen_func` doesn't support non-contiguous q, k and v. This PR adds support for non-contiguous input tensors and a dedicated test to ensure correctness. The main changes involve updating the kernel and prefill runner to handle arbitrary row and head strides, allowing Q/K/V tensors sliced from fused projections to be processed without requiring explicit `.contiguous()` copies.

Tests:
Added a new test `test_flash_attn_varlen_output_noncontiguous` in `test_flash_attention.py` to verify that the kernel produces correct results when Q/K/V are non-contiguous in memory, by comparing outputs to contiguous and reference implementations.