### PR TITLE
ci(docker): raise pip timeout/retries for triton-xpu wheel fetch

### DIFF
--- a/Dockerfile.xpu_kernel
+++ b/Dockerfile.xpu_kernel
@@ -69,7 +69,7 @@ RUN --mount=type=secret,id=github_token \
     conda activate py${PYTHON_VERSION} && \
     # . /opt/intel/oneapi/setvars.sh --force && \
     # Install Torch
-    pip install torch==2.13.0 torchvision triton-xpu --index-url https://download.pytorch.org/whl/xpu
+    pip install --timeout 300 --retries 10 torch==2.13.0 torchvision triton-xpu --index-url https://download.pytorch.org/whl/xpu
 
 # Install SGlang from source
 RUN --mount=type=secret,id=github_token \


### PR DESCRIPTION
## Summary
- Nightly Docker publish workflow keeps failing at `Dockerfile.xpu_kernel:66` while `pip install torch==2.13.0 torchvision triton-xpu` fetches `triton-xpu` wheel metadata from `download-r2.pytorch.org`. The default 15 s pip read timeout is exhausted across all 5 retries and the build aborts, so the subsequent push step is skipped and no image is published.
- Reference: run [34031947970](https://github.com/sgl-project/sgl-kernel-xpu/actions/runs/34031947970) — error: `download-r2.pytorch.org didn't respond within 15 seconds`.
- Fix: pass `--timeout 300 --retries 10` to that single `pip install` invocation so transient CDN slowness on `download-r2.pytorch.org` no longer fails the build. No pinned versions, index URL, or install list are changed.

## Test plan
- [ ] Re-run `Release Docker Images Nightly (sgl-kernel-xpu)` on this branch and confirm the `Build intel/sgl-kernel-xpu-dev` step completes and `Push intel/sgl-kernel-xpu-dev` runs.
- [ ] Confirm the resulting image contains `torch 2.13.0+xpu`, `torchvision`, and `triton-xpu` in the `py3.12` env.