### PR TITLE
cmake(device-detect): fall back to bmg instead of FATAL_ERROR

### DIFF
--- a/cmake/DeviceDetection.cmake
+++ b/cmake/DeviceDetection.cmake
@@ -97,9 +97,12 @@ function(get_device_ip_version VARIABLE_NAME)
     endif()
     message(WARNING "Failed to compile or run the get_device_ip_version C++ program.")
     set(BUILD_TARGET_DEVICE $ENV{BUILD_TARGET_DEVICE})
-    # no default device
     if(NOT BUILD_TARGET_DEVICE)
-      message(FATAL_ERROR "BUILD_TARGET_DEVICE environment variable is not set")
+      set(BUILD_TARGET_DEVICE "bmg")
+      message(WARNING
+        "Device auto-detection failed and BUILD_TARGET_DEVICE is not set; "
+        "falling back to '${BUILD_TARGET_DEVICE}'. Override with "
+        "-DDPCPP_SYCL_TARGET=<bmg|cri|...> or BUILD_TARGET_DEVICE=<...>.")
     endif()
     string(TOLOWER "${BUILD_TARGET_DEVICE}" BUILD_TARGET_DEVICE)
     set(${VARIABLE_NAME} ${BUILD_TARGET_DEVICE} PARENT_SCOPE)


### PR DESCRIPTION
## Summary
- After #390, `cmake/DeviceDetection.cmake::get_device_ip_version` raises `FATAL_ERROR` when the Level Zero probe binary crashes **and** `BUILD_TARGET_DEVICE` is not set. In build environments with no XPU exposed (any `docker build` — BuildKit has no `/dev/dri`), the probe binary segfaults and CMake aborts.
- This regressed the sglang nightly (`Release Docker Images Nightly (Intel XPU)`) starting 2026-09-04, and continues to break every downstream Dockerfile that hasn't been updated to set the new env var. See failing job [101484955550](https://github.com/sgl-project/sglang/actions/runs/34032649213/job/101484955550):
  ```
  CMake Warning at cmake/DeviceDetection.cmake:96 (message):
    Program returned non-zero exit code: Segmentation fault
  CMake Error at cmake/DeviceDetection.cmake:102 (message):
    BUILD_TARGET_DEVICE environment variable is not set
  ```
- Change: when neither the probe nor `BUILD_TARGET_DEVICE` yields a target, fall back to `bmg` with a `WARNING` instead of aborting. This restores pre-#390 behavior (bmg-by-default) for build-only environments, while still honoring the two explicit overrides (`-DDPCPP_SYCL_TARGET=...`, `BUILD_TARGET_DEVICE=...`) that CRI / future-target builds rely on.

## Test plan
- [ ] `cmake -S . -B build` inside a container with no `/dev/dri` → configures with warnings, produces a BMG-targeted build.
- [ ] `BUILD_TARGET_DEVICE=cri cmake -S . -B build` on the same host → uses CRI (override still respected).
- [ ] `cmake -DDPCPP_SYCL_TARGET=cri -S . -B build` → uses CRI (auto-detect skipped entirely).
- [ ] On a real BMG host, `cmake -S . -B build` still auto-detects IP version 20 → `bmg` (no regression on the happy path).