### PR TITLE
ci(xpu): use GITHUB_TOKEN with write permissions for baseline PR step

### DIFF
--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 concurrency:
   group: pr-test-xpu-${{ github.ref }}
   cancel-in-progress: true
@@ -12,10 +16,9 @@ concurrency:
 jobs:
   build-and-test:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
-    # Least privilege: every write op below (git push, gh pr create/comment)
-    # authenticates with secrets.PAT, not the workflow GITHUB_TOKEN.
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
     runs-on: sglang-bmg
     steps:
       - name: Checkout code
@@ -154,9 +157,9 @@ jobs:
           git commit -m "CI intermediate baseline update" || echo "No changes to commit"
           echo "Detected changes in baseline.json: $(git diff --cached --stat)"
 
-          git remote set-url origin https://x-access-token:${{ secrets.PAT }}@github.com/sgl-project/sgl-kernel-xpu.git
+          git remote set-url origin https://x-access-token:${{ github.token }}@github.com/sgl-project/sgl-kernel-xpu.git
           git push -f origin "$BRANCH"
-          export GITHUB_TOKEN="${{ secrets.PAT }}"
+          export GITHUB_TOKEN="${{ github.token }}"
 
           PR_NUMBER=$(gh pr list \
             --repo sgl-project/sgl-kernel-xpu \


### PR DESCRIPTION
## Summary

The `Auto PR for baseline.json update` step in `pr-test-xpu.yml` currently authenticates with `secrets.PAT`. Recent runs fail with HTTP 403 because that secret is not set or has expired, causing `git push` to fall back to the read-only `github-actions[bot]` identity:

```
remote: Permission to sgl-project/sgl-kernel-xpu.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/sgl-project/sgl-kernel-xpu.git/': The requested URL returned error: 403
```

Failing run: https://github.com/sgl-project/sgl-kernel-xpu/actions/runs/34182448796/job/101924149756

## Changes

- Add top-level `permissions: { contents: write, pull-requests: write }` and lift the `build-and-test` job scope from `contents: read` to match. GitHub Actions permission scopes are hierarchical: `write` implies `read`, so no separate `read` line is needed.
- Replace `\${{ secrets.PAT }}` with `\${{ github.token }}` in the `git remote set-url` and `export GITHUB_TOKEN=...` calls inside the step. `github.token` is the auto-provisioned workflow token (aka `secrets.GITHUB_TOKEN`) — no admin needs to set/rotate a PAT.
- Drop the now-stale ``Least privilege: every write op below (git push, gh pr create/comment) authenticates with secrets.PAT`` comment.

## Trade-off vs. the previous PAT-based design

Commits pushed by the auto-provisioned `GITHUB_TOKEN` do **not** trigger further workflow runs (GitHub's anti-recursion guard). If the maintainers of this repo intended the follow-up ``ci/update-baseline-pr-...`` PR to re-trigger `pr-test-xpu.yml`, that no longer happens with this change. A pinned/rotated PAT would restore that behaviour; if kept, please set `secrets.PAT` at the repo level.

## Test plan

- [ ] Add the `perf` label to a test PR so the step's `if:` guard passes.
- [ ] Verify the `Auto PR for baseline.json update` step completes without 403 and either creates or updates `ci/update-baseline-pr-<N>` on this repo.
- [ ] Confirm the follow-up PR shows a valid `benchmark/baseline.json` diff.