### PR TITLE
cmake(device-detect): unify auto-detect on device-name vocabulary

### DIFF
--- a/cmake/BuildFlags.cmake
+++ b/cmake/BuildFlags.cmake
@@ -131,18 +131,20 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 
   set(AOT_TARGETS)
 
-  # Resolve DPCPP_SYCL_TARGET: user-provided takes priority, otherwise auto-detect
+  # Resolve DPCPP_SYCL_TARGET: user-provided takes priority, otherwise auto-detect.
+  # get_device_ip_version returns a device-name string ('bmg' | 'cri') — the same
+  # vocabulary consumed by every MATCHES site downstream.
   if(DPCPP_SYCL_TARGET)
     message(STATUS "Using user-provided DPCPP_SYCL_TARGET: ${DPCPP_SYCL_TARGET}")
   else()
-    get_device_ip_version(DEVICE_IP_VERSION)
-    message(STATUS "Detected device IP version: ${DEVICE_IP_VERSION}")
-    if(DEVICE_IP_VERSION EQUAL 20)
-      set(DPCPP_SYCL_TARGET "bmg")
-    elseif(DEVICE_IP_VERSION EQUAL 35)
-      set(DPCPP_SYCL_TARGET "intel_gpu_cri")
+    get_device_ip_version(DETECTED_TARGET)
+    message(STATUS "Detected device target: ${DETECTED_TARGET}")
+    if(DETECTED_TARGET MATCHES "^(bmg|cri)$")
+      set(DPCPP_SYCL_TARGET "${DETECTED_TARGET}")
     else()
-      message(WARNING "Unknown device IP version: ${DEVICE_IP_VERSION}. Cannot auto-detect target.")
+      message(WARNING
+        "Unrecognized detected target '${DETECTED_TARGET}'. "
+        "Cannot auto-detect DPCPP_SYCL_TARGET; must be one of: bmg, cri.")
     endif()
   endif()
 

--- a/cmake/DeviceDetection.cmake
+++ b/cmake/DeviceDetection.cmake
@@ -1,11 +1,17 @@
-# Device IP version detection via Level Zero API.
+# Target-device detection via Level Zero API.
 #
 # Provides:
 #   get_device_ip_version(<variable>)
 #     Compiles and runs a small Level Zero program that queries the GPU
-#     device IP version, extracts the architecture bits, and stores the
-#     result in <variable>.  Falls back to the BUILD_TARGET_DEVICE
-#     environment variable when compilation or execution fails.
+#     device IP version, extracts the architecture bits, maps them to
+#     the canonical device-name vocabulary ('bmg' | 'cri'), and stores
+#     the result in <variable>.  Falls back to the BUILD_TARGET_DEVICE
+#     environment variable (defaulting to 'bmg') when compilation or
+#     execution fails.
+#
+# The returned value is always a device name string — same vocabulary
+# as DPCPP_SYCL_TARGET, BUILD_TARGET_DEVICE and AOT_TARGETS — so callers
+# can dispatch uniformly with MATCHES/STREQUAL.
 
 function(get_device_ip_version VARIABLE_NAME)
   # Define a C++ source file to be compiled and run
@@ -87,7 +93,20 @@ function(get_device_ip_version VARIABLE_NAME)
     string(REGEX REPLACE "\n" ";" OUTPUT_LINES "${OUTPUT_STRIPPED}")
     list(GET OUTPUT_LINES -1 LAST_LINE)
     string(STRIP "${LAST_LINE}" LAST_LINE)
-    set(${VARIABLE_NAME} "${LAST_LINE}" PARENT_SCOPE)
+    # Canonicalize the numeric arch code to the device-name vocabulary
+    # used by DPCPP_SYCL_TARGET / BUILD_TARGET_DEVICE / AOT_TARGETS.
+    #   Xe2  (BMG) = 20
+    #   Xe3P (CRI) = 35
+    if(LAST_LINE STREQUAL "20")
+      set(${VARIABLE_NAME} "bmg" PARENT_SCOPE)
+    elseif(LAST_LINE STREQUAL "35")
+      set(${VARIABLE_NAME} "cri" PARENT_SCOPE)
+    else()
+      message(WARNING
+        "Unrecognized device IP arch '${LAST_LINE}'. "
+        "Set -DDPCPP_SYCL_TARGET=<bmg|cri> or BUILD_TARGET_DEVICE=<bmg|cri> to override.")
+      set(${VARIABLE_NAME} "${LAST_LINE}" PARENT_SCOPE)
+    endif()
   else()
     if(NOT COMPILE_RESULT_VAR)
         message(WARNING "Compilation failed.")


### PR DESCRIPTION
## Summary
Follow-up to #473. `get_device_ip_version()` returned an integer arch code on the Level Zero success path but a device-name string on the fallback path; `cmake/BuildFlags.cmake` only handled the integer form via `EQUAL 20`/`EQUAL 35`. So when the L0 probe segfaulted inside the nightly Docker build (no XPU exposed) and #473's `bmg` fallback kicked in, the string matched neither branch and `DPCPP_SYCL_TARGET` was left empty, tripping the `FATAL_ERROR` in `CMakeLists.txt:94` — see [nightly run 34116982367](https://github.com/sgl-project/sgl-kernel-xpu/actions/runs/34116982367/job/101726000398):

```
-- Detected device IP version: bmg
CMake Warning at cmake/BuildFlags.cmake:145 (message):
  Unknown device IP version: bmg.  Cannot auto-detect target.
CMake Error at CMakeLists.txt:94 (message):
  Unsupported DPCPP_SYCL_TARGET: .  Must be one of: bmg, cri.
```

This two-encoding split was pre-existing (introduced with the auto-detect logic in #390); #473 just made the fallback path reliably trigger it.

## Approach
Canonicalize both paths in `cmake/DeviceDetection.cmake` to the device-name vocabulary already used by `DPCPP_SYCL_TARGET`, `BUILD_TARGET_DEVICE`, `AOT_TARGETS` and every `MATCHES` site downstream — so `get_device_ip_version()` uniformly returns `bmg` or `cri` (the numeric arch → name mapping lives in one place). `cmake/BuildFlags.cmake` now consumes device names via a single `MATCHES "^(bmg|cri)$"` guard.

Also drops the stray `intel_gpu_cri` half-name from `BuildFlags.cmake:143` — it worked only because everything downstream uses `MATCHES "cri"`, and made the mapping look inconsistent with the `"bmg"` sibling.

## Files changed
- `cmake/DeviceDetection.cmake` — map arch code (`20` → `bmg`, `35` → `cri`) before returning on the L0 success path; fallback path already returns a device name (unchanged since #473). Updates header doc to reflect the new contract.
- `cmake/BuildFlags.cmake` — replaces the `EQUAL 20 / EQUAL 35 → intel_gpu_cri` branches with a single device-name check.

No other files touched. All existing `DPCPP_SYCL_TARGET MATCHES "bmg"` / `MATCHES "cri"` dispatch sites (`CMakeLists.txt:88,100`, `BuildFlags.cmake:152,155`, `src/BuildOnLinux.cmake:254`) keep working with no code change — they already spoke this vocabulary.

## Sanity walk-through
| Scenario | Path | Result |
|----------|------|--------|
| User passes `-DDPCPP_SYCL_TARGET=cri` | user-override branch (unchanged) | `DPCPP_SYCL_TARGET=cri` ✓ |
| Auto-detect on real BMG runner | L0 success → arch 20 → mapped to `bmg` | `DPCPP_SYCL_TARGET=bmg` ✓ |
| Auto-detect on real CRI runner | L0 success → arch 35 → mapped to `cri` | `DPCPP_SYCL_TARGET=cri` ✓ |
| Docker build without device (nightly) | L0 segfault → fallback returns `bmg` (from #473) | `DPCPP_SYCL_TARGET=bmg` ✓ — the case this PR is unblocking |

## Test plan
- [ ] Nightly Docker workflow (`Release Docker Images Nightly (sgl-kernel-xpu)`) passes CMake configure and completes the `Build intel/sgl-kernel-xpu-dev` step.
- [ ] Local build on a BMG-attached runner still auto-detects to `bmg` (regression check — new `EQUAL "20"` compare in `DeviceDetection.cmake` matches the stdout of the L0 probe).
- [ ] Explicit `pip install -v . --config-settings=cmake.define.DPCPP_SYCL_TARGET=cri` still produces a CRI wheel.

/cc @mkumargarg — since #390 introduced the auto-detect design, would appreciate your eyes on whether the arch-code → device-name mapping table (`20 → bmg`, `35 → cri`) is the right place to keep this. @airMeng @kareemshaik80 for the follow-up context from #473.