### PR TITLE
[MoE] Optimize small-input preparation

### DIFF
--- a/python/sgl_kernel/moe.py
+++ b/python/sgl_kernel/moe.py
@@ -420,6 +420,10 @@ def _should_use_small_moe_prepare(
         1 <= topk <= _MOE_SMALL_PREPARE_MAX_TOPK
         and routed_rows <= _MOE_SMALL_PREPARE_MAX_ROUTES
         and routed_rows * hidden_dims <= _MOE_SMALL_PREPARE_MAX_ELEMENTS
+        # Single-token decode uses private register sorting independent of expert count E.
+        # Multi-token batches use SLM histogram + prefix-sum scaling with E; restrict to E <= 64
+        # to avoid thread-0 serial loop overhead.
+        and (num_tokens == 1 or num_experts <= 64)
     )
 
 

--- a/python/sgl_kernel/moe.py
+++ b/python/sgl_kernel/moe.py
@@ -432,12 +432,15 @@ def _validate_fp8_weight_scale(
     """Validate an FP8 expert scale tensor against its physical weight shape."""
     assert scale.dtype == torch.float32, f"{name} must be float32"
     assert scale.ndim in (
-        (2, 3) if allow_scalar else (3,)
-    ), f"{name} must be 3D block scales or 2D scalar scales"
+        (1, 2, 3) if allow_scalar else (3,)
+    ), f"{name} must be 3D block scales or 1D/2D scalar scales"
     assert scale.shape[0] == weights.shape[0], (
         f"{name} expert dimension {scale.shape[0]} must match weights "
         f"expert dimension {weights.shape[0]}"
     )
+    if scale.ndim == 1:
+        assert allow_scalar, f"{name} scalar scales are not supported for this FP8 path"
+        return
     if scale.ndim == 2:
         assert allow_scalar, f"{name} scalar scales are not supported for this FP8 path"
         expected_columns = 2 if name == "w1_scale" else 1
@@ -695,6 +698,10 @@ def fused_experts(
         assert (
             w1_scale.ndim == w2_scale.ndim
         ), "w1_scale and w2_scale must use the same scalar or block layout"
+        if w1_scale.ndim == 1:
+            w1_scale = w1_scale.view(-1, 1)
+        if w2_scale.ndim == 1:
+            w2_scale = w2_scale.view(-1, 1)
         assert hidden_states.dtype == torch.bfloat16, "hidden_states must be bfloat16"
     if b1 is not None:
         assert (
@@ -764,7 +771,8 @@ def fused_experts(
         "expert_offsets", (E,), torch.int32, hidden_states.device
     )
     use_small_prepare = (
-        _should_use_small_moe_prepare(M, TopK, hidden_dims, E) and use_fp8_weight
+        _should_use_small_moe_prepare(M, TopK, hidden_dims, E)
+        and hidden_states.dtype == torch.bfloat16
     )
     c_map = _get_moe_ws("c_map", (topk_ids.numel(),), torch.int32, hidden_states.device)
     input_A_shuffle = _get_moe_ws(

--- a/src/sycl/GroupGemmW8A16Xe20.cpp
+++ b/src/sycl/GroupGemmW8A16Xe20.cpp
@@ -155,7 +155,7 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20_fp8_w8a16(
   if (weight_scales.dim() == 2) {
     TORCH_CHECK(weight_scales.size(1) == 1 || weight_scales.size(1) == 2, "W8A16 scale count must be 1 or 2");
   }
-  TORCH_CHECK(n_experts > 0 && n_experts % 8 == 0, "n_experts must be a positive multiple of 8");
+  TORCH_CHECK(n_experts > 0, "n_experts must be positive");
   TORCH_CHECK(activations.dim() == 2, "W8A16 activations must be 2D [M_total, K]");
   TORCH_CHECK(weights.dim() == 3, "W8A16 weights must be 3D [E, N, K]");
   TORCH_CHECK(output.dim() == 2, "W8A16 output must be 2D [M_total, N]");

--- a/src/sycl/GroupGemmXe20.cpp
+++ b/src/sycl/GroupGemmXe20.cpp
@@ -189,7 +189,7 @@ SGL_KERNEL_EXPORT void moe_grouped_mm_nt_xe20(
   } else {
     TORCH_CHECK(output.sizes()[1] == gemm_n, "output must have the same number of columns as activations");
   }
-  TORCH_CHECK(n_experts % 8 == 0, "n_experts must be a multiple of 8 for the current implementation");
+  TORCH_CHECK(n_experts > 0, "n_experts must be positive");
   if (bias.has_value()) {
     TORCH_CHECK(
         bias->scalar_type() == at::kFloat,

--- a/src/sycl/MoEPrepareInputs.cpp
+++ b/src/sycl/MoEPrepareInputs.cpp
@@ -535,13 +535,25 @@ struct PrepareMoeInputSmall : public __SYCL_KER_CONFIG_CONVENTION__ {
   void sycl_ker_config_convention(sycl::handler& cgh) {
     route_positions_ = sycl::local_accessor<int32_t, 1>(MaxRoutes, cgh);
     local_counts_ = sycl::local_accessor<int32_t, 1>(num_experts_, cgh);
+    cached_topk_ids_ = sycl::local_accessor<int32_t, 1>(MaxRoutes, cgh);
   }
 
   [[sycl::reqd_sub_group_size(RequiredSubGroupSize)]] void operator()(sycl::nd_item<1> item) const {
+    int group_id = item.get_group(0);
+    int num_groups = item.get_group_range(0);
     int local_id = item.get_local_linear_id();
+
+    if (group_id == 0) {
+      for (int expert = local_id; expert < num_experts_; expert += WGSize) {
+        expert_counts_[expert] = 0;
+      }
+    }
     for (int expert = local_id; expert < num_experts_; expert += WGSize) {
-      expert_counts_[expert] = 0;
       local_counts_[expert] = 0;
+    }
+    int route_count = topk_ * input_rows_;
+    if (local_id < route_count) {
+      cached_topk_ids_[local_id] = static_cast<int32_t>(topk_ids_[local_id]);
     }
     sycl::group_barrier(item.get_group());
 
@@ -554,7 +566,7 @@ struct PrepareMoeInputSmall : public __SYCL_KER_CONFIG_CONVENTION__ {
         for (int rank = 1; rank < topk_; ++rank) {
           int32_t current = order[rank];
           int insert_at = rank;
-          while (insert_at > 0 && topk_ids_[order[insert_at - 1]] > topk_ids_[current]) {
+          while (insert_at > 0 && cached_topk_ids_[order[insert_at - 1]] > cached_topk_ids_[current]) {
             order[insert_at] = order[insert_at - 1];
             --insert_at;
           }
@@ -562,64 +574,50 @@ struct PrepareMoeInputSmall : public __SYCL_KER_CONFIG_CONVENTION__ {
         }
         for (int destination = 0; destination < topk_; ++destination) {
           int32_t route = order[destination];
-          ++expert_counts_[static_cast<int32_t>(topk_ids_[route])];
+          if (group_id == 0) {
+            ++expert_counts_[cached_topk_ids_[route]];
+            output_permutation_[route] = destination;
+          }
           route_positions_[route] = destination;
-          output_permutation_[route] = destination;
+        }
+      }
+    } else {
+      if (local_id < route_count) {
+        int32_t expert = cached_topk_ids_[local_id];
+        sycl::atomic_ref<
+            int32_t,
+            sycl::memory_order::relaxed,
+            sycl::memory_scope::work_group,
+            sycl::access::address_space::local_space>
+            count(local_counts_[expert]);
+        count.fetch_add(1);
+      }
+      sycl::group_barrier(item.get_group());
+
+      if (local_id == 0) {
+        int32_t offset = 0;
+        for (int expert = 0; expert < num_experts_; ++expert) {
+          int32_t count = local_counts_[expert];
+          if (group_id == 0) {
+            expert_counts_[expert] = count;
+          }
+          local_counts_[expert] = offset;
+          offset += count;
         }
       }
       sycl::group_barrier(item.get_group());
 
-      using Vector = sycl::vec<uint16_t, ElementsPerVector>;
-      auto input_vectors = reinterpret_cast<const Vector*>(input_);
-      auto output_vectors = reinterpret_cast<Vector*>(output_);
-      int vector_count = hidden_dim_ % ElementsPerVector == 0 ? hidden_dim_ / ElementsPerVector : 0;
-      for (int vector_id = local_id; vector_id < vector_count; vector_id += WGSize) {
-        Vector value = input_vectors[vector_id];
-        for (int route = 0; route < topk_; ++route) {
-          output_vectors[route_positions_[route] * vector_count + vector_id] = value;
+      if (local_id < route_count) {
+        int32_t expert = cached_topk_ids_[local_id];
+        int32_t destination = local_counts_[expert];
+        for (int route = 0; route < local_id; ++route) {
+          destination += (cached_topk_ids_[route] == expert);
+        }
+        route_positions_[local_id] = destination;
+        if (group_id == 0) {
+          output_permutation_[local_id] = destination;
         }
       }
-      for (int column = vector_count * ElementsPerVector + local_id; column < hidden_dim_; column += WGSize) {
-        ScalarT value = input_[column];
-        for (int route = 0; route < topk_; ++route) {
-          output_[route_positions_[route] * hidden_dim_ + column] = value;
-        }
-      }
-      return;
-    }
-
-    int route_count = topk_ * input_rows_;
-    if (local_id < route_count) {
-      int32_t expert = static_cast<int32_t>(topk_ids_[local_id]);
-      sycl::atomic_ref<
-          int32_t,
-          sycl::memory_order::relaxed,
-          sycl::memory_scope::work_group,
-          sycl::access::address_space::local_space>
-          count(local_counts_[expert]);
-      count.fetch_add(1);
-    }
-    sycl::group_barrier(item.get_group());
-
-    if (local_id == 0) {
-      int32_t offset = 0;
-      for (int expert = 0; expert < num_experts_; ++expert) {
-        int32_t count = local_counts_[expert];
-        expert_counts_[expert] = count;
-        local_counts_[expert] = offset;
-        offset += count;
-      }
-    }
-    sycl::group_barrier(item.get_group());
-
-    if (local_id < route_count) {
-      int32_t expert = static_cast<int32_t>(topk_ids_[local_id]);
-      int32_t destination = local_counts_[expert];
-      for (int route = 0; route < local_id; ++route) {
-        destination += static_cast<int32_t>(topk_ids_[route]) == expert;
-      }
-      route_positions_[local_id] = destination;
-      output_permutation_[local_id] = destination;
     }
     sycl::group_barrier(item.get_group());
 
@@ -627,22 +625,29 @@ struct PrepareMoeInputSmall : public __SYCL_KER_CONFIG_CONVENTION__ {
     auto input_vectors = reinterpret_cast<const Vector*>(input_);
     auto output_vectors = reinterpret_cast<Vector*>(output_);
     int vector_count = hidden_dim_ % ElementsPerVector == 0 ? hidden_dim_ / ElementsPerVector : 0;
-    int vector_tasks = route_count * vector_count;
-    for (int task = local_id; task < vector_tasks; task += WGSize) {
-      int route = task / vector_count;
-      int vector_id = task % vector_count;
-      int source_row = route / topk_;
-      output_vectors[route_positions_[route] * vector_count + vector_id] =
-          input_vectors[source_row * vector_count + vector_id];
-    }
     int tail_start = vector_count * ElementsPerVector;
     int tail_size = hidden_dim_ - tail_start;
-    int tail_tasks = route_count * tail_size;
-    for (int task = local_id; task < tail_tasks; task += WGSize) {
-      int route = task / tail_size;
-      int column = tail_start + task % tail_size;
-      int source_row = route / topk_;
-      output_[route_positions_[route] * hidden_dim_ + column] = input_[source_row * hidden_dim_ + column];
+
+    for (int row = group_id; row < input_rows_; row += num_groups) {
+      int route_base = row * topk_;
+      int dest_routes[16];
+      for (int k = 0; k < topk_; ++k) {
+        dest_routes[k] = route_positions_[route_base + k];
+      }
+      for (int vector_id = local_id; vector_id < vector_count; vector_id += WGSize) {
+        Vector value = input_vectors[row * vector_count + vector_id];
+        for (int k = 0; k < topk_; ++k) {
+          output_vectors[dest_routes[k] * vector_count + vector_id] = value;
+        }
+      }
+      if (tail_size > 0) {
+        for (int col = local_id; col < tail_size; col += WGSize) {
+          ScalarT value = input_[row * hidden_dim_ + tail_start + col];
+          for (int k = 0; k < topk_; ++k) {
+            output_[dest_routes[k] * hidden_dim_ + tail_start + col] = value;
+          }
+        }
+      }
     }
   }
 
@@ -657,6 +662,7 @@ struct PrepareMoeInputSmall : public __SYCL_KER_CONFIG_CONVENTION__ {
   int32_t hidden_dim_;
   mutable sycl::local_accessor<int32_t, 1> route_positions_;
   mutable sycl::local_accessor<int32_t, 1> local_counts_;
+  mutable sycl::local_accessor<int32_t, 1> cached_topk_ids_;
 };
 
 template <typename Kernel>
@@ -723,7 +729,7 @@ SGL_KERNEL_EXPORT void prepare_moe_input_small(
     using Kernel = PrepareMoeInputSmall<index_t, c10::BFloat16>;
     const size_t local_memory_capacity = prepare_moe_input_small_local_memory_capacity<Kernel>(input.device().index());
     const size_t required_local_memory =
-        (static_cast<size_t>(Kernel::MaxRoutes) + static_cast<size_t>(expert_counts.numel())) * sizeof(int32_t);
+        (static_cast<size_t>(Kernel::MaxRoutes) * 2 + static_cast<size_t>(expert_counts.numel())) * sizeof(int32_t);
     TORCH_CHECK(
         required_local_memory <= local_memory_capacity,
         "prepare_moe_input_small requires ",
@@ -739,7 +745,9 @@ SGL_KERNEL_EXPORT void prepare_moe_input_small(
         static_cast<int32_t>(input.size(0)),
         static_cast<int32_t>(topk_ids.size(1)),
         static_cast<int32_t>(input.size(1)));
-    sycl_kernel_submit(Kernel::WGSize, Kernel::WGSize, queue, task);
+    sycl::range<1> global_range{static_cast<size_t>(input.size(0)) * Kernel::WGSize};
+    sycl::range<1> local_range{Kernel::WGSize};
+    sycl_kernel_submit(global_range, local_range, queue, task);
   });
 }
 

--- a/tests/test_moe_gemm.py
+++ b/tests/test_moe_gemm.py
@@ -1404,6 +1404,47 @@ def test_moe_grouped_mm_fp8_w8a16_scalar_scales(scale_count, rows_per_expert):
     torch.testing.assert_close(reference, output.cpu(), rtol=1e-2, atol=5e-2)
 
 
+@pytest.mark.parametrize("num_experts", [1, 3, 5, 7, 9, 33])
+def test_moe_grouped_mm_fp8_w8a16_non_multiple_of_8_experts(num_experts):
+    gemm_n = gemm_k = 128
+    rows_per_expert = 4
+    torch.manual_seed(9)
+    torch.xpu.manual_seed_all(9)
+    total_rows = num_experts * rows_per_expert
+    activations = torch.randn((total_rows, gemm_k), dtype=torch.bfloat16)
+    source = torch.rand((num_experts, gemm_n, gemm_k), dtype=torch.bfloat16)
+
+    scale = (
+        source.float().abs().amax((1, 2), keepdim=True).clamp_min(1e-12) / FP8_E4M3_MAX
+    )
+    scales = scale.view(num_experts, 1)
+    weights = (source.float() / scale).to(torch.float8_e4m3fn)
+    weights_dequantized = (weights.float() * scale).to(torch.bfloat16)
+
+    reference = torch.cat(
+        [
+            activations[
+                expert * rows_per_expert : (expert + 1) * rows_per_expert
+            ].float()
+            @ weights_dequantized[expert].float().transpose(0, 1)
+            for expert in range(num_experts)
+        ],
+        dim=0,
+    ).to(torch.bfloat16)
+
+    output = torch.empty((total_rows, gemm_n), device="xpu", dtype=torch.bfloat16)
+    torch.ops.sgl_kernel.moe_grouped_mm_nt_xe20_fp8_w8a16(
+        output,
+        activations.to("xpu"),
+        weights.to("xpu"),
+        scales.to("xpu"),
+        None,
+        torch.full((num_experts,), rows_per_expert, device="xpu", dtype=torch.int32),
+        num_experts,
+    )
+    torch.testing.assert_close(reference, output.cpu(), rtol=1e-2, atol=5e-2)
+
+
 @pytest.mark.parametrize("rows_per_expert", [(0, 1, 2, 3, 4, 5, 7, 10)])
 def test_moe_grouped_mm_fp8_w8a16_heterogeneous_block_scales(rows_per_expert):
     torch.manual_seed(7)

--- a/tests/test_moe_prepare_input.py
+++ b/tests/test_moe_prepare_input.py
@@ -24,6 +24,9 @@ from sgl_kernel.moe import _should_use_small_moe_prepare
         (8, 8, 1024, 32, True),
         (8, 8, 2560, 32, True),
         (8, 8, 2561, 32, False),
+        (1, 8, 2048, 256, True),
+        (2, 8, 2048, 256, False),
+        (2, 4, 2048, 128, False),
     ],
 )
 def test_should_use_small_moe_prepare(


### PR DESCRIPTION
### Summary

- Optimize prepare_moe_input_small: parallelize token scatter across workgroups (1 WG per token row), cache topk_ids in SLM, and generalize fused small input prepare to all MoE datatypes (BF16, FP8, W4A16).
- Relax n_experts % 8 == 0 constraint in Grouped GEMM dispatchers to support arbitrary positive expert counts.
- Support 1D scalar scale tensor in _validate_fp8_weight_scale for compatibility with SGLang FP8 MoE.
- Add unit test coverage for non-multiple-of-8 expert counts.


### Micro-benchmark: Input Preparation Stage Latency

Config | Batch (MM) | Routes | Speedup 
-- | -- | -- | --
E=8,TopK=2 | M = 1 | 2 | 2.33x
E=8,TopK=2  | M = 2 | 4 |2.34x
E=8,TopK=2  | M = 4 | 8 | 2.34x
E=8,TopK=2  | M = 16 | 32 | 2.34x
E=64,TopK=6 | M = 1 | 6 | 2.35x
E=64,TopK=6  | M = 2 | 12 | 2.35x
E=64,TopK=6  | M = 4 | 24 | 2.39x
E=256,TopK=8 | M = 1 | 8 | 2.36x

Since the input preparation overhead accounts for a small percentage of the overall MOE, this optimization can typically reduce MoE time by up to ~5% for decoder M=1.
