### PR TITLE
Reduce MoE workspace headroom to 1 to avoid OOM

### DIFF
--- a/python/sgl_kernel/moe.py
+++ b/python/sgl_kernel/moe.py
@@ -369,7 +369,7 @@ def cutlass_fp4_group_mm(
     return c.to(dtype=out_dtype)
 
 
-_MOE_WS_HEADROOM = 1.1
+_MOE_WS_HEADROOM = 1
 _MOE_SMALL_PREPARE_MAX_ROUTES = 64
 _MOE_SMALL_PREPARE_MAX_TOPK = 16
 _MOE_SMALL_PREPARE_MAX_ELEMENTS = 163840


### PR DESCRIPTION
As the title. Headroom reduced from 1.1 to 1 to avoid OOM of Qwen3.5-35B on 4 B60 GPUs.