### PR TITLE
Add AOT SYCL Mamba HiCache transfer kernels for XPU

### DIFF
--- a/benchmark/bench_transfer_mamba.py
+++ b/benchmark/bench_transfer_mamba.py
@@ -1,0 +1,169 @@
+"""Benchmark the Mamba HiCache transfer kernels: PyTorch vs AOT SYCL.
+
+Both providers move exactly the same bytes -- the kernels are pure gather /
+scatter copies with no arithmetic -- so the interesting number is achieved
+bandwidth:
+
+  torch : PyTorch advanced-indexing copy (what runs without a kernel)
+  sycl  : sgl_kernel.transfer_kv_mamba_*  (AOT SYCL, compiled into the wheel)
+
+  load   : dst[dst_idx[i]]        <- src[src_idx[i], layer_id]
+  backup : dst[dst_idx[i], layer] <- src[layer, src_idx[i]]   (all layers)
+"""
+
+import itertools
+
+import pandas as pd
+import torch
+import triton
+
+try:
+    from sgl_kernel import transfer_kv_mamba_lf_pf, transfer_kv_mamba_pf_lf
+
+    HAS_SYCL = True
+except ImportError:
+    HAS_SYCL = False
+    print("Warning: sgl_kernel Mamba transfer kernels not available")
+
+all_results = []
+
+# Layers copied per backup call (a real Mamba HiCache backup is all-layer).
+NUM_LAYERS = 4
+DTYPE = torch.bfloat16
+
+
+def _make_indices(pool, num_items, device):
+    src_idx = torch.randperm(pool, device=device)[:num_items].to(torch.int64)
+    dst_idx = torch.randperm(pool, device=device)[:num_items].to(torch.int64)
+    return src_idx, dst_idx
+
+
+def torch_load_pf_lf(src, dst, src_idx, dst_idx, layer_id, item_elems, num_layers):
+    """PyTorch reference gather: page_first -> single-layer."""
+    dst.view(-1, item_elems)[dst_idx] = src.view(-1, num_layers, item_elems)[
+        src_idx, layer_id
+    ]
+
+
+def torch_backup_lf_pf(src_layers, dst, src_idx, dst_idx, item_elems, num_layers):
+    """PyTorch reference scatter: layer_first -> page_first (all layers)."""
+    s = src_layers.view(num_layers, -1, item_elems)
+    dst.view(-1, num_layers, item_elems)[dst_idx] = s[:, src_idx, :].permute(1, 0, 2)
+
+
+def bytes_moved(op, num_items, item_elems, num_layers, elem_size):
+    """Bytes read + written by one call (copy => 2x the payload)."""
+    items = num_items if op == "load" else num_items * num_layers
+    return 2 * items * item_elems * elem_size
+
+
+# (num_items, item_elems, op). item_elems spans a small per-page Mamba state up
+# to a large fused conv+ssm state; num_items spans a short prefix-cache hit up to
+# a full-batch backup.
+configs = list(
+    itertools.product(
+        [16, 128, 512],  # num_items (pages transferred)
+        [1024, 8192, 65536],  # item_elems (state elements per page per layer)
+        ["load", "backup"],
+    )
+)
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["num_items", "item_elems", "op"],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=["torch", "sycl"],
+        line_names=["PyTorch (index copy)", "SYCL"],
+        styles=[("blue", "-"), ("red", "-")],
+        ylabel="us",
+        plot_name="torch-vs-sycl-transfer-mamba-performance",
+        args={},
+    )
+)
+def benchmark(num_items, item_elems, op, provider):
+    device = torch.device("xpu")
+    num_layers = NUM_LAYERS
+    pool = num_items  # every page in the pool participates
+    elem_size = torch.tensor([], dtype=DTYPE).element_size()
+    item_size = item_elems * elem_size
+    layout_dim = item_size * num_layers
+    layer_id = min(2, num_layers - 1)
+    quantiles = [0.5, 0.2, 0.8]
+
+    if provider == "sycl" and not HAS_SYCL:
+        print("Warning: sgl_kernel Mamba transfer not available, skipping")
+        return 0, 0, 0
+
+    src_idx, dst_idx = _make_indices(pool, num_items, device)
+
+    if op == "load":
+        src = torch.randn(pool, num_layers, item_elems, device=device, dtype=DTYPE)
+        dst = torch.zeros(pool, item_elems, device=device, dtype=DTYPE)
+        if provider == "torch":
+            fn = lambda: torch_load_pf_lf(
+                src, dst, src_idx, dst_idx, layer_id, item_elems, num_layers
+            )
+        else:
+            fn = lambda: transfer_kv_mamba_pf_lf(
+                src, dst, src_idx, dst_idx, layer_id, item_size, layout_dim
+            )
+    else:
+        src = torch.randn(num_layers, pool, item_elems, device=device, dtype=DTYPE)
+        dst = torch.zeros(pool, num_layers, item_elems, device=device, dtype=DTYPE)
+        if provider == "torch":
+            fn = lambda: torch_backup_lf_pf(
+                src, dst, src_idx, dst_idx, item_elems, num_layers
+            )
+        else:
+            fn = lambda: transfer_kv_mamba_lf_pf(
+                src, dst, src_idx, dst_idx, item_size, layout_dim, num_layers
+            )
+
+    # Warm up (first launch pays kernel setup) before the measurement window.
+    fn()
+    torch.xpu.synchronize()
+
+    ms, min_ms, max_ms = triton.testing.do_bench(fn, quantiles=quantiles)
+
+    total_bytes = bytes_moved(op, num_items, item_elems, num_layers, elem_size)
+    all_results.append(
+        {
+            "op": op,
+            "num_items": num_items,
+            "item_elems": item_elems,
+            "num_layers": num_layers,
+            "provider": provider,
+            "time_us": 1000 * ms,
+            "bandwidth_gbs": (total_bytes / 1e9) / (ms / 1e3),
+        }
+    )
+
+    return 1000 * ms, 1000 * min_ms, 1000 * max_ms
+
+
+if __name__ == "__main__":
+    if not torch.xpu.is_available():
+        print("ERROR: Intel XPU not available.")
+        exit(1)
+    if not HAS_SYCL:
+        print(
+            "ERROR: sgl_kernel Mamba transfer kernels not available. Install "
+            "sgl-kernel-xpu on an XPU host."
+        )
+        exit(1)
+
+    print("Running PyTorch vs SYCL Mamba HiCache transfer benchmarks...")
+    print("torch: advanced-indexing gather/scatter copy")
+    print("sycl : sgl_kernel.transfer_kv_mamba_{pf_lf,lf_pf}")
+    print(f"dtype={DTYPE}, num_layers={NUM_LAYERS}")
+    print("\n" + "=" * 80 + "\n")
+
+    benchmark.run(print_data=True)
+
+    print("Benchmark finished!")
+    df = pd.DataFrame(all_results)
+    df["time_us"] = df["time_us"].round(2)
+    df["bandwidth_gbs"] = df["bandwidth_gbs"].round(1)
+    print(df.to_markdown(index=False))

--- a/benchmark/run_suite.py
+++ b/benchmark/run_suite.py
@@ -92,6 +92,12 @@ suites = {
             estimated_time=30,
         ),
         BenchFile("bench_scatter_tokens_to_experts.py"),
+        # --- KV cache / HiCache transfer ---
+        BenchFile(
+            "bench_transfer_mamba.py",
+            tee_log="transfer_mamba.log",
+            estimated_time=15,
+        ),
         # --- norm / rope / quant ---
         BenchFile("bench_merge_states_v2.py", tee_log="merge_states.py.log"),
         BenchFile("bench_mrope.py", tee_log="mrope.py.log"),

--- a/include/sgl_kernel_ops.h
+++ b/include/sgl_kernel_ops.h
@@ -375,6 +375,22 @@ void transfer_kv_all_layer_mla_lf_pf(
     int64_t num_layers,
     int64_t block_quota,
     int64_t sgs_per_wg);
+void transfer_kv_mamba_pf_lf(
+    const at::Tensor& src,
+    at::Tensor& dst,
+    const at::Tensor& src_indices,
+    const at::Tensor& dst_indices,
+    int64_t layer_id,
+    int64_t item_size,
+    int64_t src_layout_dim);
+void transfer_kv_mamba_lf_pf(
+    const at::Tensor& src_layers,
+    at::Tensor& dst,
+    const at::Tensor& src_indices,
+    const at::Tensor& dst_indices,
+    int64_t item_size,
+    int64_t dst_layout_dim,
+    int64_t num_layers);
 void silu_and_mul(torch::Tensor& out, torch::Tensor& input);
 void silu_and_mul_clamp(torch::Tensor& out, torch::Tensor& input, double swiglu_limit);
 void gelu_tanh_and_mul(torch::Tensor& out, torch::Tensor& input);

--- a/python/sgl_kernel/__init__.py
+++ b/python/sgl_kernel/__init__.py
@@ -140,6 +140,8 @@ from sgl_kernel.kvcacheio import (
     transfer_kv_all_layer_mla,
     transfer_kv_all_layer_mla_lf_pf,
     transfer_kv_direct,
+    transfer_kv_mamba_lf_pf,
+    transfer_kv_mamba_pf_lf,
     transfer_kv_per_layer,
     transfer_kv_per_layer_direct_pf_lf,
     transfer_kv_per_layer_mla,

--- a/python/sgl_kernel/kvcacheio.py
+++ b/python/sgl_kernel/kvcacheio.py
@@ -313,6 +313,63 @@ def transfer_kv_all_layer_mla_lf_pf(
     )
 
 
+def transfer_kv_mamba_pf_lf(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    src_indices: torch.Tensor,
+    dst_indices: torch.Tensor,
+    layer_id: int,
+    item_size: int,
+    src_layout_dim: int,
+) -> None:
+    """Mamba HiCache load: dst[dst_idx[i]] ← src[src_idx[i], layer_id].
+
+    ``item_size`` and ``src_layout_dim`` are BYTES (per item, and per page in
+    ``src``), matching the CUDA ``transfer_kv_mamba_pf_lf``. The Mamba state is
+    one fused block per page, so there is no K/V split and no tuning knobs: the
+    kernel picks its copy width and grid from the alignment and the device size.
+    """
+    torch.ops.sgl_kernel.transfer_kv_mamba_pf_lf.default(
+        src,
+        dst,
+        src_indices,
+        dst_indices,
+        layer_id,
+        item_size,
+        src_layout_dim,
+    )
+
+
+def transfer_kv_mamba_lf_pf(
+    src_layers: torch.Tensor,
+    dst: torch.Tensor,
+    src_indices: torch.Tensor,
+    dst_indices: torch.Tensor,
+    item_size: int,
+    dst_layout_dim: int,
+    num_layers: int,
+) -> None:
+    """Mamba HiCache backup: dst[dst_idx[i], layer] ← src[layer, src_idx[i]], all layers.
+
+    NOTE (API): unlike the CUDA kernel — which takes a uint64 pointer array of
+    the per-layer device buffers — this takes the actual contiguous layer-first
+    source TENSOR of shape ``(num_layers, pool, ...)``. The scheduler already
+    holds it, and dereferencing a host-built pointer array is neither safe nor
+    portable across SYCL runtimes. Numerically identical.
+
+    ``item_size`` and ``dst_layout_dim`` are BYTES (per item, and per page in dst).
+    """
+    torch.ops.sgl_kernel.transfer_kv_mamba_lf_pf.default(
+        src_layers,
+        dst,
+        src_indices,
+        dst_indices,
+        item_size,
+        dst_layout_dim,
+        num_layers,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Group B: Python/PyTorch fallbacks (host↔device; no equivalent of
 # cudaMemcpyBatchAsync on XPU — use PyTorch copy_ page-by-page).

--- a/src/sycl/KVCacheIO.cpp
+++ b/src/sycl/KVCacheIO.cpp
@@ -32,6 +32,7 @@ limitations under the License.
 
 #include <ATen/ATen.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <vector>
 
@@ -936,3 +937,317 @@ SGL_KERNEL_EXPORT void transfer_kv_all_layer_mla_lf_pf(
       block_quota,
       sgs_per_wg);
 }
+
+// ===========================================================================
+// Mamba HiCache transfer (SYCL port of sgl-kernel csrc/kvcacheio/transfer_mamba.cuh,
+// i.e. TransferMambaKernel::run_pf_lf / ::run_lf_pf)
+//
+//   load  (pf→lf): dst[dst_idx[i]]        ← src[src_idx[i], layer_id]
+//   backup(lf→pf): dst[dst_idx[i], layer] ← src[layer, src_idx[i]]  (all layers)
+//
+// Layouts (all contiguous):
+//   page_first  : [pool, num_layers, item]  per-page stride = num_layers * item
+//   layer_first : [num_layers, pool, item]  per-layer stride = pool * item
+//   single-layer: [pool, item]              per-page stride = item
+//
+// Unlike the KV kernels above (which hard-require item_size % 8 == 0), the copy
+// unit is chosen at runtime from pointer and stride alignment, so odd Mamba
+// state sizes stay correct.
+//
+// backup takes the contiguous layer_first tensor plus its per-layer byte stride
+// where CUDA takes a uint64 array of per-layer pointers: dereferencing a
+// host-built pointer array is not portable across SYCL runtimes.
+// ===========================================================================
+
+static constexpr int64_t kMambaWgSize = 256;
+// Split an item across work-groups only while each still has enough to amortize
+// its launch: at least this many units per work-item.
+static constexpr int64_t kMambaMinUnitsPerThread = 8;
+// Measured on BMG (160 CUs): 1 leaves the large-item copies short of peak, 4 and
+// 8 are within noise, so 4 fills the device while keeping chunks as large (and
+// as streaming-friendly) as possible.
+static constexpr int64_t kMambaGroupsPerCu = 4;
+
+// Widest power-of-two copy unit (≤ 8B) dividing every address and byte stride,
+// so every access stays naturally aligned.  OR-ing the quantities makes the
+// lowest set bit the minimum over their individual lowest set bits, which is
+// exactly the shared 2-power.
+static inline int64_t mamba_copy_width(std::initializer_list<int64_t> byte_quantities) {
+  int64_t combined = 0;
+  for (int64_t q : byte_quantities)
+    combined |= q;
+  for (int64_t w : {8, 4, 2}) {
+    if ((combined & (w - 1)) == 0) return w;
+  }
+  return 1;
+}
+
+// One work-group per copy unit (item for load, item × layer for backup) leaves
+// most of the device idle when items are few and large -- 16 pages of 64Ki
+// elements is 16 work-groups on a 160-CU GPU, measurably slower than a plain
+// PyTorch indexed copy -- so each unit is split into `chunks` contiguous ranges
+// until the grid fills the device.  With enough units to fill it (the common
+// HiCache case) this returns chunks == 1.
+struct MambaChunking {
+  int64_t chunks;
+  int64_t units_per_chunk;
+};
+
+static MambaChunking mamba_plan_chunks(int64_t num_copy_units, int64_t item_units) {
+  const int64_t max_chunks = std::max<int64_t>(1, item_units / (kMambaWgSize * kMambaMinUnitsPerThread));
+  const int64_t target_wgs = kMambaGroupsPerCu * dpcppMaxComputeUnitSize();
+  const int64_t wanted = std::clamp<int64_t>(div_up(target_wgs, num_copy_units), 1, max_chunks);
+  if (wanted == 1) return {1, item_units};
+
+  // Round up to a whole work-group stride so every chunk boundary stays
+  // cache-line aligned, then recompute the count from the rounded size so no
+  // work-group is launched for an entirely empty range.
+  const int64_t units_per_chunk = div_up(div_up(item_units, wanted), kMambaWgSize) * kMambaWgSize;
+  return {div_up(item_units, units_per_chunk), units_per_chunk};
+}
+
+// Load: page_first → single-layer.  Grid = (num_items) × (chunks * kMambaWgSize).
+// 2-D rather than flat-and-divided so the hardware supplies both indices:
+// recovering (item, chunk) from a flat group id costs an int64 div+mod per
+// work-item, which measurably slowed the small-item shapes.
+template <typename CopyT>
+struct TransferMambaLoadKernel {
+  [[sycl::reqd_sub_group_size(XPU_SG_SIZE)]] void operator()(sycl::nd_item<2> item) const {
+    const int64_t begin = static_cast<int64_t>(item.get_group(1)) * units_per_chunk_;
+    if (begin >= item_units_) return;  // only reachable for a tail chunk
+    const int64_t end = sycl::min(begin + units_per_chunk_, item_units_);
+
+    const int64_t item_id = static_cast<int64_t>(item.get_group(0));
+    const CopyT* src = src_ + src_indices_[item_id] * src_page_stride_ + layer_id_ * item_units_;
+    CopyT* dst = dst_ + dst_indices_[item_id] * item_units_;
+
+    const int64_t stride = static_cast<int64_t>(item.get_local_range(1));
+    for (int64_t i = begin + static_cast<int64_t>(item.get_local_id(1)); i < end; i += stride) {
+      dst[i] = src[i];
+    }
+  }
+
+  const CopyT* src_;
+  CopyT* dst_;
+  const int64_t* src_indices_;
+  const int64_t* dst_indices_;
+  int64_t layer_id_;
+  int64_t item_units_;
+  int64_t src_page_stride_;
+  int64_t units_per_chunk_;
+};
+
+// Backup: layer_first → page_first, all layers.
+// Grid = (num_items) × (num_layers) × (chunks * kMambaWgSize), 3-D for the same
+// reason the load grid is 2-D.
+template <typename CopyT>
+struct TransferMambaBackupKernel {
+  [[sycl::reqd_sub_group_size(XPU_SG_SIZE)]] void operator()(sycl::nd_item<3> item) const {
+    const int64_t begin = static_cast<int64_t>(item.get_group(2)) * units_per_chunk_;
+    if (begin >= item_units_) return;  // only reachable for a tail chunk
+    const int64_t end = sycl::min(begin + units_per_chunk_, item_units_);
+
+    const int64_t item_id = static_cast<int64_t>(item.get_group(0));
+    const int64_t layer = static_cast<int64_t>(item.get_group(1));
+    const CopyT* src = src_ + layer * src_layer_stride_ + src_indices_[item_id] * item_units_;
+    CopyT* dst = dst_ + dst_indices_[item_id] * dst_page_stride_ + layer * item_units_;
+
+    const int64_t stride = static_cast<int64_t>(item.get_local_range(2));
+    for (int64_t i = begin + static_cast<int64_t>(item.get_local_id(2)); i < end; i += stride) {
+      dst[i] = src[i];
+    }
+  }
+
+  const CopyT* src_;
+  CopyT* dst_;
+  const int64_t* src_indices_;
+  const int64_t* dst_indices_;
+  int64_t item_units_;
+  int64_t src_layer_stride_;
+  int64_t dst_page_stride_;
+  int64_t units_per_chunk_;
+};
+
+template <typename CopyT>
+static void launch_mamba_load(
+    const void* src,
+    void* dst,
+    const int64_t* src_indices,
+    const int64_t* dst_indices,
+    int64_t layer_id,
+    int64_t item_bytes,
+    int64_t src_page_stride_bytes,
+    int64_t num_items) {
+  constexpr int64_t kUnit = static_cast<int64_t>(sizeof(CopyT));
+  const int64_t item_units = item_bytes / kUnit;
+  // Plain locals rather than a structured binding: the SYCL device pass compiles
+  // as C++17, where capturing one in the command-group lambda is an extension.
+  const MambaChunking plan = mamba_plan_chunks(num_items, item_units);
+  const int64_t chunks = plan.chunks;
+
+  TransferMambaLoadKernel<CopyT> kernel{
+      .src_ = static_cast<const CopyT*>(src),
+      .dst_ = static_cast<CopyT*>(dst),
+      .src_indices_ = src_indices,
+      .dst_indices_ = dst_indices,
+      .layer_id_ = layer_id,
+      .item_units_ = item_units,
+      .src_page_stride_ = src_page_stride_bytes / kUnit,
+      .units_per_chunk_ = plan.units_per_chunk,
+  };
+
+  auto cgf = DPCPP_Q_CGF(cgh) {
+    cgh.parallel_for<decltype(kernel)>(
+        sycl::nd_range<2>(
+            sycl::range<2>(static_cast<size_t>(num_items), static_cast<size_t>(chunks * kMambaWgSize)),
+            sycl::range<2>(1, static_cast<size_t>(kMambaWgSize))),
+        kernel);
+  };
+  dpcppGetCurrentQueue().submit(cgf);
+}
+
+template <typename CopyT>
+static void launch_mamba_backup(
+    const void* src,
+    void* dst,
+    const int64_t* src_indices,
+    const int64_t* dst_indices,
+    int64_t item_bytes,
+    int64_t src_layer_stride_bytes,
+    int64_t dst_page_stride_bytes,
+    int64_t num_items,
+    int64_t num_layers) {
+  constexpr int64_t kUnit = static_cast<int64_t>(sizeof(CopyT));
+  const int64_t item_units = item_bytes / kUnit;
+  const MambaChunking plan = mamba_plan_chunks(num_items * num_layers, item_units);
+  const int64_t chunks = plan.chunks;
+
+  TransferMambaBackupKernel<CopyT> kernel{
+      .src_ = static_cast<const CopyT*>(src),
+      .dst_ = static_cast<CopyT*>(dst),
+      .src_indices_ = src_indices,
+      .dst_indices_ = dst_indices,
+      .item_units_ = item_units,
+      .src_layer_stride_ = src_layer_stride_bytes / kUnit,
+      .dst_page_stride_ = dst_page_stride_bytes / kUnit,
+      .units_per_chunk_ = plan.units_per_chunk,
+  };
+
+  auto cgf = DPCPP_Q_CGF(cgh) {
+    cgh.parallel_for<decltype(kernel)>(
+        sycl::nd_range<3>(
+            sycl::range<3>(
+                static_cast<size_t>(num_items),
+                static_cast<size_t>(num_layers),
+                static_cast<size_t>(chunks * kMambaWgSize)),
+            sycl::range<3>(1, 1, static_cast<size_t>(kMambaWgSize))),
+        kernel);
+  };
+  dpcppGetCurrentQueue().submit(cgf);
+}
+
+// Dispatch on the runtime-chosen copy width.  The unit type carries no
+// semantics -- this is a byte copy, not a per-dtype instantiation.
+#define _MAMBA_DISPATCH_WIDTH(WIDTH, LAUNCH, ...) \
+  switch (WIDTH) {                                \
+    case 8:                                       \
+      LAUNCH<uint64_t>(__VA_ARGS__);              \
+      break;                                      \
+    case 4:                                       \
+      LAUNCH<uint32_t>(__VA_ARGS__);              \
+      break;                                      \
+    case 2:                                       \
+      LAUNCH<uint16_t>(__VA_ARGS__);              \
+      break;                                      \
+    default:                                      \
+      LAUNCH<uint8_t>(__VA_ARGS__);               \
+      break;                                      \
+  }
+
+// Shared argument validation for both directions; returns the item count.
+static int64_t check_mamba_transfer(
+    const at::Tensor& src,
+    const at::Tensor& dst,
+    const at::Tensor& src_indices,
+    const at::Tensor& dst_indices,
+    int64_t item_size,
+    int64_t layout_dim) {
+  TORCH_CHECK(src_indices.scalar_type() == at::kLong, "src_indices must be int64");
+  TORCH_CHECK(dst_indices.scalar_type() == at::kLong, "dst_indices must be int64");
+  TORCH_CHECK(src_indices.numel() == dst_indices.numel(), "index count mismatch");
+  TORCH_CHECK(src_indices.is_contiguous() && dst_indices.is_contiguous(), "indices must be contiguous");
+  // Flat byte addressing assumes both pools are contiguous.
+  TORCH_CHECK(src.is_contiguous() && dst.is_contiguous(), "src/dst must be contiguous");
+  TORCH_CHECK(item_size > 0, "item_size must be positive");
+  TORCH_CHECK(layout_dim >= item_size, "layout_dim must be at least item_size");
+  TORCH_CHECK(layout_dim % item_size == 0, "layout_dim must be a whole number of items");
+  return src_indices.numel();
+}
+
+// Load: page_first → single-layer, one layer slot.
+// item_size and src_layout_dim are BYTES (per item, and per page in src).
+SGL_KERNEL_EXPORT void transfer_kv_mamba_pf_lf(
+    const at::Tensor& src,
+    at::Tensor& dst,
+    const at::Tensor& src_indices,
+    const at::Tensor& dst_indices,
+    int64_t layer_id,
+    int64_t item_size,
+    int64_t src_layout_dim) {
+  const int64_t num_items = check_mamba_transfer(src, dst, src_indices, dst_indices, item_size, src_layout_dim);
+  if (num_items == 0) return;
+  TORCH_CHECK(layer_id >= 0 && layer_id < src_layout_dim / item_size, "layer_id out of range for src_layout_dim");
+
+  const auto src_addr = reinterpret_cast<int64_t>(src.const_data_ptr());
+  const auto dst_addr = reinterpret_cast<int64_t>(dst.data_ptr());
+  const int64_t width = mamba_copy_width({src_addr, dst_addr, item_size, src_layout_dim});
+
+  _MAMBA_DISPATCH_WIDTH(
+      width,
+      launch_mamba_load,
+      src.const_data_ptr(),
+      dst.data_ptr(),
+      src_indices.const_data_ptr<int64_t>(),
+      dst_indices.const_data_ptr<int64_t>(),
+      layer_id,
+      item_size,
+      src_layout_dim,
+      num_items);
+}
+
+// Backup: layer_first → page_first, all layers.
+// item_size and dst_layout_dim are BYTES (per item, and per page in dst).
+SGL_KERNEL_EXPORT void transfer_kv_mamba_lf_pf(
+    const at::Tensor& src_layers,
+    at::Tensor& dst,
+    const at::Tensor& src_indices,
+    const at::Tensor& dst_indices,
+    int64_t item_size,
+    int64_t dst_layout_dim,
+    int64_t num_layers) {
+  const int64_t num_items = check_mamba_transfer(src_layers, dst, src_indices, dst_indices, item_size, dst_layout_dim);
+  TORCH_CHECK(num_layers > 0, "num_layers must be positive");
+  TORCH_CHECK(src_layers.dim() >= 1 && src_layers.size(0) == num_layers, "src_layers.size(0) must be num_layers");
+  TORCH_CHECK(dst_layout_dim / item_size >= num_layers, "dst_layout_dim must hold num_layers items");
+  if (num_items == 0) return;
+
+  const int64_t src_layer_stride = src_layers.stride(0) * src_layers.element_size();
+  const auto src_addr = reinterpret_cast<int64_t>(src_layers.const_data_ptr());
+  const auto dst_addr = reinterpret_cast<int64_t>(dst.data_ptr());
+  const int64_t width = mamba_copy_width({src_addr, dst_addr, item_size, dst_layout_dim, src_layer_stride});
+
+  _MAMBA_DISPATCH_WIDTH(
+      width,
+      launch_mamba_backup,
+      src_layers.const_data_ptr(),
+      dst.data_ptr(),
+      src_indices.const_data_ptr<int64_t>(),
+      dst_indices.const_data_ptr<int64_t>(),
+      item_size,
+      src_layer_stride,
+      dst_layout_dim,
+      num_items,
+      num_layers);
+}
+
+#undef _MAMBA_DISPATCH_WIDTH

--- a/src/torch_extension_sycl.cc
+++ b/src/torch_extension_sycl.cc
@@ -195,6 +195,17 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "int num_layers, int block_quota, int sgs_per_wg) -> ()");
   m.impl("transfer_kv_all_layer_mla_lf_pf", torch::kXPU, &transfer_kv_all_layer_mla_lf_pf);
 
+  // Mamba HiCache state transfer (single fused copy per page; no K/V split)
+  m.def(
+      "transfer_kv_mamba_pf_lf(Tensor src, Tensor(a!) dst, "
+      "Tensor src_indices, Tensor dst_indices, int layer_id, int item_size, int src_layout_dim) -> ()");
+  m.impl("transfer_kv_mamba_pf_lf", torch::kXPU, &transfer_kv_mamba_pf_lf);
+
+  m.def(
+      "transfer_kv_mamba_lf_pf(Tensor src_layers, Tensor(a!) dst, "
+      "Tensor src_indices, Tensor dst_indices, int item_size, int dst_layout_dim, int num_layers) -> ()");
+  m.impl("transfer_kv_mamba_lf_pf", torch::kXPU, &transfer_kv_mamba_lf_pf);
+
 #ifdef USE_MOE
   m.def(
       "moe_fused_gate(Tensor input, Tensor? bias, int num_expert_group, int topk_group, int topk, int "

--- a/tests/run_suite.py
+++ b/tests/run_suite.py
@@ -64,6 +64,7 @@ suites = {
         TestFile("test_fused_norm_rope_v2.py"),
         TestFile("test_hc_post.py"),
         TestFile("test_jit_kernels.py"),
+        TestFile("test_transfer_mamba.py"),
         TestFile("test_embedding_lora_a_fwd.py"),
         TestFile("test_sgemm_lora_a_fwd.py"),
         TestFile("test_sgemm_lora_b_fwd.py"),

--- a/tests/test_transfer_mamba.py
+++ b/tests/test_transfer_mamba.py
@@ -1,0 +1,215 @@
+"""Tests for the AOT SYCL Mamba HiCache transfer kernels.
+
+    load  (pf->lf): dst[dst_idx[i]]        <- src[src_idx[i], layer_id]
+    backup(lf->pf): dst[dst_idx[i], layer] <- src[layer, src_idx[i]]  (all layers)
+
+These kernels are pure indexed block copies, so a correct copy is bit-exact:
+every comparison here uses rtol=0, atol=0.
+
+Layouts (all contiguous):
+    page_first   [pool, num_layers, item_elems]
+    layer_first  [num_layers, pool, item_elems]
+    single-layer [pool, item_elems]
+"""
+
+import pytest
+import torch
+from sgl_kernel import transfer_kv_mamba_lf_pf, transfer_kv_mamba_pf_lf
+
+
+@pytest.fixture(autouse=True)
+def skip_if_no_xpu():
+    if not torch.xpu.is_available():
+        pytest.skip("XPU not available")
+
+
+def _indices(pool, num_items):
+    """Two independent permutations, so src and dst slots never line up."""
+    src_idx = torch.randperm(pool, device="xpu")[:num_items].to(torch.int64)
+    dst_idx = torch.randperm(pool, device="xpu")[:num_items].to(torch.int64)
+    return src_idx, dst_idx
+
+
+def _rand(shape, dtype):
+    if dtype in (torch.bfloat16, torch.float16, torch.float32):
+        return torch.randn(*shape, device="xpu", dtype=dtype)
+    # Integer dtypes exercise the same byte copy with a different element width.
+    return torch.randint(-128, 127, shape, device="xpu", dtype=dtype)
+
+
+def _ref_load(src, dst, src_idx, dst_idx, layer_id, item_elems, num_layers):
+    ref = dst.clone()
+    ref.view(-1, item_elems)[dst_idx] = src.view(-1, num_layers, item_elems)[
+        src_idx, layer_id
+    ]
+    return ref
+
+
+def _ref_backup(src_layers, dst, src_idx, dst_idx, item_elems, num_layers):
+    ref = dst.clone()
+    s = src_layers.view(num_layers, -1, item_elems)
+    ref.view(-1, num_layers, item_elems)[dst_idx] = s[:, src_idx, :].permute(1, 0, 2)
+    return ref
+
+
+@pytest.mark.parametrize("num_layers", [1, 8, 32])
+@pytest.mark.parametrize("item_elems", [16, 128, 513, 2048])
+@pytest.mark.parametrize(
+    "dtype", [torch.bfloat16, torch.float16, torch.float32, torch.int8]
+)
+def test_load_pf_lf(dtype, item_elems, num_layers):
+    """page_first -> single-layer, one layer slot."""
+    torch.manual_seed(0)
+    pool, num_items = 64, 48
+    layer_id = num_layers // 2
+
+    src = _rand((pool, num_layers, item_elems), dtype)
+    dst = torch.zeros(pool, item_elems, device="xpu", dtype=dtype)
+    src_idx, dst_idx = _indices(pool, num_items)
+
+    ref = _ref_load(src, dst, src_idx, dst_idx, layer_id, item_elems, num_layers)
+
+    item_size = item_elems * src.element_size()
+    transfer_kv_mamba_pf_lf(
+        src, dst, src_idx, dst_idx, layer_id, item_size, item_size * num_layers
+    )
+    torch.xpu.synchronize()
+
+    torch.testing.assert_close(dst, ref, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("num_layers", [1, 8, 32])
+@pytest.mark.parametrize("item_elems", [16, 128, 513, 2048])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32, torch.int8])
+def test_backup_lf_pf(dtype, item_elems, num_layers):
+    """layer_first -> page_first, all layers at once."""
+    torch.manual_seed(0)
+    pool, num_items = 64, 48
+
+    src_layers = _rand((num_layers, pool, item_elems), dtype)
+    dst = torch.zeros(pool, num_layers, item_elems, device="xpu", dtype=dtype)
+    src_idx, dst_idx = _indices(pool, num_items)
+
+    ref = _ref_backup(src_layers, dst, src_idx, dst_idx, item_elems, num_layers)
+
+    item_size = item_elems * src_layers.element_size()
+    transfer_kv_mamba_lf_pf(
+        src_layers, dst, src_idx, dst_idx, item_size, item_size * num_layers, num_layers
+    )
+    torch.xpu.synchronize()
+
+    torch.testing.assert_close(dst, ref, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("num_items", [1, 4])
+@pytest.mark.parametrize("item_elems", [65536, 70000])
+def test_chunked_grid_large_items(num_items, item_elems):
+    """Few, very large items: the only shapes that take the multi-chunk grid path.
+
+    Every other test here has enough copy units to fill the device, so the
+    planner returns chunks == 1 and this splitting logic goes unexercised.
+    70000 is deliberately not a whole multiple of the chunk stride, so the tail
+    chunk is short.
+    """
+    torch.manual_seed(0)
+    pool, num_layers, layer_id = num_items, 2, 1
+    dtype = torch.float32
+
+    src = _rand((pool, num_layers, item_elems), dtype)
+    dst = torch.zeros(pool, item_elems, device="xpu", dtype=dtype)
+    idx = torch.randperm(pool, device="xpu")[:num_items].to(torch.int64)
+    rev = idx.flip(0).contiguous()
+    item_size = item_elems * src.element_size()
+
+    ref = _ref_load(src, dst, idx, rev, layer_id, item_elems, num_layers)
+    transfer_kv_mamba_pf_lf(
+        src, dst, idx, rev, layer_id, item_size, item_size * num_layers
+    )
+    torch.xpu.synchronize()
+    torch.testing.assert_close(dst, ref, rtol=0, atol=0)
+
+    src_layers = _rand((num_layers, pool, item_elems), dtype)
+    dst_pf = torch.zeros(pool, num_layers, item_elems, device="xpu", dtype=dtype)
+    ref_pf = _ref_backup(src_layers, dst_pf, idx, rev, item_elems, num_layers)
+    transfer_kv_mamba_lf_pf(
+        src_layers, dst_pf, idx, rev, item_size, item_size * num_layers, num_layers
+    )
+    torch.xpu.synchronize()
+    torch.testing.assert_close(dst_pf, ref_pf, rtol=0, atol=0)
+
+
+def test_odd_item_size_falls_back_to_narrow_copy():
+    """An item size that is not 8-byte aligned must still copy exactly.
+
+    The kernel picks its copy unit from the alignment of the pointers and byte
+    strides; int8 with an odd item_elems forces the 1-byte unit.
+    """
+    torch.manual_seed(0)
+    pool, num_items, num_layers, item_elems = 32, 32, 3, 45  # 45 B item, layer_id*45
+    dtype = torch.int8
+
+    src = _rand((pool, num_layers, item_elems), dtype)
+    dst = torch.zeros(pool, item_elems, device="xpu", dtype=dtype)
+    src_idx, dst_idx = _indices(pool, num_items)
+
+    ref = _ref_load(src, dst, src_idx, dst_idx, 2, item_elems, num_layers)
+    transfer_kv_mamba_pf_lf(
+        src, dst, src_idx, dst_idx, 2, item_elems, item_elems * num_layers
+    )
+    torch.xpu.synchronize()
+    torch.testing.assert_close(dst, ref, rtol=0, atol=0)
+
+
+def test_empty_indices_is_noop():
+    pool, num_layers, item_elems = 8, 4, 64
+    src = _rand((pool, num_layers, item_elems), torch.bfloat16)
+    dst = torch.zeros(pool, item_elems, device="xpu", dtype=torch.bfloat16)
+    empty = torch.empty(0, device="xpu", dtype=torch.int64)
+    item_size = item_elems * src.element_size()
+
+    transfer_kv_mamba_pf_lf(
+        src, dst, empty, empty, 0, item_size, item_size * num_layers
+    )
+    torch.xpu.synchronize()
+    assert torch.count_nonzero(dst) == 0
+
+    dst_pf = torch.zeros(
+        pool, num_layers, item_elems, device="xpu", dtype=torch.bfloat16
+    )
+    src_layers = _rand((num_layers, pool, item_elems), torch.bfloat16)
+    transfer_kv_mamba_lf_pf(
+        src_layers, dst_pf, empty, empty, item_size, item_size * num_layers, num_layers
+    )
+    torch.xpu.synchronize()
+    assert torch.count_nonzero(dst_pf) == 0
+
+
+def test_load_then_backup_roundtrip():
+    """backup(load(x)) must reproduce the original page-first pool."""
+    torch.manual_seed(0)
+    pool, num_layers, item_elems = 32, 4, 256
+    dtype = torch.bfloat16
+    item_size = item_elems * 2
+
+    pf = _rand((pool, num_layers, item_elems), dtype)
+    idx = torch.arange(pool, device="xpu", dtype=torch.int64)
+
+    # Pull every layer out of the pf pool into a layer-first staging buffer...
+    lf = torch.zeros(num_layers, pool, item_elems, device="xpu", dtype=dtype)
+    for layer in range(num_layers):
+        transfer_kv_mamba_pf_lf(
+            pf, lf[layer], idx, idx, layer, item_size, item_size * num_layers
+        )
+
+    # ...then push all layers back into a fresh pf pool in one call.
+    out = torch.zeros_like(pf)
+    transfer_kv_mamba_lf_pf(
+        lf, out, idx, idx, item_size, item_size * num_layers, num_layers
+    )
+    torch.xpu.synchronize()
+
+    torch.testing.assert_close(out, pf, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Motivation

Mamba/hybrid models keep conv+ssm state in a paged GPU cache and back it up to a
layer-major host cache. On XPU that move currently falls back to PyTorch
advanced indexing, which is a per-element gather/scatter: it flat-lines at
~32-38 GB/s on the backup path regardless of transfer size, because it is bound
by indexing overhead rather than bandwidth. This adds the two AOT SYCL kernels
that CUDA already has (`csrc/kvcacheio/transfer_mamba.cuh`,
`TransferMambaKernel::run_pf_lf` / `::run_lf_pf`).

## What this adds

```
load  (pf->lf): dst[dst_idx[i]]        <- src[src_idx[i], layer_id]
backup(lf->pf): dst[dst_idx[i], layer] <- src[layer, src_idx[i]]  (all layers)
```

- `transfer_kv_mamba_pf_lf` moves a single layer.
- `transfer_kv_mamba_lf_pf` moves every layer in one launch.

`item_size` and `layout_dim` are taken in **BYTES**, matching the CUDA kernels.

## Implementation notes

**Runtime copy width, so it is dtype-agnostic.** The copy unit (8/4/2/1 B) is
picked at runtime from the OR of the two pointer addresses and the byte strides,
so one kernel serves every state dtype and no per-dtype instantiation is needed.
Well-aligned shapes move 8 B per work-item; an unaligned `item_size` degrades to
a 1 B unit instead of failing. This is a deliberate difference from the KV
kernels above it in the same file, which hard-require `item_size % 8 == 0`.

**Chunked grid.** The natural mapping is one work-group per copy unit (item for
load, item x layer for backup). With few, large items that leaves the device
idle - 16 pages of 64Ki elements is 16 work-groups on a 160-CU GPU, which
measured *slower* than the PyTorch indexed copy - so each unit is split into
contiguous chunks until the grid fills the device. With enough units to fill it
(the common HiCache case) the split collapses back to one group per unit.

**N-D ranges rather than a flat range.** Expressed as `nd_range<2>` (load) and
`nd_range<3>` (backup) so the hardware supplies the item/layer/chunk indices.
Recovering them from a flat group id costs an int64 div+mod per work-item, which
measurably slowed the small-item shapes.

**Backup takes a tensor, not a pointer array.** Where CUDA passes a uint64 array
of per-layer pointers, this takes the contiguous layer-first tensor plus its
per-layer byte stride: dereferencing a host-built pointer array is not portable
across SYCL runtimes. Numerically identical.

## Tests

`tests/test_transfer_mamba.py` adds **91 cases**. These kernels are pure indexed
block copies, so a correct result is bit-exact and every comparison uses
`rtol=0, atol=0`:

- 4 dtypes x 4 item sizes x 3 layer counts
- the multi-chunk grid path (few very large items, with one size deliberately
  not a multiple of the chunk stride so the tail chunk is short)
- an unaligned item size that forces the 1-byte copy unit
- empty indices
- a load/backup roundtrip

**Result: 91/91 passed** on BMG.

## Benchmark

`benchmark/bench_transfer_mamba.py`, BMG, `dtype=bfloat16`, `num_layers=4`.
`torch` = advanced-indexing gather/scatter, `sycl` = these kernels. Bandwidth
counts read+write (2x payload).

| op | items | elems | MiB | torch us | sycl us | speedup | torch GB/s | sycl GB/s |
|---|---|---|---|---|---|---|---|---|
| load | 16 | 1024 | 0.06 | 10.26 | 5.00 | 2.05x | 6.4 | 13.1 |
| backup | 16 | 1024 | 0.25 | 18.07 | 5.16 | 3.50x | 14.5 | 50.8 |
| load | 16 | 8192 | 0.50 | 17.08 | 7.60 | 2.25x | 30.7 | 68.9 |
| backup | 16 | 8192 | 2.00 | 66.20 | 8.07 | 8.20x | 31.7 | 259.8 |
| load | 16 | 65536 | 4.00 | 63.10 | 11.56 | 5.46x | 66.5 | 362.8 |
| backup | 16 | 65536 | 16.00 | 450.78 | 29.64 | 15.21x | 37.2 | 566.1 |
| load | 128 | 1024 | 0.50 | 15.68 | 6.20 | 2.53x | 33.4 | 84.6 |
| backup | 128 | 1024 | 2.00 | 65.16 | 9.64 | 6.76x | 32.2 | 217.7 |
| load | 128 | 8192 | 4.00 | 63.70 | 12.45 | 5.12x | 65.8 | 336.9 |
| backup | 128 | 8192 | 16.00 | 450.36 | 29.43 | **15.30x** | 37.3 | **570.1** |
| load | 128 | 65536 | 32.00 | 465.31 | 62.24 | 7.48x | 72.1 | 539.1 |
| backup | 128 | 65536 | 128.00 | 3614.11 | 323.70 | 11.16x | 37.1 | 414.6 |
| load | 512 | 1024 | 2.00 | 36.41 | 10.36 | 3.51x | 57.6 | 202.3 |
| backup | 512 | 1024 | 8.00 | 229.56 | 24.53 | 9.36x | 36.5 | 341.9 |
| load | 512 | 8192 | 16.00 | 229.27 | 33.28 | 6.89x | 73.2 | 504.1 |
| backup | 512 | 8192 | 64.00 | 1818.07 | 155.36 | 11.70x | 36.9 | 431.9 |
| load | 512 | 65536 | 128.00 | 1994.09 | 312.08 | 6.39x | 67.3 | 430.1 |
| backup | 512 | 65536 | 512.00 | 14322.00 | 1354.14 | 10.58x | 37.5 | 396.5 |

**Aggregate over all 18 configs: geomean 6.26x** (range 2.05x - 15.30x)

- `load` (n=9): geomean **4.16x**, 13-539 GB/s vs torch 6-73 GB/s
- `backup` (n=9): geomean **9.42x**, 51-570 GB/s vs torch 15-38 GB/s

Reading of the data:

- **Backup is where this pays.** torch sits at 31.7-37.5 GB/s on all nine backup
  configs across a 2000x size range (0.25 MiB to 512 MiB) - that is per-element
  scatter overhead, not bandwidth. The SYCL kernel scales with the transfer
  instead, peaking at 570 GB/s, which is why backup speedup is roughly 2x the
  load figure.
- **Peak is mid-sweep, not at the largest shape.** Best bandwidth is at a 16 MiB
  working set; it declines to ~396 GB/s at 512 MiB where the transfer is
  DRAM-bound with no cache left to exploit.
- **The 1024-element shapes are launch-latency-bound, not bandwidth-bound.** The
  SYCL floor is ~5-10 us there regardless of layout. `load / 16 / 1024` moves
  only 64 KiB, so its 13.1 GB/s is fixed overhead - note torch is worse still on
  that shape at 6.4 GB/s, the lowest number in the table. Not expected to matter
  in a real HiCache path.
