### PR TITLE
[XPU] flash_mla_decode: derive latent/rope dims instead of hardcoding…

### DIFF
--- a/python/sgl_kernel/attention.py
+++ b/python/sgl_kernel/attention.py
@@ -74,11 +74,11 @@ def flash_mla_decode(
 
     _, PAGE_SIZE, D_ckv = kv_c_and_k_pe_cache.shape
 
-    D_latent = 512
-    D_rope = 64
-    assert D_q_nope == D_latent
-    assert D_q_pe == D_rope
-    assert D_ckv == D_latent + D_rope
+    D_latent = D_q_nope
+    D_rope = D_q_pe
+    assert (
+        D_ckv == D_latent + D_rope
+    ), f"kv dim {D_ckv} must equal D_latent({D_latent}) + D_rope({D_rope})"
 
     MAX_HEADS = 128
     assert H <= MAX_HEADS, f"H must be <= {MAX_HEADS}, but got {H}"

--- a/tests/test_flash_mla_decode.py
+++ b/tests/test_flash_mla_decode.py
@@ -72,6 +72,11 @@ def ref_mla(
 @pytest.mark.parametrize("block_size", [16, 32, 64, 128])
 @pytest.mark.parametrize("num_heads", [16, 32, 64, 128])
 @pytest.mark.parametrize("num_kv_splits", [-1, 1])
+@pytest.mark.parametrize(
+    "dv, q_pe_dim, q_nope_dim",
+    [(512, 64, 128), (256, 32, 64)],
+    ids=["deepseek", "minicpm3"],
+)
 def test_flash_mla_decode(
     dtype: torch.dtype,
     mean_seq_len: int,
@@ -80,16 +85,15 @@ def test_flash_mla_decode(
     block_size: int,
     num_heads: int,
     num_kv_splits: int,
+    dv: int,
+    q_pe_dim: int,
+    q_nope_dim: int,
 ):
 
     torch.random.manual_seed(42)
 
-    d = 576
+    d = dv + q_pe_dim
     h_q = num_heads
-    dv = 512
-
-    q_nope_dim = 128
-    q_pe_dim = 64
     scale = (q_nope_dim + q_pe_dim) ** (-0.5)
     if varlen:
         seq_lens_cpu = torch.empty(bs, dtype=dtype).normal_(


### PR DESCRIPTION
The flash_mla_decode wrapper pinned D_latent=512 and D_rope=64 and asserted the query dims equal them, so an MLA model whose latent/rope dims differ from DeepSeek's (e.g. MiniCPM3-4B: 256/32) tripped the assert before reaching the kernel. The SYCL kernel is dimension-generic -- it tiles the latent dim and predicates the tail, and flash_mla_prefill in this file already derives its dims the same way -- so 512/64 is one instance, not a constraint.

Derive D_latent/D_rope from the q tensors and keep only the D_ckv == D_latent + D_rope check. D_latent still sizes the output, so it must be the real latent width rather than a hardcoded 512.