### PR TITLE
added optimization on MLA sparse Stage-1 gather kernel

### DIFF
--- a/src/sycl/kernels/mla_sparse/collective/xe_mla_sparse_2stage_epilogue.hpp
+++ b/src/sycl/kernels/mla_sparse/collective/xe_mla_sparse_2stage_epilogue.hpp
@@ -36,8 +36,7 @@ using cutlass::flash_attention::kernel::LOG_E_2;
 /////////////////////////////////////////////////////////////////////////////////////////////////
 // HAS_MAX_LOGITS_ gates the prefill-only pre-sink row-max (max_logits) write: the
 // decode epilogue is instantiated with false so that store is compiled out; the
-// prefill config passes true. Kept a template param (rather than the old runtime
-// null-guard) so decode never emits the extra store path.
+// prefill config passes true.
 //
 // IS_SPLIT_KV_ turns this into the split-K *publishing* epilogue: instead of finishing
 // the row (attn_sink merge, softmax normalization, LSE) and writing `out`, it stores the
@@ -158,8 +157,6 @@ class XeMlaSparse2StageEpilogue {
       // Which split of the gathered topk dim produced tArA / tA_max / tA_sum. Read only
       // under IS_SPLIT_KV; the non-split instantiation ignores it.
       int kv_split_idx = 0) {
-    float* lse = params.lse;
-
     TiledMMAPV mma_pv{};
 
     Tensor proxyO = make_identity_tensor(O.shape());
@@ -271,12 +268,15 @@ class XeMlaSparse2StageEpilogue {
         int local_head_idx = sg_id * valid_tid_per_sg + tid_in_sg;
         int head_idx = cur_head_start_idx + local_head_idx;
         if (head_idx < params.h_q) {
-          int stat_idx = batch_idx * params.stride_split_stats_b + seq_idx * params.stride_split_stats_s_q +
-                         kv_split_idx * params.stride_split_stats_split + head_idx;
-          // An empty / fully-masked split lands here with tA_sum still 0 (the mainloop's
-          // topk loop ran zero times), which is exactly the reduction's skip signal.
-          params.split_exp_sums[stat_idx] = rA_sum(0);
-          params.split_max_logits[stat_idx] = rA_max(0);
+          // [b, s_q, num_kv_splits, h_q] stat tensors (h_q contiguous).
+          auto stat_layout = make_layout(
+              make_shape(params.b, params.s_q, params.num_kv_splits, params.h_q),
+              make_stride(
+                  params.stride_split_stats_b, params.stride_split_stats_s_q, params.stride_split_stats_split, _1{}));
+          Tensor mSplitExpSums = make_tensor(make_gmem_ptr(params.split_exp_sums), stat_layout);
+          Tensor mSplitMaxLogits = make_tensor(make_gmem_ptr(params.split_max_logits), stat_layout);
+          mSplitExpSums(batch_idx, seq_idx, kv_split_idx, head_idx) = rA_sum(0);
+          mSplitMaxLogits(batch_idx, seq_idx, kv_split_idx, head_idx) = rA_max(0);
         }
       }
 
@@ -293,8 +293,6 @@ class XeMlaSparse2StageEpilogue {
       int local_head_idx = sg_id * valid_tid_per_sg + tid_in_sg;
       int head_idx = cur_head_start_idx + local_head_idx;
       if (head_idx < params.h_q) {
-        int lse_idx = batch_idx * params.stride_lse_b + seq_idx * params.stride_lse_s_q + head_idx;
-
         float row_max = -INFINITY;
         if (rA_max(0) != params.sm_scale_div_log2 * cutlass::platform::numeric_limits<ElementA>::lowest()) {
           row_max = rA_max(0) * LOG_E_2;
@@ -304,14 +302,22 @@ class XeMlaSparse2StageEpilogue {
         if (rA_sum(0) > 0.f) {
           row_lse = row_max + sycl::native::log2(rA_sum(0)) * LOG_E_2;
         }
-        lse[lse_idx] = row_lse;
-        // Prefill also returns the pre-sink row max (max_logits); decode is
-        // instantiated HAS_MAX_LOGITS=false so this store is compiled out. Uses the
-        // same [b, s_q, h_q] indexing as lse.
+        // [b, s_q, h_q] lse tensor (h_q contiguous).
+        Tensor mLse = make_tensor(
+            make_gmem_ptr(params.lse),
+            make_layout(
+                make_shape(params.b, params.s_q, params.h_q),
+                make_stride(params.stride_lse_b, params.stride_lse_s_q, _1{})));
+        mLse(batch_idx, seq_idx, head_idx) = row_lse;
+        // Prefill also returns the pre-sink row max (max_logits); decode is instantiated
+        // HAS_MAX_LOGITS=false so this store is compiled out. Same [b, s_q, h_q] indexing as lse.
         if constexpr (HAS_MAX_LOGITS) {
-          int max_logits_idx =
-              batch_idx * params.stride_max_logits_b + seq_idx * params.stride_max_logits_s_q + head_idx;
-          params.max_logits[max_logits_idx] = row_max;
+          Tensor mMaxLogits = make_tensor(
+              make_gmem_ptr(params.max_logits),
+              make_layout(
+                  make_shape(params.b, params.s_q, params.h_q),
+                  make_stride(params.stride_max_logits_b, params.stride_max_logits_s_q, _1{})));
+          mMaxLogits(batch_idx, seq_idx, head_idx) = row_max;
         }
       }
     }

--- a/src/sycl/kernels/mla_sparse/collective/xe_mla_sparse_2stage_epilogue.hpp
+++ b/src/sycl/kernels/mla_sparse/collective/xe_mla_sparse_2stage_epilogue.hpp
@@ -26,7 +26,8 @@
 #pragma once
 
 #include "sycl/kernels/mla_sparse/device/xe_mla_sparse_2stage_common.hpp"
-
+#define THR_ID -1
+#define BLK_ID -1
 namespace cutlass::flash_attention::collective {
 
 using cutlass::flash_attention::kernel::Epilogue2StageParams;
@@ -170,6 +171,16 @@ class XeMlaSparse2StageEpilogue {
     auto tOrO = thr_copy_o.partition_sg_fragment_S(gO);
     auto tOgO = thr_copy_o.partition_D(gO);
 
+    // if(cute::thread(THR_ID, BLK_ID)){
+    //     #define PRINT(x) print(#x ": "); print(x); print("\n");
+    //     PRINT(tArA);
+    //     PRINT(tA_max);
+    //     PRINT(tA_sum);
+    //     PRINT(gO);
+    //     PRINT(tOrO);
+    //     PRINT(tOgO);
+    //     PRINT(ReduceK{});
+    // }
     auto reduce_L = [&]() {
       if constexpr (ReduceK{} == _1{}) {
         return std::make_tuple(tArA, tA_max, tA_sum, true);
@@ -192,6 +203,15 @@ class XeMlaSparse2StageEpilogue {
         auto sA = make_tensor(make_smem_ptr<ElementA>(&shared_storage.a_data), sA_layout);
         auto sA_max = make_tensor(make_smem_ptr<ElementA>(&shared_storage.a_max_data), sA_row_layout);
         auto sA_sum = make_tensor(make_smem_ptr<ElementA>(&shared_storage.a_sum_data), sA_row_layout);
+        // if(cute::thread(THR_ID, BLK_ID)){
+        //   #define PRINT(x) print(#x ": "); print(x); print("\n");
+        //   PRINT(tArA);
+        //   PRINT(tA_max);
+        //   PRINT(tA_sum);
+        //   PRINT(sA);
+        //   PRINT(sA_max);
+        //   PRINT(sA_sum);
+        // }
 
         copy_block_r2s(tA_max, sA_max(_, _, k_blk, a_tile));
         barrier_arrive(ScopeWorkgroup, SemanticsRelease | SemanticsWGMemory);
@@ -221,6 +241,13 @@ class XeMlaSparse2StageEpilogue {
                 rA_max, rA_kmax[kr], rA_kmax[kr], [](auto gmax, auto kmax) { return sycl::native::exp2(kmax - gmax); });
           }
         }
+        // if(cute::thread(THR_ID, BLK_ID)){
+        //   #define PRINT(x) print(#x ": "); print(x); print("\n");
+        //   PRINT(rA);
+        //   PRINT(rA_max);
+        //   PRINT(rA_sum);
+        //   PRINT(rA_kmax);
+        // }
 
         barrier_wait(ScopeWorkgroup, SemanticsAcquire | SemanticsWGMemory);
 
@@ -324,7 +351,7 @@ class XeMlaSparse2StageEpilogue {
         CUTE_UNROLL
         for (int i = 0; i < rA.size(); ++i) {
           auto global_exp_sum = broadcast<0>(rA_sum, rA, i);
-          ElementA final_rescale = global_exp_sum != 0 ? ElementA(1) / global_exp_sum : ElementA(0);
+          ElementA final_rescale = global_exp_sum != 0 ? sycl::native::recip(global_exp_sum) : ElementA(0);
           int local_head_idx = get<0>(rA.tv_layout()(0, i));
           int head_idx = cur_head_start_idx + reduce_head_offset + local_head_idx;
           if (head_idx < params.h_q) {
@@ -332,7 +359,7 @@ class XeMlaSparse2StageEpilogue {
             float attn_sink_val = params.attn_sink[head_idx];
             ElementA sink_exp_sum = sycl::native::exp2(static_cast<ElementA>(attn_sink_val * LOG_2_E) - global_max);
             ElementA global_exp_sum_with_sink = global_exp_sum + sink_exp_sum;
-            final_rescale = global_exp_sum_with_sink != 0 ? ElementA(1) / global_exp_sum_with_sink : ElementA(0);
+            final_rescale = global_exp_sum_with_sink != 0 ? sycl::native::recip(global_exp_sum_with_sink) : ElementA(0);
           }
           rA(i) *= final_rescale;
         }
@@ -352,7 +379,7 @@ class XeMlaSparse2StageEpilogue {
         CUTE_UNROLL
         for (int i = 0; i < rA_sum.size(); ++i) {
           if (rA_sum(i) != 0) {
-            rA_sum(i) = ElementA(1) / rA_sum(i);
+            rA_sum(i) = sycl::native::recip(rA_sum(i));
           } else {
             rA_sum(i) = 0;
           }
@@ -367,7 +394,7 @@ class XeMlaSparse2StageEpilogue {
       CUTE_UNROLL
       for (int i = 0; i < rA_sum.size(); ++i) {
         if (rA_sum(i) != 0) {
-          rA_sum(i) = ElementA(1) / rA_sum(i);
+          rA_sum(i) = sycl::native::recip(rA_sum(i));
         } else {
           rA_sum(i) = 0;
         }

--- a/src/sycl/kernels/mla_sparse/collective/xe_mla_sparse_2stage_epilogue.hpp
+++ b/src/sycl/kernels/mla_sparse/collective/xe_mla_sparse_2stage_epilogue.hpp
@@ -26,8 +26,7 @@
 #pragma once
 
 #include "sycl/kernels/mla_sparse/device/xe_mla_sparse_2stage_common.hpp"
-#define THR_ID -1
-#define BLK_ID -1
+
 namespace cutlass::flash_attention::collective {
 
 using cutlass::flash_attention::kernel::Epilogue2StageParams;
@@ -171,16 +170,6 @@ class XeMlaSparse2StageEpilogue {
     auto tOrO = thr_copy_o.partition_sg_fragment_S(gO);
     auto tOgO = thr_copy_o.partition_D(gO);
 
-    // if(cute::thread(THR_ID, BLK_ID)){
-    //     #define PRINT(x) print(#x ": "); print(x); print("\n");
-    //     PRINT(tArA);
-    //     PRINT(tA_max);
-    //     PRINT(tA_sum);
-    //     PRINT(gO);
-    //     PRINT(tOrO);
-    //     PRINT(tOgO);
-    //     PRINT(ReduceK{});
-    // }
     auto reduce_L = [&]() {
       if constexpr (ReduceK{} == _1{}) {
         return std::make_tuple(tArA, tA_max, tA_sum, true);
@@ -203,15 +192,6 @@ class XeMlaSparse2StageEpilogue {
         auto sA = make_tensor(make_smem_ptr<ElementA>(&shared_storage.a_data), sA_layout);
         auto sA_max = make_tensor(make_smem_ptr<ElementA>(&shared_storage.a_max_data), sA_row_layout);
         auto sA_sum = make_tensor(make_smem_ptr<ElementA>(&shared_storage.a_sum_data), sA_row_layout);
-        // if(cute::thread(THR_ID, BLK_ID)){
-        //   #define PRINT(x) print(#x ": "); print(x); print("\n");
-        //   PRINT(tArA);
-        //   PRINT(tA_max);
-        //   PRINT(tA_sum);
-        //   PRINT(sA);
-        //   PRINT(sA_max);
-        //   PRINT(sA_sum);
-        // }
 
         copy_block_r2s(tA_max, sA_max(_, _, k_blk, a_tile));
         barrier_arrive(ScopeWorkgroup, SemanticsRelease | SemanticsWGMemory);
@@ -241,13 +221,6 @@ class XeMlaSparse2StageEpilogue {
                 rA_max, rA_kmax[kr], rA_kmax[kr], [](auto gmax, auto kmax) { return sycl::native::exp2(kmax - gmax); });
           }
         }
-        // if(cute::thread(THR_ID, BLK_ID)){
-        //   #define PRINT(x) print(#x ": "); print(x); print("\n");
-        //   PRINT(rA);
-        //   PRINT(rA_max);
-        //   PRINT(rA_sum);
-        //   PRINT(rA_kmax);
-        // }
 
         barrier_wait(ScopeWorkgroup, SemanticsAcquire | SemanticsWGMemory);
 

--- a/src/sycl/kernels/mla_sparse/collective/xe_mla_sparse_2stage_mainloop.hpp
+++ b/src/sycl/kernels/mla_sparse/collective/xe_mla_sparse_2stage_mainloop.hpp
@@ -30,8 +30,7 @@
 #pragma once
 
 #include "sycl/kernels/mla_sparse/device/xe_mla_sparse_2stage_common.hpp"
-#define THR_ID -1
-#define BLK_ID -1
+
 namespace cutlass::flash_attention::collective {
 
 using cutlass::flash_attention::kernel::LOG_2_E;
@@ -161,26 +160,6 @@ class XeMlaSparse2StageMainloop {
     auto tSrK = thr_mma_qk.partition_sg_fragment_B(gK(_, _, 0, 0));
     auto tSrS = thr_mma_qk.partition_sg_fragment_C(proxyP);
 
-    // if(cute::thread(THR_ID, BLK_ID)){
-    //     print("****************************\n");
-    //     #define PRINT(x) print(#x ": "); print(x); print("\n");
-    //     PRINT(gQ);
-    //     PRINT(gK);
-    //     PRINT(gV);
-    //     PRINT(gV_split);
-    //     PRINT(tQgQ);
-    //     PRINT(tKgK);
-    //     PRINT(tVgV);
-
-    //     PRINT(tSrQ);
-    //     PRINT(tQcQ);
-    //     PRINT(tQrQ);
-
-    //     PRINT(tKrK);
-    //     PRINT(tSrK);
-    //     PRINT(tSrS);
-    //   }
-
     auto qk_gemm_one_tile = [&](int block_idx, int tile_idx) {
       if constexpr (IS_FP8_QUERY) {
         CUTE_UNROLL
@@ -260,11 +239,7 @@ class XeMlaSparse2StageMainloop {
       }
       return rescale;
     };
-    // if(cute::thread(THR_ID, BLK_ID)){
-    //   #define PRINT(x) print(#x ": "); print(x); print("\n");
-    //   PRINT(tA_max);
-    //   PRINT(tA_sum);
-    // }
+
     auto tArP = thr_mma_pv.partition_sg_fragment_A(proxyP);
     auto tVrV = thr_copy_v.partition_sg_fragment_D(gV_split(_, _, 0, 0));
     auto tArV = thr_mma_pv.partition_sg_fragment_B(gV_split(_, _, 0, 0));
@@ -274,13 +249,6 @@ class XeMlaSparse2StageMainloop {
       reorder(tVrV, tArV);
       cute::gemm(mma_pv, tArP, tArV, tArA(_, _, _, local_v_tile_idx));
     };
-    // if(cute::thread(THR_ID, BLK_ID)){
-    //     #define PRINT(x) print(#x ": "); print(x); print("\n");
-    //     PRINT(tArA);
-    //     PRINT(tArP);
-    //     PRINT(tVrV)
-    //     PRINT(tArV);
-    // }
     // Fully-masked-block skip: resolve the per-batch valid lengths of the two
     // concatenated pools once, in registers, so we can cheaply prove an entire
     // 64-column block lies outside every valid range and skip its QK/softmax/PV
@@ -318,15 +286,6 @@ class XeMlaSparse2StageMainloop {
     const int blocks_per_split = ceil_div(num_topk_blocks, num_kv_splits);
     const int blk_start = kv_split_idx * blocks_per_split;
     const int blk_end = cute::min(num_topk_blocks, blk_start + blocks_per_split);
-    // if(cute::thread(THR_ID, BLK_ID)){
-    //   #define PRINT(x) print(#x ": "); print(x); print("\n");
-    //   PRINT(num_topk_blocks);
-    //   PRINT(num_kv_splits);
-    //   PRINT(blocks_per_split);
-    //   PRINT(kv_split_idx);
-    //   PRINT(blk_start);
-    //   PRINT(blk_end);
-    // }
 
     CUTE_NO_UNROLL
     for (int topk_idx = blk_start; topk_idx < blk_end; ++topk_idx) {

--- a/src/sycl/kernels/mla_sparse/collective/xe_mla_sparse_2stage_mainloop.hpp
+++ b/src/sycl/kernels/mla_sparse/collective/xe_mla_sparse_2stage_mainloop.hpp
@@ -3,28 +3,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **************************************************************************************************/
 /*! \file
-    \brief Two-stage sparse MLA Stage 2 mainloop collective for DeepSeek V4
-           (decode + prefill).
+    \brief Two-stage sparse MLA Stage 2 mainloop collective
 
     QK/PV DPAS GEMM engine + online (log2) softmax over the Stage 1 gathered tile.
     Consumes the per-(batch, seq, v-split) gmem Q/K/V tiles built by the kernel
     wrapper and produces the O accumulator + softmax max/sum row stats, which the
     epilogue collective then reduces, normalizes, and writes out.
-
-    Path-agnostic: both two-stage paths use this collective unchanged (see the Stage-2
-    kernel wrapper, kernel/xe_mla_sparse_2stage_dense_kernel.hpp).
-
-    Structural analog of collective/xe_mla_sparse_mainloop.hpp (the fused path): a
-    compute collective owning the MMA/tile/fragment type aliases, its Params, its
-    SharedStorage, ctor (Params const&, SharedStorage&), and operator(). Shared
-    declarations (SparseAttnDecodeParams, LOG_* constants, the copy_block_*
-    helpers) come from the kernel/ common header; the DPAS/tile geometry it reads
-    off its Traits template param is MlaSparseDecode2StageTileTraits, declared in that
-    same common header. Traits carries geometry only -- element types, MMA atoms, tile
-    shapes, sizes -- never the assembly (which collectives / kernels / runner), which
-    is the config struct's business.
-
-    Correctness reference: tests/test_flash_mla_with_kvcache.py _sm120_sparse_decode_fwd.
 */
 
 #pragma once

--- a/src/sycl/kernels/mla_sparse/collective/xe_mla_sparse_2stage_mainloop.hpp
+++ b/src/sycl/kernels/mla_sparse/collective/xe_mla_sparse_2stage_mainloop.hpp
@@ -30,7 +30,8 @@
 #pragma once
 
 #include "sycl/kernels/mla_sparse/device/xe_mla_sparse_2stage_common.hpp"
-
+#define THR_ID -1
+#define BLK_ID -1
 namespace cutlass::flash_attention::collective {
 
 using cutlass::flash_attention::kernel::LOG_2_E;
@@ -160,6 +161,26 @@ class XeMlaSparse2StageMainloop {
     auto tSrK = thr_mma_qk.partition_sg_fragment_B(gK(_, _, 0, 0));
     auto tSrS = thr_mma_qk.partition_sg_fragment_C(proxyP);
 
+    // if(cute::thread(THR_ID, BLK_ID)){
+    //     print("****************************\n");
+    //     #define PRINT(x) print(#x ": "); print(x); print("\n");
+    //     PRINT(gQ);
+    //     PRINT(gK);
+    //     PRINT(gV);
+    //     PRINT(gV_split);
+    //     PRINT(tQgQ);
+    //     PRINT(tKgK);
+    //     PRINT(tVgV);
+
+    //     PRINT(tSrQ);
+    //     PRINT(tQcQ);
+    //     PRINT(tQrQ);
+
+    //     PRINT(tKrK);
+    //     PRINT(tSrK);
+    //     PRINT(tSrS);
+    //   }
+
     auto qk_gemm_one_tile = [&](int block_idx, int tile_idx) {
       if constexpr (IS_FP8_QUERY) {
         CUTE_UNROLL
@@ -190,11 +211,16 @@ class XeMlaSparse2StageMainloop {
     auto mask_rS = [&](int block_idx) {
       Tensor coord_S = make_identity_tensor(select<0, 1>(TileShapeQK{}));
       Tensor tCgC = thr_mma_qk.partition_C(coord_S);
+      int prev_col_idx = -1;
+      bool is_valid = true;
       CUTE_UNROLL
       for (int i = 0; i < tSrS.size(); ++i) {
-        int col_idx = get<1>(tCgC(i));
-        int topk_idx = block_idx * Traits::B_TOPK + col_idx;
-        bool is_valid = topk_idx < params.gathered_topk && gathered_valid_mask_ptr[topk_idx];
+        const int col_idx = get<1>(tCgC(i));
+        if (col_idx != prev_col_idx) {
+          const int topk_idx = block_idx * Traits::B_TOPK + col_idx;
+          is_valid = topk_idx < params.gathered_topk && gathered_valid_mask_ptr[topk_idx];
+          prev_col_idx = col_idx;
+        }
         if (!is_valid) {
           tSrS(i) = cutlass::platform::numeric_limits<ElementS>::lowest();
         }
@@ -234,7 +260,11 @@ class XeMlaSparse2StageMainloop {
       }
       return rescale;
     };
-
+    // if(cute::thread(THR_ID, BLK_ID)){
+    //   #define PRINT(x) print(#x ": "); print(x); print("\n");
+    //   PRINT(tA_max);
+    //   PRINT(tA_sum);
+    // }
     auto tArP = thr_mma_pv.partition_sg_fragment_A(proxyP);
     auto tVrV = thr_copy_v.partition_sg_fragment_D(gV_split(_, _, 0, 0));
     auto tArV = thr_mma_pv.partition_sg_fragment_B(gV_split(_, _, 0, 0));
@@ -244,7 +274,13 @@ class XeMlaSparse2StageMainloop {
       reorder(tVrV, tArV);
       cute::gemm(mma_pv, tArP, tArV, tArA(_, _, _, local_v_tile_idx));
     };
-
+    // if(cute::thread(THR_ID, BLK_ID)){
+    //     #define PRINT(x) print(#x ": "); print(x); print("\n");
+    //     PRINT(tArA);
+    //     PRINT(tArP);
+    //     PRINT(tVrV)
+    //     PRINT(tArV);
+    // }
     // Fully-masked-block skip: resolve the per-batch valid lengths of the two
     // concatenated pools once, in registers, so we can cheaply prove an entire
     // 64-column block lies outside every valid range and skip its QK/softmax/PV
@@ -282,6 +318,15 @@ class XeMlaSparse2StageMainloop {
     const int blocks_per_split = ceil_div(num_topk_blocks, num_kv_splits);
     const int blk_start = kv_split_idx * blocks_per_split;
     const int blk_end = cute::min(num_topk_blocks, blk_start + blocks_per_split);
+    // if(cute::thread(THR_ID, BLK_ID)){
+    //   #define PRINT(x) print(#x ": "); print(x); print("\n");
+    //   PRINT(num_topk_blocks);
+    //   PRINT(num_kv_splits);
+    //   PRINT(blocks_per_split);
+    //   PRINT(kv_split_idx);
+    //   PRINT(blk_start);
+    //   PRINT(blk_end);
+    // }
 
     CUTE_NO_UNROLL
     for (int topk_idx = blk_start; topk_idx < blk_end; ++topk_idx) {

--- a/src/sycl/kernels/mla_sparse/device/mla_sparse_decode_2stage_types.hpp
+++ b/src/sycl/kernels/mla_sparse/device/mla_sparse_decode_2stage_types.hpp
@@ -375,6 +375,8 @@ inline typename T::Fmla::Arguments args_from_options_2stage(
   g.extra_num_blocks = extra_num_blocks;
   g.extra_page_block_size = extra_page_block_size;
   g.extra_topk = extra_topk;
+  g.page_block_divmod = cutlass::FastDivmod(std::max(1, page_block_size));
+  g.extra_page_block_divmod = cutlass::FastDivmod(std::max(1, extra_page_block_size));
   g.kv = reinterpret_cast<uint8_t*>(k_cache.data_ptr());
   g.stride_kv_block = to_int_stride(k_cache.stride(0));
   g.extra_kv = has_extra ? reinterpret_cast<uint8_t*>(extra_k_cache.value().data_ptr()) : nullptr;

--- a/src/sycl/kernels/mla_sparse/device/mla_sparse_decode_2stage_types.hpp
+++ b/src/sycl/kernels/mla_sparse/device/mla_sparse_decode_2stage_types.hpp
@@ -344,6 +344,9 @@ inline typename T::Fmla::Arguments args_from_options_2stage(
   // --- Epilogue slice: reduce / normalize / LSE / attn_sink (no max_logits for decode). ---
   auto& ep = params.epilogue;
   ep.h_q = h_q;
+  ep.b = b;
+  ep.s_q = s_q;
+  ep.num_kv_splits = num_kv_splits;
   ep.sm_scale_div_log2 = sm_scale_div_log2;
   ep.lse = reinterpret_cast<float*>(lse_out.data_ptr());
   ep.stride_lse_b = to_int_stride(lse_out.stride(0));
@@ -553,6 +556,7 @@ inline void runMlaSparse2StageImpl(
   for (int b0 = 0; b0 < b; b0 += chunk_b) {
     const int cb = std::min(chunk_b, b - b0);
     params.kernel.shape.b = cb;
+    params.epilogue.b = cb;  // keep the epilogue's lse / stat layout extent in step with the chunk
     gather_args.b = cb;
 
     void* q_ptr = batch_base(q, b0);

--- a/src/sycl/kernels/mla_sparse/device/mla_sparse_prefill_2stage_types.hpp
+++ b/src/sycl/kernels/mla_sparse/device/mla_sparse_prefill_2stage_types.hpp
@@ -256,6 +256,10 @@ inline typename T::Fmla::Arguments args_from_options_prefill_2stage(
   //     max_logits are [s_q, h_q]; the row is the mapped batch, s_q stride is 0. ---
   auto& ep = params.epilogue;
   ep.h_q = h_q;
+  ep.b = shape.b;
+  ep.s_q = shape.s_q;
+  // Prefill is never split-K (no o_accum), so num_kv_splits stays 1 and the split-stat
+  // path is compiled out; b / s_q feed the lse / max_logits [b, s_q, h_q] views.
   ep.sm_scale_div_log2 = sm_scale_div_log2;
   ep.lse = reinterpret_cast<float*>(lse.data_ptr());
   ep.stride_lse_b = to_int_stride(lse.stride(0));
@@ -400,6 +404,7 @@ inline void runMlaSparsePrefill2StageImpl(
   for (int r0 = 0; r0 < s_q; r0 += chunk_rows) {
     const int cr = std::min(chunk_rows, s_q - r0);
     params.kernel.shape.b = cr;
+    params.epilogue.b = cr;  // keep the epilogue's lse / max_logits layout extent in step with the chunk
     gather_args.b = cr;
 
     void* q_ptr = row_base(q, r0);

--- a/src/sycl/kernels/mla_sparse/device/xe_mla_sparse_2stage_common.hpp
+++ b/src/sycl/kernels/mla_sparse/device/xe_mla_sparse_2stage_common.hpp
@@ -48,6 +48,7 @@
 
 #include "cutlass/bfloat16.h"
 #include "cutlass/device_kernel.h"
+#include "cutlass/fast_math.h"
 #include "cutlass/float8.h"
 #include "cutlass/half.h"
 
@@ -266,6 +267,12 @@ struct Gather2StageParams {
 struct DecodeGather2StageParams : Gather2StageParams {
   int num_blocks = 0, page_block_size = 0;
   int extra_num_blocks = 0, extra_page_block_size = 0, extra_topk = 0;
+
+  // Precomputed magic-number reciprocals for the two page sizes, so locate_token's
+  // token_idx -> (block_idx, rel_idx) split costs a multiply-high plus two shifts instead
+  // of an divide.
+  cutlass::FastDivmod page_block_divmod;
+  cutlass::FastDivmod extra_page_block_divmod;
 
   uint8_t* __restrict__ kv = nullptr;  // packed fp8 KV cache
   int stride_kv_block = 0;

--- a/src/sycl/kernels/mla_sparse/device/xe_mla_sparse_2stage_common.hpp
+++ b/src/sycl/kernels/mla_sparse/device/xe_mla_sparse_2stage_common.hpp
@@ -212,6 +212,12 @@ struct Mainloop2StageParams {
 // write out (leaving these fields null/0).
 struct Epilogue2StageParams {
   int h_q = 0;
+  // Batch / query-seqlen (and, for split-K, the split count) the stat tensors are sliced
+  // from: lse / max_logits are [b, s_q, h_q]; the split stats are [b, s_q, num_kv_splits,
+  // h_q]. The epilogue builds those CuTe views and indexes by (batch, seq, [kv-split,] head)
+  // instead of a flattened base + idx*stride. num_kv_splits is read only by the split-K
+  // publish path (IS_SPLIT_KV); non-split leaves it 1.
+  int b = 0, s_q = 0, num_kv_splits = 1;
   float sm_scale_div_log2 = 0.f;
 
   float* __restrict__ lse = nullptr;  // [b, s_q, h_q]

--- a/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_dense_kernel.hpp
+++ b/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_dense_kernel.hpp
@@ -202,44 +202,59 @@ class XeMlaSparse2StageDenseKernel {
       const int head_bid = tile.head_bid;
       const int v_split_idx = tile.v_split_idx;
       const int cur_head_start_idx = head_bid * Traits::B_H;
-      const int cur_v_start_idx = v_split_idx * Traits::D_V_PER_SPLIT;
 
-      // Q [h_q, D_QK] gmem view, offset to (batch, seq).
-      auto* q_ptr = q + batch_idx * kp.stride_q_b + seq_idx * kp.stride_q_s_q;
-      auto q_layout = make_layout(make_shape(s.h_q, D_QK), make_stride(kp.stride_q_h_q, _1{}));
-      Tensor Q = make_tensor(make_gmem_ptr(q_ptr), q_layout);
+      // Q [h_q, D_QK], sliced to (batch, seq).
+      auto mQ = make_tensor(
+          make_gmem_ptr(q),
+          make_layout(
+              make_shape(s.b, s.s_q, s.h_q, D_QK), make_stride(kp.stride_q_b, kp.stride_q_s_q, kp.stride_q_h_q, _1{})));
+      Tensor Q = mQ(batch_idx, seq_idx, _, _);
 
-      // O [h_q, D_V] gmem view, offset to (batch, seq). Under split-K this is instead the
-      // o_accum slice for (batch, seq, kv-split): same shape, so the epilogue's store path
-      // is untouched and only the base pointer / row stride change. The final `out` is
-      // then written by the reduction companion.
-      auto o_layout_for = [&](ElementO* base, int stride_h_q) {
-        auto layout = make_layout(make_shape(s.h_q, Traits::D_V), make_stride(stride_h_q, _1{}));
-        return make_tensor(make_gmem_ptr(base), layout);
-      };
+      // O [h_q, D_V], sliced to (batch, seq). Under split-K this is instead the o_accum
+      // partial sliced to (batch, seq, kv-split): the slice has the same [h_q, D_V] shape
       auto O = [&] {
         if constexpr (is_split_kv) {
-          ElementO* base = kp.o_accum + batch_idx * kp.stride_o_accum_b + seq_idx * kp.stride_o_accum_s_q +
-                           tile.kv_split_idx * kp.stride_o_accum_split;
-          return o_layout_for(base, kp.stride_o_accum_h_q);
+          auto mO = make_tensor(
+              make_gmem_ptr(kp.o_accum),
+              make_layout(
+                  make_shape(s.b, s.s_q, num_kv_splits, s.h_q, Traits::D_V),
+                  make_stride(
+                      kp.stride_o_accum_b,
+                      kp.stride_o_accum_s_q,
+                      kp.stride_o_accum_split,
+                      kp.stride_o_accum_h_q,
+                      _1{})));
+          return mO(batch_idx, seq_idx, tile.kv_split_idx, _, _);
         } else {
-          return o_layout_for(out + batch_idx * kp.stride_o_b + seq_idx * kp.stride_o_s_q, kp.stride_o_h_q);
+          auto mO = make_tensor(
+              make_gmem_ptr(out),
+              make_layout(
+                  make_shape(s.b, s.s_q, s.h_q, Traits::D_V),
+                  make_stride(kp.stride_o_b, kp.stride_o_s_q, kp.stride_o_h_q, _1{})));
+          return mO(batch_idx, seq_idx, _, _);
         }
       }();
 
-      // K == V == the Stage 1 gathered latent (MLA aliasing). K is the full
-      // [gathered_topk, D_QK] view (D_QK is 512 or 576); V is the transposed
-      // [D_V_PER_SPLIT, gathered_topk] first-D_V sub-view of the same buffer offset
-      // to this V-split (V width stays D_V == 512 even when D_QK == 576).
-      const auto* gathered_k_ptr =
-          kp.gathered_k + batch_idx * kp.stride_gathered_k_b + seq_idx * kp.stride_gathered_k_s_q;
-      const auto* gathered_v_ptr = gathered_k_ptr + cur_v_start_idx;
-      auto gathered_k_layout =
-          make_layout(make_shape(s.gathered_topk, D_QK), make_stride(kp.stride_gathered_k_topk, _1{}));
-      auto gathered_v_layout =
-          make_layout(make_shape(Traits::D_V_PER_SPLIT, s.gathered_topk), make_stride(_1{}, kp.stride_gathered_k_topk));
-      Tensor K = make_tensor(make_gmem_ptr(const_cast<ElementKV*>(gathered_k_ptr)), gathered_k_layout);
-      Tensor V = make_tensor(make_gmem_ptr(const_cast<ElementKV*>(gathered_v_ptr)), gathered_v_layout);
+      // K is the full [gathered_topk, D_QK] view (D_QK is 512 or 576).
+      // V is the transposed [D_V_PER_SPLIT, gathered_topk] first-D_V
+      auto* gathered_k_base = const_cast<ElementKV*>(kp.gathered_k);
+      auto mK = make_tensor(
+          make_gmem_ptr(gathered_k_base),
+          make_layout(
+              make_shape(s.b, s.s_q, s.gathered_topk, D_QK),
+              make_stride(kp.stride_gathered_k_b, kp.stride_gathered_k_s_q, kp.stride_gathered_k_topk, _1{})));
+      auto mV = make_tensor(
+          make_gmem_ptr(gathered_k_base),
+          make_layout(
+              make_shape(s.b, s.s_q, Traits::V_SPLIT, Traits::D_V_PER_SPLIT, s.gathered_topk),
+              make_stride(
+                  kp.stride_gathered_k_b,
+                  kp.stride_gathered_k_s_q,
+                  Traits::D_V_PER_SPLIT,
+                  _1{},
+                  kp.stride_gathered_k_topk)));
+      Tensor K = mK(batch_idx, seq_idx, _, _);
+      Tensor V = mV(batch_idx, seq_idx, v_split_idx, _, _);
 
       FragA tArA;
       FragARow tA_max, tA_sum;
@@ -248,8 +263,7 @@ class XeMlaSparse2StageDenseKernel {
       mainloop(Q, K, V, tArA, tA_max, tA_sum, thr_id, batch_idx, seq_idx, head_bid, tile.kv_split_idx, num_kv_splits);
 
       // Both collectives use the same SLM union; the epilogue's ReduceK reduction
-      // reads/writes it via workgroup barriers internally. The mainloop uses no SLM,
-      // so no extra barrier is needed between phases here.
+      // reads/writes it via workgroup barriers internally.
       CollectiveEpilogue epilogue{params.epilogue, shared_storage.epilogue};
       epilogue(
           O,

--- a/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_dense_kernel.hpp
+++ b/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_dense_kernel.hpp
@@ -166,20 +166,11 @@ class XeMlaSparse2StageDenseKernel {
 
   static dim3 get_grid_shape(Params const& params) {
     auto const& s = params.kernel.shape;
-    // cute::print("grid: ");
-    // cute::print(ceil_div(s.h_q, Traits::B_H) * s.s_q * s.b * Traits::V_SPLIT);
-    // cute::print("\n");
-    // cute::print("num_kv_splits: ");
-    // cute::print(cute::max(1, params.scheduler.num_kv_splits));
-    // cute::print("\n");
     return dim3(
         ceil_div(s.h_q, Traits::B_H) * s.s_q * s.b * Traits::V_SPLIT, 1, cute::max(1, params.scheduler.num_kv_splits));
   }
 
   static dim3 get_block_shape() {
-    // cute::print("block: ");
-    // cute::print(Traits::NUM_THREADS);
-    // cute::print("\n");
     return dim3(Traits::NUM_THREADS, 1, 1);
   }
 

--- a/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_dense_kernel.hpp
+++ b/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_dense_kernel.hpp
@@ -166,11 +166,20 @@ class XeMlaSparse2StageDenseKernel {
 
   static dim3 get_grid_shape(Params const& params) {
     auto const& s = params.kernel.shape;
+    // cute::print("grid: ");
+    // cute::print(ceil_div(s.h_q, Traits::B_H) * s.s_q * s.b * Traits::V_SPLIT);
+    // cute::print("\n");
+    // cute::print("num_kv_splits: ");
+    // cute::print(cute::max(1, params.scheduler.num_kv_splits));
+    // cute::print("\n");
     return dim3(
         ceil_div(s.h_q, Traits::B_H) * s.s_q * s.b * Traits::V_SPLIT, 1, cute::max(1, params.scheduler.num_kv_splits));
   }
 
   static dim3 get_block_shape() {
+    // cute::print("block: ");
+    // cute::print(Traits::NUM_THREADS);
+    // cute::print("\n");
     return dim3(Traits::NUM_THREADS, 1, 1);
   }
 

--- a/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_gather_kernel.hpp
+++ b/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_gather_kernel.hpp
@@ -190,7 +190,7 @@ struct DecodeFp8PagedSource {
 
   // NoPE conversion and store, from already-loaded registers.
   template <class TensorGOut>
-  CUTLASS_DEVICE static void convert_and_store_nope(
+  CUTLASS_DEVICE static void dequantize_and_store_nope(
       TensorGOut&& gOut, PackedElement const (&packed_fp8)[NOPE_ITERS], PackedElement scale_word, int lane_id) {
     CUTE_UNROLL
     for (int u = 0; u < NOPE_ITERS; ++u) {
@@ -222,11 +222,11 @@ struct DecodeFp8PagedSource {
     const PackedElement scale_word =
         valid_token ? *reinterpret_cast<const PackedElement*>(token.scales) : PackedElement(0);
 
-    PackedElement packed_fp8[NOPE_ITERS];
+    PackedElement packed_nope[NOPE_ITERS];
     CUTE_UNROLL
     for (int u = 0; u < NOPE_ITERS; ++u) {
       const int i = lane_id + u * SUBGROUP_SIZE;
-      packed_fp8[u] = (valid_token && i < NOPE_PACKS) ? sNope(i) : PackedElement(0);
+      packed_nope[u] = (valid_token && i < NOPE_PACKS) ? sNope(i) : PackedElement(0);
     }
     PackedElement packed_rope[ROPE_ITERS];
     CUTE_UNROLL
@@ -235,11 +235,11 @@ struct DecodeFp8PagedSource {
       packed_rope[u] = (valid_token && j < ROPE_PACKS) ? sRope(j) : PackedElement(0);
     }
 
-    convert_and_store_nope(gOut, packed_fp8, scale_word, lane_id);
+    // Dequantize and store the NoPE portion of the token.
+    dequantize_and_store_nope(gOut, packed_nope, scale_word, lane_id);
 
     // RoPE: already bf16 -- a straight packed copy into the tail of the row, from the
-    // registers staged above. 16 packs over 16 lanes is a single iteration, so 8 B/lane
-    // already covers it in one request.
+    // registers staged above.
     CUTE_UNROLL
     for (int u = 0; u < ROPE_ITERS; ++u) {
       const int j = lane_id + u * SUBGROUP_SIZE;

--- a/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_gather_kernel.hpp
+++ b/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_gather_kernel.hpp
@@ -15,44 +15,10 @@
 
     - DecodeFp8PagedSource  : reads a *packed fp8 paged* KV cache and dequantizes
         (per-64 e8m0 scales; nope fp8 + rope bf16 -> 512-dim bf16), concatenating a
-        primary + extra pool. Reference: tests/test_flash_mla_with_kvcache.py
-        _gather_and_dequant.
+        primary + extra pool.
     - PrefillDenseBf16Source: reads a dense *bf16 unpaged* KV source and does a plain
         D_QK-wide copy (D_QK is 512 or 576): no fp8 decode, no scale section, no extra
-        pool, no paging. Reference: tests/test_flash_mla_sparse_fwd.py
-        reference_mla_sparse_prefill (Stage 1).
-
-  Structure follows the dense MLA path's companion kernel, XeMlaReduceSplitKV
-  (kernel/xe_mla_reduce_split_kv.hpp), which is the in-repo model for a non-MMA
-  helper kernel written the sycl-tla way: gmem is addressed through cute tensor
-  views (make_tensor / make_gmem_ptr / make_layout) and coordinate indexing rather
-  than hand-rolled pointer arithmetic, and the launch grid is decoded into a
-  work-tile by a TileScheduler that also owns get_grid_shape. Like that kernel, and
-  unlike the Stage-2 mainloop, there is no MMA here and therefore no TiledCopy /
-  block-2d copy atom: each subgroup streams one topk row, so the copies are plain
-  lane-strided tensor accesses, vectorized via cute::recast to a wider element.
-
-  Shared declarations (the Gather2StageParams blocks, constants) come from
-  xe_mla_sparse_2stage_common.hpp, and its grid-to-work-tile scheduler
-  (XeMlaSparseGather2StageTileScheduler) from xe_mla_sparse_2stage_tile_scheduler.hpp
-  alongside the Stage-2 one. Stage 1 owns its own tile constants and does not use the
-  Stage-2 config struct (MlaSparseDecode2StageXe).
-
-  Stage 1 is a fully standalone kernel: its Params ARE the gather params (the source
-  policy's decode / prefill child), with no reference to the Stage-2 dense params. It is
-  the Stage-2 runner's companion kernel, wired in exactly like the dense MLA path's
-  split-KV reduction companion: it exposes the same host-side contract
-  (Arguments/Params, to_underlying_arguments, can_implement, get_workspace_size,
-  get_grid_shape, get_block_shape) and device::MLASparse launches it before the dense
-  kernel on the in-order XPU queue. The two stages communicate only through the
-  gathered_k / gathered_valid_mask HBM buffers, which each stage's params name
-  independently.
-
-  The two aliases below give each path a `template <int> class` entry point keyed on
-  D_QK, which is how the Stage-2 config struct (MlaSparseDecode2StageXe's
-  GatherKernelTmpl parameter) selects the decode vs prefill gather:
-    - SparseDecodeGatherDequantKernel<D_QK> == SparseGatherKernel<D_QK, DecodeFp8PagedSource>
-    - SparsePrefillGatherKernel<D_QK>       == SparseGatherKernel<D_QK, PrefillDenseBf16Source>
+        pool, no paging.
 */
 
 #pragma once
@@ -69,6 +35,11 @@ namespace cutlass::flash_attention::kernel {
 // checking the two row pointers subsumes every base / stride / index contribution --
 // no separate per-stride divisibility test is needed.
 /////////////////////////////////////////////////////////////////////////////////////////////////
+template <class PackedElement>
+CUTLASS_DEVICE bool is_aligned_for(const void* p) {
+  return (reinterpret_cast<uintptr_t>(p) & (sizeof(PackedElement) - 1)) == 0;
+}
+
 template <class PackedElement>
 CUTLASS_DEVICE bool is_packed_aligned(const void* src, const void* dst) {
   constexpr uintptr_t kMask = sizeof(PackedElement) - 1;
@@ -89,6 +60,7 @@ struct DecodeFp8PagedSource {
   static constexpr int FP8_VALUES_PER_PACK = 8;
   static constexpr int BF16_VALUES_PER_PACK = 4;
   using PackedElement = uint64_t;
+  using PackedOut = intel::ushort8;
 
   static_assert(D_QK == 512, "packed fp8 sparse decode currently supports logical D_QK=512");
   static_assert(D_QK % SUBGROUP_SIZE == 0, "D_QK must be divisible by SUBGROUP_SIZE");
@@ -107,12 +79,27 @@ struct DecodeFp8PagedSource {
   static_assert(
       sizeof(PackedElement) == sizeof(cutlass::bfloat16_t) * BF16_VALUES_PER_PACK,
       "PackedElement must cover one bf16 lane chunk");
+  static_assert(
+      sizeof(PackedOut) == sizeof(cutlass::bfloat16_t) * FP8_VALUES_PER_PACK,
+      "PackedOut must hold every bf16 one fp8 pack dequantizes to");
+  static_assert(
+      SPARSE_MLA_FP8_SCALE_BYTES_PER_TOKEN == sizeof(PackedElement),
+      "the e8m0 scale section must be exactly one packed load");
+  static_assert(
+      SPARSE_MLA_FP8_DATA_BYTES_PER_TOKEN % sizeof(PackedElement) == 0 &&
+          SPARSE_MLA_FP8_NOPE_BYTES % sizeof(PackedElement) == 0,
+      "scales inherit nope's alignment only if both section offsets are packed multiples");
   static constexpr int NUM_VALS_PER_THREAD = D_QK / SUBGROUP_SIZE;
   // Chunk counts once each section is viewed as PackedElements, and where the RoPE
   // section starts in the destination row's PackedElement view.
   static constexpr int NOPE_PACKS = SPARSE_MLA_FP8_NOPE_BYTES / FP8_VALUES_PER_PACK;
   static constexpr int ROPE_PACKS = SPARSE_MLA_FP8_ROPE_DIM / BF16_VALUES_PER_PACK;
   static constexpr int ROPE_PACK_BASE = SPARSE_MLA_FP8_NOPE_BYTES / BF16_VALUES_PER_PACK;
+  static constexpr int NOPE_ITERS = cute::ceil_div(NOPE_PACKS, SUBGROUP_SIZE);
+  static constexpr int ROPE_ITERS = cute::ceil_div(ROPE_PACKS, SUBGROUP_SIZE);
+  static_assert(
+      NOPE_PACKS * sizeof(PackedOut) == SPARSE_MLA_FP8_NOPE_BYTES * sizeof(cutlass::bfloat16_t),
+      "the NoPE PackedOut chunks must tile the destination row's NoPE region exactly");
 
   // Per-(batch, seq) invariants hoisted out of the topk-column loop: the two pools'
   // index pointers and (optional) topk-length caps. The index arrays are 1-D and
@@ -158,8 +145,6 @@ struct DecodeFp8PagedSource {
     return ctx;
   }
 
-  // Section views over one token's record. Shapes are static, strides unit: both
-  // recast cleanly to PackedElement for the vectorized paths.
   CUTLASS_DEVICE
   static auto make_nope_view(const uint8_t* nope) {
     return make_tensor(make_gmem_ptr(nope), make_layout(Shape<Int<SPARSE_MLA_FP8_NOPE_BYTES>>{}, Stride<_1>{}));
@@ -176,8 +161,7 @@ struct DecodeFp8PagedSource {
   }
 
   CUTLASS_DEVICE
-  static uint16_t fp8_e4m3_scaled_to_bf16_bits(uint8_t fp8_byte, uint8_t scale_byte) {
-    const float scale = e8m0_to_float(scale_byte);
+  static uint16_t fp8_e4m3_scaled_to_bf16_bits(uint8_t fp8_byte, float scale) {
     const auto fp8_val = cutlass::float_e4m3_t::bitcast(fp8_byte);
     return cutlass::bfloat16_t(static_cast<float>(fp8_val) * scale).storage;
   }
@@ -204,54 +188,76 @@ struct DecodeFp8PagedSource {
     }
   }
 
-  // Vectorized path: recast both sides to PackedElement so each lane handles 8 fp8
-  // (-> two 4-wide bf16 stores) or 4 bf16 per step.
+  // NoPE conversion and store, from already-loaded registers.
+  template <class TensorGOut>
+  CUTLASS_DEVICE static void convert_and_store_nope(
+      TensorGOut&& gOut, PackedElement const (&packed_fp8)[NOPE_ITERS], PackedElement scale_word, int lane_id) {
+    CUTE_UNROLL
+    for (int u = 0; u < NOPE_ITERS; ++u) {
+      const int i = lane_id + u * SUBGROUP_SIZE;
+      if (i >= NOPE_PACKS) {
+        continue;
+      }
+      const float scale = e8m0_to_float(uint8_t(scale_word >> (8 * ((i * FP8_VALUES_PER_PACK) / 64))));
+      PackedOut out;
+      CUTE_UNROLL
+      for (int vec_offset = 0; vec_offset < FP8_VALUES_PER_PACK; ++vec_offset) {
+        const uint8_t fp8_byte = static_cast<uint8_t>(packed_fp8[u] >> (8 * vec_offset));
+        out[vec_offset] = fp8_e4m3_scaled_to_bf16_bits(fp8_byte, scale);
+      }
+      gOut(i) = out;
+    }
+  }
+
+  // Vectorized path: each lane converts 8 fp8 into one 16-byte bf16 store (NoPE) or
+  // moves 4 bf16 (RoPE). An invalid token arrives with zeroed inputs and so writes zeros.
   template <class TensorGRow>
   CUTLASS_DEVICE static void
   store_dequantized_token_packed(TensorGRow&& gRow, TokenRecord const& token, bool valid_token, int lane_id) {
     auto gPacked = recast<PackedElement>(gRow);                      // (D_QK / BF16_VALUES_PER_PACK)
+    auto gOut = recast<PackedOut>(gRow);                             // (D_QK / FP8_VALUES_PER_PACK)
     auto sNope = recast<PackedElement>(make_nope_view(token.nope));  // (NOPE_BYTES / FP8_VALUES_PER_PACK)
     auto sRope = recast<PackedElement>(make_rope_view(token.rope));  // (ROPE_DIM / BF16_VALUES_PER_PACK)
 
-    // NoPE: each source chunk of 8 fp8 dequantizes into two destination chunks of
-    // 4 bf16. All 8 values share one e8m0 scale byte (scales are per 64 values).
-    CUTE_NO_UNROLL
-    for (int i = lane_id; i < NOPE_PACKS; i += SUBGROUP_SIZE) {
-      PackedElement packed_lo = 0;
-      PackedElement packed_hi = 0;
-      if (valid_token) {
-        const PackedElement packed_fp8 = sNope(i);
-        const uint8_t scale_byte = token.scales[(i * FP8_VALUES_PER_PACK) / 64];
-        CUTE_UNROLL
-        for (int vec_offset = 0; vec_offset < FP8_VALUES_PER_PACK; ++vec_offset) {
-          const uint8_t fp8_byte = static_cast<uint8_t>(packed_fp8 >> (8 * vec_offset));
-          const uint16_t bf16_bits = fp8_e4m3_scaled_to_bf16_bits(fp8_byte, scale_byte);
-          if (vec_offset < BF16_VALUES_PER_PACK) {
-            packed_lo |= PackedElement(bf16_bits) << (16 * vec_offset);
-          } else {
-            packed_hi |= PackedElement(bf16_bits) << (16 * (vec_offset - BF16_VALUES_PER_PACK));
-          }
-        }
-      }
-      gPacked(2 * i) = packed_lo;
-      gPacked(2 * i + 1) = packed_hi;
+    const PackedElement scale_word =
+        valid_token ? *reinterpret_cast<const PackedElement*>(token.scales) : PackedElement(0);
+
+    PackedElement packed_fp8[NOPE_ITERS];
+    CUTE_UNROLL
+    for (int u = 0; u < NOPE_ITERS; ++u) {
+      const int i = lane_id + u * SUBGROUP_SIZE;
+      packed_fp8[u] = (valid_token && i < NOPE_PACKS) ? sNope(i) : PackedElement(0);
+    }
+    PackedElement packed_rope[ROPE_ITERS];
+    CUTE_UNROLL
+    for (int u = 0; u < ROPE_ITERS; ++u) {
+      const int j = lane_id + u * SUBGROUP_SIZE;
+      packed_rope[u] = (valid_token && j < ROPE_PACKS) ? sRope(j) : PackedElement(0);
     }
 
-    // RoPE: already bf16 -- a straight packed copy into the tail of the row.
-    CUTE_NO_UNROLL
-    for (int j = lane_id; j < ROPE_PACKS; j += SUBGROUP_SIZE) {
-      gPacked(ROPE_PACK_BASE + j) = valid_token ? sRope(j) : PackedElement(0);
+    convert_and_store_nope(gOut, packed_fp8, scale_word, lane_id);
+
+    // RoPE: already bf16 -- a straight packed copy into the tail of the row, from the
+    // registers staged above. 16 packs over 16 lanes is a single iteration, so 8 B/lane
+    // already covers it in one request.
+    CUTE_UNROLL
+    for (int u = 0; u < ROPE_ITERS; ++u) {
+      const int j = lane_id + u * SUBGROUP_SIZE;
+      if (j < ROPE_PACKS) {
+        gPacked(ROPE_PACK_BASE + j) = packed_rope[u];
+      }
     }
   }
 
-  // Locate one token inside the paged pool: page block, then the block's data
-  // section (page_block_size records of SPARSE_MLA_FP8_DATA_BYTES_PER_TOKEN) followed
-  // by its scale section (page_block_size records of SPARSE_MLA_FP8_SCALE_BYTES_PER_TOKEN).
   CUTLASS_DEVICE
-  static TokenRecord
-  locate_token(const uint8_t* active_kv, int token_idx, int active_page_block_size, int active_stride_kv_block) {
-    const int block_idx = token_idx / active_page_block_size;
-    const int rel_idx = token_idx - block_idx * active_page_block_size;
+  static TokenRecord locate_token(
+      const uint8_t* active_kv,
+      int token_idx,
+      cutlass::FastDivmod const& active_page_block_divmod,
+      int active_stride_kv_block) {
+    const int active_page_block_size = active_page_block_divmod.divisor;
+    int block_idx, rel_idx;
+    active_page_block_divmod(block_idx, rel_idx, token_idx);
     const uint8_t* block = active_kv + block_idx * active_stride_kv_block;
     const uint8_t* record = block + rel_idx * SPARSE_MLA_FP8_DATA_BYTES_PER_TOKEN;
 
@@ -277,6 +283,8 @@ struct DecodeFp8PagedSource {
     const int active_num_blocks = is_extra ? params.extra_num_blocks : params.num_blocks;
     const int active_page_block_size = is_extra ? params.extra_page_block_size : params.page_block_size;
     const int active_stride_kv_block = is_extra ? params.stride_extra_kv_block : params.stride_kv_block;
+    cutlass::FastDivmod const& active_page_block_divmod =
+        is_extra ? params.extra_page_block_divmod : params.page_block_divmod;
 
     bool valid_token = false;
     int token_idx = -1;
@@ -286,11 +294,9 @@ struct DecodeFp8PagedSource {
       valid_token = token_idx >= 0 && token_idx < active_num_blocks * active_page_block_size;
     }
 
-    // Invalid tokens keep null section pointers: the stores below zero-fill the row
-    // without ever reading the source, so 0 * NaN can never pollute Stage 2.
     TokenRecord token{nullptr, nullptr, nullptr};
     if (valid_token) {
-      token = locate_token(active_kv, token_idx, active_page_block_size, active_stride_kv_block);
+      token = locate_token(active_kv, token_idx, active_page_block_divmod, active_stride_kv_block);
     }
 
     if (is_packed_aligned<PackedElement>(token.nope, raw_pointer_cast(gRow.data()))) {
@@ -312,20 +318,16 @@ struct PrefillDenseBf16Source {
   using GatherParams = PrefillGather2StageParams;
 
   static constexpr int SUBGROUP_SIZE = intel::sg_size;
-  // Coalesced packed copy: 4 bf16 (== 8 bytes) per lane per step.
-  static constexpr int BF16_VALUES_PER_PACK = 4;
-  using PackedElement = uint64_t;
-  // Dense bf16 KV: D_QK is 512 (latent) or 576 (nope-512 + rope-64). Both tile
-  // evenly over one subgroup's packed span (16 lanes x 4 bf16 = 64): 512/64=8,
-  // 576/64=9. The whole D_QK row is copied verbatim (V uses its first-512 sub-view
-  // downstream), so no nope/rope split is needed here.
+  static constexpr int BF16_VALUES_PER_PACK = 8;
+  using PackedElement = intel::ushort8;
   static_assert(D_QK == 512 || D_QK == 576, "sparse prefill supports dense bf16 D_QK in {512, 576}");
-  static_assert(D_QK % (SUBGROUP_SIZE * BF16_VALUES_PER_PACK) == 0, "D_QK must tile evenly over packed lanes");
+  static_assert(D_QK % BF16_VALUES_PER_PACK == 0, "D_QK must tile evenly over one lane's packed chunk");
   static_assert(
       sizeof(PackedElement) == sizeof(cutlass::bfloat16_t) * BF16_VALUES_PER_PACK,
       "PackedElement must cover one bf16 lane chunk");
-  // Chunk count once a row is viewed as PackedElements.
+
   static constexpr int ROW_PACKS = D_QK / BF16_VALUES_PER_PACK;
+  static constexpr int ROW_ITERS = cute::ceil_div(ROW_PACKS, SUBGROUP_SIZE);
 
   // Per-(batch, seq) invariants hoisted out of the topk-column loop: the index
   // pointer and (optional) topk-length cap for the single dense pool.
@@ -349,15 +351,22 @@ struct PrefillDenseBf16Source {
     return make_tensor(make_gmem_ptr(row), make_layout(Shape<Int<D_QK>>{}, Stride<_1>{}));
   }
 
-  // Copy one dense bf16 KV row (D_QK wide) into the gathered tile, 4 bf16 per lane
-  // per step. Zero-fills invalid tokens so 0 * NaN can never pollute Stage 2.
   template <class TensorGRow, class TensorSRow>
   CUTLASS_DEVICE static void copy_token_packed(TensorGRow&& gRow, TensorSRow&& sRow, bool valid_token, int lane_id) {
     auto gPacked = recast<PackedElement>(gRow);
     auto sPacked = recast<PackedElement>(sRow);
-    CUTE_NO_UNROLL
-    for (int i = lane_id; i < ROW_PACKS; i += SUBGROUP_SIZE) {
-      gPacked(i) = valid_token ? sPacked(i) : PackedElement(0);
+    PackedElement staged[ROW_ITERS];
+    CUTE_UNROLL
+    for (int u = 0; u < ROW_ITERS; ++u) {
+      const int i = lane_id + u * SUBGROUP_SIZE;
+      staged[u] = (valid_token && i < ROW_PACKS) ? sPacked(i) : PackedElement(0);
+    }
+    CUTE_UNROLL
+    for (int u = 0; u < ROW_ITERS; ++u) {
+      const int i = lane_id + u * SUBGROUP_SIZE;
+      if (i < ROW_PACKS) {
+        gPacked(i) = staged[u];
+      }
     }
   }
 
@@ -408,9 +417,6 @@ class SparseGatherKernel {
  public:
   using Source = SourcePolicyTmpl<D_QK>;
 
-  // Stage 1 is a standalone kernel with its own Params: the source policy's gather
-  // params (decode or prefill child). It has no dependency on the Stage-2 dense
-  // kernel's params -- the two stages meet only at the gathered-KV HBM buffers.
   using GatherParams = typename Source::GatherParams;
   using Arguments = GatherParams;
   using KernelArguments = GatherParams;
@@ -423,18 +429,9 @@ class SparseGatherKernel {
 
   using TileScheduler = XeMlaSparseGather2StageTileScheduler<B_TOPK>;
 
-  // Gather uses no SLM: each subgroup owns a whole topk row, so there is nothing to
-  // exchange. The empty SharedStorage is kept to match the collective/kernel
-  // convention; SharedStorageSize stays 0 so the launcher requests no SLM.
   struct SharedStorage {};
   static constexpr int SharedStorageSize = 0;
 
-  // Host-side contract for the device::MLASparse runner, mirroring what the split-KV
-  // reduction companion provides to device::MLA (kernel/xe_mla_reduce_split_kv.hpp):
-  // Arguments == Params (nothing to transform). Unlike that companion, this stage does
-  // own a workspace -- the gathered-KV tile + valid mask it writes -- but it receives
-  // those buffers through its params pointers, not the opaque blob, so
-  // initialize_workspace stays a no-op; see get_workspace_size below.
   static Params to_underlying_arguments(Arguments const& args, void* /* workspace */) {
     return args;
   }
@@ -447,12 +444,7 @@ class SparseGatherKernel {
   // Stage 1 is NOT workspace-free: its outputs are the dense gathered-KV tile
   // ([b, s_q, gathered_topk, D_QK] bf16) plus the int32 valid mask
   // ([b, s_q, gathered_topk]), and those buffers are exactly this kernel's
-  // workspace. The buffers are handed in through the params pointers
-  // (gathered_k / gathered_valid_mask) rather than the opaque blob, but their size
-  // is this kernel's business, so the host asks for it here (via the runner's
-  // MLASparse::get_workspace_size) instead of recomputing the layout -- see the
-  // batch chunking against DECODE_GATHERED_K_MAX_BYTES in
-  // device/mla_sparse_decode_2stage_types.hpp.
+  // workspace.
   static size_t get_workspace_size(Arguments const& args) {
     const size_t rows = size_t(args.b) * size_t(args.s_q) * size_t(args.gathered_topk);
     return rows * (size_t(D_QK) * sizeof(cutlass::bfloat16_t) + sizeof(int));
@@ -462,7 +454,6 @@ class SparseGatherKernel {
     return cutlass::Status::kSuccess;
   }
 
-  // launch<> contract. The scheduler owns the grid, as in XeMlaReduceSplitKV.
   static dim3 get_grid_shape(Params const& params) {
     return TileScheduler::get_grid_shape(params);
   }
@@ -477,10 +468,9 @@ class SparseGatherKernel {
     const int sg_id = thr_id / SUBGROUP_SIZE;
     const int lane_id = thr_id % SUBGROUP_SIZE;
 
-    // Stage-1 outputs as cute tensors. The gathered tile is laid out d-major (mode 0
-    // is the static D_QK with unit stride) so one topk column is a contiguous D_QK
-    // span -- that is what the policies' packed copies walk, and what lets them
-    // recast the row to a wider element.
+    // The gathered tile is laid out d-major (mode 0 is the static D_QK with unit stride)
+    // so one topk column is a contiguous D_QK span -- that is what the policies'
+    // packed copies walk, and what lets them recast the row to a wider element.
     Tensor mK = make_tensor(
         make_gmem_ptr(params.gathered_k),
         make_layout(
@@ -497,10 +487,6 @@ class SparseGatherKernel {
     for (TileScheduler tile_scheduler{params}; tile_scheduler.is_valid(); ++tile_scheduler) {
       auto [batch_idx, seq_idx, topk_block_idx] = tile_scheduler.get_block_coord();
 
-      // This work-group's (batch, seq) slice of the gathered tile: (D_QK, gathered_topk).
-      // Sliced by coordinate rather than local_tile'd into B_TOPK blocks, because
-      // gathered_topk is dynamic and need not be a multiple of B_TOPK -- the loop below
-      // bounds-checks the last, partial block instead.
       Tensor gK = mK(_, _, seq_idx, batch_idx);
       const int topk_base = topk_block_idx * B_TOPK;
 
@@ -522,10 +508,6 @@ class SparseGatherKernel {
   }
 };
 
-// Per-path entry points with the `template <int> class` (D_QK-keyed) interface the
-// Stage-2 config struct's GatherKernelTmpl param selects on. The config resolves one of
-// these as MlaSparseDecode2StageXe::GatherKernel and passes it to device::MLASparse as
-// the companion kernel.
 template <int D_QK>
 using SparseDecodeGatherDequantKernel = SparseGatherKernel<D_QK, DecodeFp8PagedSource>;
 

--- a/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_reduce_split_kv.hpp
+++ b/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_reduce_split_kv.hpp
@@ -202,7 +202,7 @@ class XeMlaSparse2StageReduceSplitKV {
         total_exp_sum += sycl::native::exp2(static_cast<ElementAcc>(ep.attn_sink[head_idx] * LOG_2_E) - global_max);
       }
     }
-    const ElementAcc inv_exp_sum = total_exp_sum != ElementAcc(0) ? ElementAcc(1) / total_exp_sum : ElementAcc(0);
+    const ElementAcc inv_exp_sum = total_exp_sum != ElementAcc(0) ? sycl::native::recip(total_exp_sum) : ElementAcc(0);
 
     // Pass 2: combine the partial O columns this thread owns. k-outer / v-inner so the
     // per-split exp2 rescale is hoisted out of the D_V walk and acc[] stays in registers.

--- a/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_reduce_split_kv.hpp
+++ b/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_reduce_split_kv.hpp
@@ -184,10 +184,10 @@ class XeMlaSparse2StageReduceSplitKV {
       if (thr_id == 0) {
         const float row_max = row_has_mass ? global_max * LOG_E_2 : -INFINITY;
         const float row_lse = row_has_mass ? row_max + sycl::native::log2(total_exp_sum) * LOG_E_2 : INFINITY;
-        Tensor rLse = make_tensor(
+        Tensor r_Lse = make_tensor(
             make_gmem_ptr(ep.lse),
             make_layout(make_shape(s.b, s.s_q, s.h_q), make_stride(ep.stride_lse_b, ep.stride_lse_s_q, _1{})));
-        rLse(batch_idx, seq_idx, head_idx) = row_lse;
+        r_Lse(batch_idx, seq_idx, head_idx) = row_lse;
         if constexpr (HAS_MAX_LOGITS) {
           Tensor rMaxLogits = make_tensor(
               make_gmem_ptr(ep.max_logits),

--- a/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_reduce_split_kv.hpp
+++ b/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_reduce_split_kv.hpp
@@ -10,40 +10,12 @@
         Stage 1  gather+dequant  ->  Stage 2  dense flash (per kv-split partials)
                                  ->  THIS     combine splits + finish the row
 
-    When the Stage-2 dense kernel is instantiated with a split-K epilogue
-    (XeMlaSparse2StageEpilogue<..., IS_SPLIT_KV = true>), each kv-split work-group only
-    covers a slice of the gathered topk dim, so it can produce an UNNORMALIZED partial O
-    plus this split's online-softmax row stats but not the finished row. This kernel does
-    the cross-split flash rescale-and-combine and everything that depends on the whole
-    row: the attn_sink merge, the softmax normalization, the pre-sink LSE, and (prefill)
-    max_logits. Without split-K it is never instantiated or launched, and the fused /
-    non-split two-stage paths are unchanged.
-
-    Structural analog of the paged path's XeMlaReduceSplitKV
-    (mla/kernel/xe_mla_reduce_split_kv.hpp), with three deliberate differences:
-
-      - Params ARE the dense kernel's Params (SparseAttn2StageParams). Every tensor the
-        reduction touches -- o_accum / split stats (kernel + epilogue slices), the final
-        out / lse / max_logits / attn_sink (kernel + epilogue slices), num_kv_splits
-        (scheduler slice) -- already lives there, so there is no separate argument type to
-        keep in sync and the runner hands both kernels the same object.
-
-      - No SLM and no work-group barrier. The paged kernel stages the per-split stats
-        through SLM (which is what forces its kvMaxSplits-sized arrays); here every thread
-        in the work-group needs the same 2 * num_kv_splits scalars, and re-reading them
-        from gmem costs one L1 line per split for the whole work-group. That drops the
-        barrier, the shared storage, and the kvMaxSplits device-side dependency.
-
-      - One work-group per (batch, seq, head) row rather than a tile scheduler over
-        (seq, head, batch): the row is exactly D_V wide, which one work-group covers in
-        VALS_PER_THREAD statically-unrolled steps, so the k-outer / v-inner loop keeps the
-        partial sums in registers (a v-outer / k-inner loop would need one exp2 per element
-        per split, or a runtime-indexed rescale array that would spill).
 */
 
 #pragma once
 
 #include "sycl/kernels/mla_sparse/device/xe_mla_sparse_2stage_common.hpp"
+#include "sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_tile_scheduler.hpp"
 
 namespace cutlass::flash_attention::kernel {
 
@@ -65,6 +37,8 @@ class XeMlaSparse2StageReduceSplitKV {
   using Traits = typename DenseKernel::Traits;
   using ElementO = typename DenseKernel::ElementO;
   using ElementAcc = float;  // o_accum combines and normalizes in fp32
+
+  using TileScheduler = XeMlaSparse2StageReduceTileScheduler;
 
   static constexpr bool HAS_ATTN_SINK = DenseKernel::HAS_ATTN_SINK;
   static constexpr bool HAS_MAX_LOGITS = DenseKernel::HAS_MAX_LOGITS;
@@ -124,12 +98,8 @@ class XeMlaSparse2StageReduceSplitKV {
     return cutlass::Status::kSuccess;
   }
 
-  // One work-group per (batch, seq, head) output row. head is the fastest-varying index
-  // so neighbouring work-groups walk contiguous o_accum rows (its layout is
-  // [b, s_q, num_kv_splits, h_q, d_v]).
   static dim3 get_grid_shape(Params const& params) {
-    auto const& s = params.kernel.shape;
-    return dim3(s.b * s.s_q * s.h_q, 1, 1);
+    return TileScheduler::get_grid_shape(params.kernel.shape);
   }
 
   static dim3 get_block_shape() {
@@ -147,91 +117,120 @@ class XeMlaSparse2StageReduceSplitKV {
     const int num_kv_splits = cute::max(1, params.scheduler.num_kv_splits);
     const int thr_id = int(ThreadIdxX());
 
-    const int row = int(BlockIdxX());
-    const int head_idx = row % s.h_q;
-    const int q_tile = row / s.h_q;
-    const int seq_idx = q_tile % s.s_q;
-    const int batch_idx = q_tile / s.s_q;
-
-    // Per-split stats for this row: [b, s_q, num_kv_splits, h_q], split-strided.
-    const int stat_base = batch_idx * ep.stride_split_stats_b + seq_idx * ep.stride_split_stats_s_q + head_idx;
-    const float* __restrict__ split_exp_sums = ep.split_exp_sums + stat_base;
-    const float* __restrict__ split_max_logits = ep.split_max_logits + stat_base;
-
-    // Pass 1: the row's global (log2-domain, sm_scale-folded) max across splits, then the
-    // flash-rescaled total exp-sum. Every thread computes both from the same
-    // 2 * num_kv_splits gmem scalars -- one L1 line per split serves the whole
-    // work-group, which is cheaper than an SLM stage plus a barrier.
-    //
-    // An empty or fully-masked split published exp_sum == 0 (see the split epilogue); it
-    // is skipped in all three loops below, so neither its max (still the sentinel) nor its
-    // o_accum slice (never accumulated into) is read.
-    ElementAcc global_max = cutlass::platform::numeric_limits<ElementAcc>::lowest();
+    TileScheduler tile_scheduler{s};
     CUTLASS_PRAGMA_NO_UNROLL
-    for (int k = 0; k < num_kv_splits; ++k) {
-      if (split_exp_sums[k * ep.stride_split_stats_split] <= ElementAcc(0)) continue;
-      global_max = sycl::max(global_max, split_max_logits[k * ep.stride_split_stats_split]);
-    }
+    for (; tile_scheduler.is_valid(); ++tile_scheduler) {
+      const Sparse2StageReduceWorkTile tile = tile_scheduler.get_block_coord();
+      const int batch_idx = tile.batch_idx;
+      const int seq_idx = tile.seq_idx;
+      const int head_idx = tile.head_idx;
 
-    ElementAcc total_exp_sum = ElementAcc(0);
-    CUTLASS_PRAGMA_NO_UNROLL
-    for (int k = 0; k < num_kv_splits; ++k) {
-      const ElementAcc local_exp_sum = split_exp_sums[k * ep.stride_split_stats_split];
-      if (local_exp_sum <= ElementAcc(0)) continue;
-      const ElementAcc local_max = split_max_logits[k * ep.stride_split_stats_split];
-      total_exp_sum += local_exp_sum * sycl::native::exp2(local_max - global_max);
-    }
+      // Per-split partial O: [b, s_q, num_kv_splits, h_q, D_V] -> this row's [splits, D_V].
+      Tensor mOaccum = make_tensor(
+          make_gmem_ptr(kp.o_accum),
+          make_layout(
+              make_shape(s.b, s.s_q, num_kv_splits, s.h_q, D_V),
+              make_stride(
+                  kp.stride_o_accum_b, kp.stride_o_accum_s_q, kp.stride_o_accum_split, kp.stride_o_accum_h_q, _1{})));
+      Tensor rOaccum = mOaccum(batch_idx, seq_idx, _, head_idx, _);
 
-    // Pre-sink LSE (and the prefill-only pre-sink row max), keyed off total_exp_sum rather
-    // than a max sentinel so a fully-masked row reports (-inf max, +inf lse) exactly as
-    // the non-split epilogue does. One writer per row.
-    const bool row_has_mass = total_exp_sum > ElementAcc(0);
-    if (thr_id == 0) {
-      const float row_max = row_has_mass ? global_max * LOG_E_2 : -INFINITY;
-      const float row_lse = row_has_mass ? row_max + sycl::native::log2(total_exp_sum) * LOG_E_2 : INFINITY;
-      ep.lse[batch_idx * ep.stride_lse_b + seq_idx * ep.stride_lse_s_q + head_idx] = row_lse;
-      if constexpr (HAS_MAX_LOGITS) {
-        ep.max_logits[batch_idx * ep.stride_max_logits_b + seq_idx * ep.stride_max_logits_s_q + head_idx] = row_max;
+      // Final output row: [b, s_q, h_q, D_V] -> this row's [D_V].
+      Tensor mOut = make_tensor(
+          make_gmem_ptr(kp.out),
+          make_layout(
+              make_shape(s.b, s.s_q, s.h_q, D_V), make_stride(kp.stride_o_b, kp.stride_o_s_q, kp.stride_o_h_q, _1{})));
+      Tensor rOut = mOut(batch_idx, seq_idx, head_idx, _);
+
+      // Per-split softmax stats: [b, s_q, num_kv_splits, h_q] (h_q contiguous) -> [splits].
+      auto stat_row = [&](const float* base) {
+        Tensor t = make_tensor(
+            make_gmem_ptr(base),
+            make_layout(
+                make_shape(s.b, s.s_q, num_kv_splits, s.h_q),
+                make_stride(ep.stride_split_stats_b, ep.stride_split_stats_s_q, ep.stride_split_stats_split, _1{})));
+        return t(batch_idx, seq_idx, _, head_idx);
+      };
+      Tensor split_exp_sums = stat_row(ep.split_exp_sums);
+      Tensor split_max_logits = stat_row(ep.split_max_logits);
+
+      // Pass 1: the row's global (log2-domain, sm_scale-folded) max across splits, then the
+      // flash-rescaled total exp-sum. Every thread computes both from the same
+      // 2 * num_kv_splits gmem scalars -- one L1 line per split serves the whole
+      // work-group, which is cheaper than an SLM stage plus a barrier.
+      //
+      // An empty or fully-masked split published exp_sum == 0; it
+      // is skipped in all three loops below, so neither its max (still the sentinel) nor its
+      // o_accum slice (never accumulated into) is read.
+      ElementAcc global_max = cutlass::platform::numeric_limits<ElementAcc>::lowest();
+      CUTLASS_PRAGMA_NO_UNROLL
+      for (int k = 0; k < num_kv_splits; ++k) {
+        if (split_exp_sums(k) <= ElementAcc(0)) continue;
+        global_max = sycl::max(global_max, split_max_logits(k));
       }
-    }
 
-    // attn_sink joins the denominator only, after LSE (which is pre-sink) -- same order
-    // and same exp2 formulation as the non-split epilogue's ReduceK == 1 branch.
-    if constexpr (HAS_ATTN_SINK) {
-      if (row_has_mass) {
-        total_exp_sum += sycl::native::exp2(static_cast<ElementAcc>(ep.attn_sink[head_idx] * LOG_2_E) - global_max);
+      ElementAcc total_exp_sum = ElementAcc(0);
+      CUTLASS_PRAGMA_NO_UNROLL
+      for (int k = 0; k < num_kv_splits; ++k) {
+        const ElementAcc local_exp_sum = split_exp_sums(k);
+        if (local_exp_sum <= ElementAcc(0)) continue;
+        const ElementAcc local_max = split_max_logits(k);
+        total_exp_sum += local_exp_sum * sycl::native::exp2(local_max - global_max);
       }
-    }
-    const ElementAcc inv_exp_sum = total_exp_sum != ElementAcc(0) ? sycl::native::recip(total_exp_sum) : ElementAcc(0);
 
-    // Pass 2: combine the partial O columns this thread owns. k-outer / v-inner so the
-    // per-split exp2 rescale is hoisted out of the D_V walk and acc[] stays in registers.
-    const ElementO* __restrict__ o_accum = kp.o_accum + batch_idx * kp.stride_o_accum_b +
-                                           seq_idx * kp.stride_o_accum_s_q + head_idx * kp.stride_o_accum_h_q;
+      // Pre-sink LSE (and the prefill-only pre-sink row max), keyed off total_exp_sum rather
+      // than a max sentinel so a fully-masked row reports (-inf max, +inf lse) exactly as
+      // the non-split epilogue does. One writer per row.
+      const bool row_has_mass = total_exp_sum > ElementAcc(0);
+      if (thr_id == 0) {
+        const float row_max = row_has_mass ? global_max * LOG_E_2 : -INFINITY;
+        const float row_lse = row_has_mass ? row_max + sycl::native::log2(total_exp_sum) * LOG_E_2 : INFINITY;
+        Tensor rLse = make_tensor(
+            make_gmem_ptr(ep.lse),
+            make_layout(make_shape(s.b, s.s_q, s.h_q), make_stride(ep.stride_lse_b, ep.stride_lse_s_q, _1{})));
+        rLse(batch_idx, seq_idx, head_idx) = row_lse;
+        if constexpr (HAS_MAX_LOGITS) {
+          Tensor rMaxLogits = make_tensor(
+              make_gmem_ptr(ep.max_logits),
+              make_layout(
+                  make_shape(s.b, s.s_q, s.h_q), make_stride(ep.stride_max_logits_b, ep.stride_max_logits_s_q, _1{})));
+          rMaxLogits(batch_idx, seq_idx, head_idx) = row_max;
+        }
+      }
 
-    ElementAcc acc[VALS_PER_THREAD];
-    CUTLASS_PRAGMA_UNROLL
-    for (int v = 0; v < VALS_PER_THREAD; ++v) {
-      acc[v] = ElementAcc(0);
-    }
+      // attn_sink joins the denominator only, after LSE (which is pre-sink) -- same order
+      // and same exp2 formulation as the non-split epilogue's ReduceK == 1 branch.
+      if constexpr (HAS_ATTN_SINK) {
+        if (row_has_mass) {
+          total_exp_sum += sycl::native::exp2(static_cast<ElementAcc>(ep.attn_sink[head_idx] * LOG_2_E) - global_max);
+        }
+      }
+      const ElementAcc inv_exp_sum =
+          total_exp_sum != ElementAcc(0) ? sycl::native::recip(total_exp_sum) : ElementAcc(0);
 
-    CUTLASS_PRAGMA_NO_UNROLL
-    for (int k = 0; k < num_kv_splits; ++k) {
-      const ElementAcc local_exp_sum = split_exp_sums[k * ep.stride_split_stats_split];
-      if (local_exp_sum <= ElementAcc(0)) continue;
-      const ElementAcc rescale = sycl::native::exp2(split_max_logits[k * ep.stride_split_stats_split] - global_max);
-      const ElementO* __restrict__ o_split = o_accum + k * kp.stride_o_accum_split;
+      // Pass 2: combine the partial O columns this thread owns. k-outer / v-inner so the
+      // per-split exp2 rescale is hoisted out of the D_V walk and acc[] stays in registers.
+      ElementAcc acc[VALS_PER_THREAD];
       CUTLASS_PRAGMA_UNROLL
       for (int v = 0; v < VALS_PER_THREAD; ++v) {
-        acc[v] += static_cast<ElementAcc>(o_split[v * WG_SIZE + thr_id]) * rescale;
+        acc[v] = ElementAcc(0);
       }
-    }
 
-    ElementO* __restrict__ out =
-        kp.out + batch_idx * kp.stride_o_b + seq_idx * kp.stride_o_s_q + head_idx * kp.stride_o_h_q;
-    CUTLASS_PRAGMA_UNROLL
-    for (int v = 0; v < VALS_PER_THREAD; ++v) {
-      out[v * WG_SIZE + thr_id] = static_cast<ElementO>(acc[v] * inv_exp_sum);
+      CUTLASS_PRAGMA_NO_UNROLL
+      for (int k = 0; k < num_kv_splits; ++k) {
+        const ElementAcc local_exp_sum = split_exp_sums(k);
+        if (local_exp_sum <= ElementAcc(0)) continue;
+        const ElementAcc rescale = sycl::native::exp2(split_max_logits(k) - global_max);
+        Tensor o_split = rOaccum(k, _);  // this split's [D_V] row, stride 1
+        CUTLASS_PRAGMA_UNROLL
+        for (int v = 0; v < VALS_PER_THREAD; ++v) {
+          acc[v] += static_cast<ElementAcc>(o_split(v * WG_SIZE + thr_id)) * rescale;
+        }
+      }
+
+      CUTLASS_PRAGMA_UNROLL
+      for (int v = 0; v < VALS_PER_THREAD; ++v) {
+        rOut(v * WG_SIZE + thr_id) = static_cast<ElementO>(acc[v] * inv_exp_sum);
+      }
     }
   }
 };

--- a/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_tile_scheduler.hpp
+++ b/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_tile_scheduler.hpp
@@ -15,10 +15,12 @@
       - XeMlaSparseGather2StageTileScheduler<B_TOPK> (Stage 1, gather). Grid is
         (b * s_q, ceil_div(gathered_topk, B_TOPK), 1): BlockIdxX enumerates the
         (batch, seq) pairs row-major and BlockIdxY the topk-block, decoded into a
-        (batch_idx, seq_idx, topk_block_idx) coordinate. Unlike the Stage-2 scheduler
-        it also owns get_grid_shape, since the gather kernel's grid is derivable from
-        its params alone. Its Params slice is the *base* Gather2StageParams, so the
-        one scheduler serves both the decode and prefill param children.
+        (batch_idx, seq_idx, topk_block_idx) coordinate. (Swapping those two axes was
+        measured and did not pay -- see the note on get_grid_shape.) Unlike the
+        Stage-2 scheduler it also owns get_grid_shape, since the gather kernel's grid
+        is derivable from its params alone. Its Params slice is the *base*
+        Gather2StageParams, so the one scheduler serves both the decode and prefill
+        param children.
 
       - XeMlaSparse2StageIndividualTileScheduler<B_H, V_SPLIT> (Stage 2, dense flash).
         Grid is (ceil_div(h_q, B_H) * s_q * b * V_SPLIT, 1, num_kv_splits): BlockIdxX

--- a/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_tile_scheduler.hpp
+++ b/src/sycl/kernels/mla_sparse/kernel/xe_mla_sparse_2stage_tile_scheduler.hpp
@@ -160,4 +160,63 @@ class XeMlaSparse2StageIndividualTileScheduler {
   bool valid_;
 };
 
+/////////////////////////////////////////////////////////////////////////////////////////////////
+// Stage 2 (split-K reduction).
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+// A decoded reduction work-tile coordinate: one output row.
+struct Sparse2StageReduceWorkTile {
+  int batch_idx;
+  int seq_idx;
+  int head_idx;
+};
+
+// Reduction scheduler: one work-group per (batch, seq, head) output row. Enumerated over a
+// natural 3D grid with head on grid.x (fastest-varying) so neighbouring work-groups walk
+// contiguous o_accum / out rows -- both are [..., h_q, D_V] with the head stride == D_V, so
+// adjacent heads are adjacent rows. This is the paged reduction's scheme
+// (XeMlaReduceSplitKScheduler, mla/kernel/mla_tile_scheduler.hpp): because the grid is the
+// coordinate, get_block_coord reads it straight off BlockIdx with no divmod, and the kernel
+// body never touches BlockIdx -- matching the gather + dense Stage-2 schedulers above. Like
+// them it is a stateless single-tile decoder.
+class XeMlaSparse2StageReduceTileScheduler {
+ public:
+  // Reads only the three dims that size the grid. The reduction's Params is the whole dense
+  // SparseAttn2StageParams, so it forwards params.kernel.shape here.
+  using Params = SparseDecode2StageProblemShape;
+
+  // head -> grid.x (fastest), seq -> grid.y, batch -> grid.z. The reduction's can_implement
+  // guarantees all three are >= 1 before launch.
+  static dim3 get_grid_shape(Params const& shape) {
+    return dim3(shape.h_q, shape.s_q, shape.b);
+  }
+
+  CUTLASS_DEVICE
+  XeMlaSparse2StageReduceTileScheduler(Params const& /* shape */) : valid_(true) {
+    tile_.head_idx = int(BlockIdxX());
+    tile_.seq_idx = int(BlockIdxY());
+    tile_.batch_idx = int(BlockIdxZ());
+  }
+
+  CUTLASS_DEVICE
+  bool is_valid() const {
+    return valid_;
+  }
+
+  CUTLASS_DEVICE
+  Sparse2StageReduceWorkTile get_block_coord() const {
+    return tile_;
+  }
+
+  CUTLASS_DEVICE
+  XeMlaSparse2StageReduceTileScheduler& operator++() {
+    valid_ = false;
+    return *this;
+  }
+
+ private:
+  Sparse2StageReduceWorkTile tile_;
+  bool valid_;
+};
+
 }  // namespace cutlass::flash_attention::kernel


### PR DESCRIPTION
- Hoist e8m0 scale conversion out of the per-element inner loop: one exp2 per
  64-element group instead of one per element (~7x fewer conversions)
- Widen NoPE stores from 8 B (PackedElement) to 16 B (PackedOut / ushort8)
  so each subgroup request matches one 256 B BMG cache line exactly, reducing
  store requests per token from 5 to 4
- Vectorize RoPE copy via PackedElement (8 B/lane) for the same alignment reason

decode:

| batch_size | topk | extra_topk | Triton V4 (ms) | SGL Kernel (ms) | Triton BW (GB/s) | SGL Kernel BW (GB/s) | SGL Improv. (%) |
|------------|------|------------|----------------|-----------------|------------------|----------------------|-----------------|
|          1 |   64 |          0 |         0.6408 |          0.0380 |             0.11 |                 1.86 |          +16.85 |
|          1 |   64 |        512 |         1.2975 |          0.0428 |             0.29 |                 8.69 |          +15.25 |
|          1 |  128 |          0 |         0.7506 |          0.0396 |             0.14 |                 2.73 |          +15.93 |
|          1 |  128 |        512 |         1.3774 |          0.0418 |             0.30 |                 9.80 |          +15.73 |
|          1 |  512 |          0 |         0.7644 |          0.0409 |             0.44 |                 8.17 |          +15.67 |
|          1 |  512 |        512 |         1.5379 |          0.0436 |             0.41 |                14.57 |          +14.34 |
|          8 |   64 |          0 |         0.7570 |          0.0382 |             0.74 |                14.77 |          +16.78 |
|          8 |   64 |        512 |         1.5625 |          0.0572 |             1.90 |                51.92 |          +11.46 |
|          8 |  128 |          0 |         0.7591 |          0.0406 |             1.14 |                21.29 |          +16.80 |
|          8 |  128 |        512 |         1.5671 |          0.0605 |             2.09 |                54.13 |          +10.77 |
|          8 |  512 |          0 |         0.7743 |          0.0548 |             3.45 |                48.70 |          +12.04 |
|          8 |  512 |        512 |         1.5709 |          0.0757 |             3.23 |                67.07 |           +9.01 |
|         42 |   64 |          0 |         0.8158 |          0.0534 |             3.63 |                55.38 |          +12.03 |
|         42 |   64 |        512 |         1.3432 |          0.1871 |            11.62 |                83.38 |          +10.22 |
|         42 |  128 |          0 |         0.6667 |          0.0628 |             6.81 |                72.34 |          +10.41 |
|         42 |  128 |        512 |         1.3589 |          0.2034 |            12.65 |                84.49 |           +9.80 |
|         42 |  512 |          0 |         0.6844 |          0.1795 |            20.49 |                78.13 |          +11.49 |
|         42 |  512 |        512 |         1.3506 |          0.3105 |            19.74 |                85.89 |          +10.65 |
|        128 |   64 |          0 |         0.6966 |          0.0873 |            12.95 |               103.32 |           +8.30 |
|        128 |   64 |        512 |         1.5656 |          0.4836 |            30.38 |                98.33 |          +10.61 |
|        128 |  128 |          0 |         0.7639 |          0.1391 |            18.11 |                99.50 |          +10.03 |
|        128 |  128 |        512 |         1.5859 |          0.5171 |            33.02 |               101.27 |          +10.30 |
|        128 |  512 |          0 |         0.8702 |          0.4355 |            49.11 |                98.12 |          +11.01 |
|        128 |  512 |        512 |         1.7045 |          0.7984 |            47.68 |               101.80 |          +10.89 |
|        256 |   64 |          0 |         0.7098 |          0.1594 |            25.41 |               113.15 |           +8.97 |
|        256 |   64 |        512 |         2.0969 |          0.8962 |            45.36 |               106.13 |          +10.74 |
|        256 |  128 |          0 |         0.7076 |          0.2608 |            39.11 |               106.11 |          +10.68 |
|        256 |  128 |        512 |         2.1149 |          0.9868 |            49.53 |               106.15 |          +10.64 |
|        256 |  512 |          0 |         1.4087 |          0.8029 |            60.68 |               106.46 |          +11.05 |

prefill:

| s_q  | head_q | topk | d_qk | Triton Ref (ms) | SGL Kernel (ms) | Triton Ref BW (GB/s) | SGL Kernel BW (GB/s) | SGL Improv. (%) |
|------|--------|------|------|-----------------|-----------------|----------------------|----------------------|-----------------|
|  512 |     16 | 2048 |  512 |         29.7050 |          9.2083 |                36.71 |               118.43 |           +2.48 |
|  512 |     32 | 2048 |  512 |         32.4998 |          9.5562 |                34.07 |               115.87 |           +1.38 |
|  512 |    128 | 2048 |  512 |         56.2174 |         15.1687 |                21.49 |                79.64 |           +1.80 |
| 2048 |     16 |  512 |  512 |         32.5510 |          7.5471 |                35.05 |               151.16 |           +2.37 |
| 2048 |    128 |  512 |  512 |         61.8243 |         13.4872 |                26.05 |               119.42 |           +1.48 |
|  512 |     16 | 2048 |  576 |         33.5803 |         11.1191 |                36.50 |               110.24 |           +2.04 |
|  512 |     32 | 2048 |  576 |         36.4082 |         11.6140 |                34.16 |               107.08 |           +1.66 |
|  512 |    128 | 2048 |  576 |         60.9379 |         18.9752 |                22.16 |                71.18 |           +1.16 |
| 2048 |     16 |  512 |  576 |         34.4110 |          9.8904 |                37.18 |               129.34 |           +3.24 |
| 2048 |    128 |  512 |  576 |         65.3142 |         17.7283 |                27.23 |               100.31 |           +1.97 |
